### PR TITLE
asterisk-11.x: fix mysql_config location

### DIFF
--- a/net/asterisk-11.x/Makefile
+++ b/net/asterisk-11.x/Makefile
@@ -176,6 +176,8 @@ else
 endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_asterisk11-mysql),)
+  CONFIGURE_VARS+= \
+	ac_cv_path_ac_pt_CONFIG_MYSQLCLIENT=$(STAGING_DIR)/usr/bin/mysql_config
   CONFIGURE_ARGS+= \
 	--with-mysqlclient
 else


### PR DESCRIPTION
on Arch Linux configure find host mysql_config first
set location explicitly to fix build fail

Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>