### PR TITLE
dahdi-linux: fix oct612x compile on some ARM targets

### DIFF
--- a/libs/dahdi-linux/patches/001-include-slab-h-in-oct612x-user-c.patch
+++ b/libs/dahdi-linux/patches/001-include-slab-h-in-oct612x-user-c.patch
@@ -1,0 +1,12 @@
+Index: dahdi-linux-2.10.0.1/drivers/dahdi/oct612x/oct612x-user.c
+===================================================================
+--- dahdi-linux-2.10.0.1.orig/drivers/dahdi/oct612x/oct612x-user.c
++++ dahdi-linux-2.10.0.1/drivers/dahdi/oct612x/oct612x-user.c
+@@ -22,6 +22,7 @@
+ 
+ #include <linux/kernel.h>
+ #include <linux/module.h>
++#include <linux/slab.h>
+ 
+ #include <dahdi/kernel.h>
+ 


### PR DESCRIPTION
Unbreak dahdi-linux build at least for cns3xxx, kirkwood, mvebu and oxnas
by explicitely including slab.h in oct612x-user.c.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>