### PR TITLE
dahdi-tools: Removed dahdi_tool, as it requires libnewt (it's not optional unfortunately). Also add fxotune.

### DIFF
--- a/libs/dahdi-tools/Makefile
+++ b/libs/dahdi-tools/Makefile
@@ -31,17 +31,12 @@ endef
 define Package/dahdi-cfg
   $(call Package/dahdi-cfg/Default)
   DEPENDS+=+libpthread
-  TITLE:=DAHDI tools dahdi_cfg and dahdi_scan
+  TITLE:=DAHDI tools dahdi_cfg, dahdi_scan and fxotune
 endef
 
 define Package/dahdi-monitor
   $(call Package/dahdi-cfg/Default)
   TITLE:=DAHDI tools dahdi_monitor, dahdi_speed and dahdi_test
-endef
-
-define Package/dahdi-tool
-  $(call Package/dahdi-cfg/Default)
-  TITLE:=DAHDI tools dahdi_tool
 endef
 
 define Package/dahdi-tools-libtonezone
@@ -54,13 +49,6 @@ endef
 TARGET_CFLAGS += $(FPIC)
 EXTRA_CFLAGS:= $(TARGET_CPPFLAGS)
 
-CONFIGURE_ARGS+= \
-	--with-dahdi="$(STAGING_DIR)/usr" \
-	--without-newt \
-	--without-usb \
-	--without-selinux \
-	--without-ppp
-
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		$(TARGET_CONFIGURE_OPTS) \
@@ -72,7 +60,7 @@ define Build/Compile
 		INSTALL_PREFIX="$(PKG_INSTALL_DIR)" \
 		DAHDI_INCLUDE="$(STAGING_DIR)/usr/include" \
 		CONFIGURE_SILENT="--silent" \
-		dahdi_cfg dahdi_monitor dahdi_tool dahdi_scan dahdi_speed dahdi_test fxotune libs
+		dahdi_cfg dahdi_monitor dahdi_scan dahdi_speed dahdi_test fxotune libs
 endef
 
 define Build/InstallDev
@@ -88,6 +76,7 @@ define Package/dahdi-cfg/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_BUILD_DIR)/dahdi_cfg $(1)/usr/sbin/
 	$(CP) $(PKG_BUILD_DIR)/dahdi_scan $(1)/usr/sbin/
+	$(CP) $(PKG_BUILD_DIR)/fxotune $(1)/usr/sbin/
 endef
 
 define Package/dahdi-monitor/install
@@ -95,11 +84,6 @@ define Package/dahdi-monitor/install
 	$(CP) $(PKG_BUILD_DIR)/dahdi_monitor $(1)/usr/sbin/
 	$(CP) $(PKG_BUILD_DIR)/dahdi_speed $(1)/usr/sbin/
 	$(CP) $(PKG_BUILD_DIR)/dahdi_test $(1)/usr/sbin/
-endef
-
-define Package/dahdi-tool/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(CP) $(PKG_BUILD_DIR)/dahdi_tool $(1)/usr/sbin/
 endef
 
 define Package/dahdi-tools-libtonezone/install
@@ -110,5 +94,4 @@ endef
 
 $(eval $(call BuildPackage,dahdi-cfg))
 $(eval $(call BuildPackage,dahdi-monitor))
-$(eval $(call BuildPackage,dahdi-tool))
 $(eval $(call BuildPackage,dahdi-tools-libtonezone))


### PR DESCRIPTION
Follow-up of #4.
