### PR TITLE
asterisk-13.x: fix xml2-config location

### DIFF
--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -213,6 +213,9 @@ CONFIGURE_ARGS+= \
 	--with-sounds-cache="$(DL_DIR)" \
 	--enable-xmldoc
 
+CONFIGURE_VARS += \
+	ac_cv_path_ac_pt_CONFIG_LIBXML2=$(STAGING_DIR)/host/bin/xml2-config
+
 AST_MENUSELECT_OPTS = \
 	--without-newt \
 	--without-curses \


### PR DESCRIPTION
on Arch Linux libxml2 detection fails
set xml2-location explicitly to fix build fail

Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>