### PR TITLE
dahdi-linux: fix build with kernel 3.15 and newer

### DIFF
--- a/libs/dahdi-linux/patches/002-backport-smp_mb__after_atomic.patch
+++ b/libs/dahdi-linux/patches/002-backport-smp_mb__after_atomic.patch
@@ -1,0 +1,89 @@
+Index: dahdi-linux-2.10.0.1/drivers/dahdi/wcaxx-base.c
+===================================================================
+--- dahdi-linux-2.10.0.1.orig/drivers/dahdi/wcaxx-base.c
++++ dahdi-linux-2.10.0.1/drivers/dahdi/wcaxx-base.c
+@@ -3823,7 +3823,11 @@ static void wcaxx_back_out_gracefully(st
+ 	unsigned long flags;
+ 
+ 	clear_bit(INITIALIZED, &wc->bit_flags);
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 15, 0))
+ 	smp_mb__after_clear_bit();
++#else
++	smp_mb__after_atomic();
++#endif
+ 
+ 	/* Make sure we're not on the card list anymore. */
+ 	mutex_lock(&card_list_lock);
+Index: dahdi-linux-2.10.0.1/drivers/dahdi/wcte12xp/base.c
+===================================================================
+--- dahdi-linux-2.10.0.1.orig/drivers/dahdi/wcte12xp/base.c
++++ dahdi-linux-2.10.0.1/drivers/dahdi/wcte12xp/base.c
+@@ -2110,7 +2110,11 @@ static int t1xxp_set_linemode(struct dah
+ 	 * them. */
+ 	clear_bit(INITIALIZED, &wc->bit_flags);
+ 	synchronize_irq(wc->vb.pdev->irq);
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 15, 0))
+ 	smp_mb__after_clear_bit();
++#else
++	smp_mb__after_atomic();
++#endif
+ 	del_timer_sync(&wc->timer);
+ 	flush_workqueue(wc->wq);
+ 
+@@ -3076,7 +3080,11 @@ static void __devexit te12xp_remove_one(
+ 	remove_sysfs_files(wc);
+ 
+ 	clear_bit(INITIALIZED, &wc->bit_flags);
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 15, 0))
+ 	smp_mb__after_clear_bit();
++#else
++	smp_mb__after_atomic();
++#endif
+ 
+ 	del_timer_sync(&wc->timer);
+ 	flush_workqueue(wc->wq);
+Index: dahdi-linux-2.10.0.1/drivers/dahdi/wcte13xp-base.c
+===================================================================
+--- dahdi-linux-2.10.0.1.orig/drivers/dahdi/wcte13xp-base.c
++++ dahdi-linux-2.10.0.1/drivers/dahdi/wcte13xp-base.c
+@@ -1849,7 +1849,12 @@ static int t13x_set_linemode(struct dahd
+ 	clear_bit(INITIALIZED, &wc->bit_flags);
+ 	disable_irq(wc->xb.pdev->irq);
+ 
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 15, 0))
+ 	smp_mb__after_clear_bit();
++#else
++	smp_mb__after_atomic();
++#endif
++
+ 	del_timer_sync(&wc->timer);
+ 	flush_workqueue(wc->wq);
+ 
+@@ -2725,7 +2730,11 @@ static void __devexit te13xp_remove_one(
+ 		return;
+ 
+ 	clear_bit(INITIALIZED, &wc->bit_flags);
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 15, 0))
+ 	smp_mb__after_clear_bit();
++#else
++	smp_mb__after_atomic();
++#endif
+ 
+ 	/* Quiesce DMA engine interrupts */
+ 	wcxb_stop(&wc->xb);
+Index: dahdi-linux-2.10.0.1/drivers/dahdi/wcte43x-base.c
+===================================================================
+--- dahdi-linux-2.10.0.1.orig/drivers/dahdi/wcte43x-base.c
++++ dahdi-linux-2.10.0.1/drivers/dahdi/wcte43x-base.c
+@@ -3581,7 +3581,11 @@ static void __devexit t43x_remove_one(st
+ 		return;
+ 
+ 	wc->not_ready = 1;
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 15, 0))
+ 	smp_mb__after_clear_bit();
++#else
++	smp_mb__after_atomic();
++#endif
+ 
+ 	/* Stop everything */
+ 	wcxb_stop(&wc->xb);


### PR DESCRIPTION
smp_mb__after_clear_bit() was removed from newer kernels.
Use smp_mb__after_atomic() instead.

Spotted on buildbot on targets using kernel 3.18:
.../dahdi-linux-2.10.0.1/drivers/dahdi/wcte13xp-base.c: In function 't13x_set_linemode':
.../dahdi-linux-2.10.0.1/drivers/dahdi/wcte13xp-base.c:1852:2: error: implicit declaration of function 'smp_mb__after_clear_bit' [-Werror=implicit-function-declaration]
  smp_mb__after_clear_bit();
  ^

Signed-off-by: Daniel Golle <daniel@makrotopia.org>