### PR TITLE
Asterisk13.x: Add missing Confbridge

### DIFF
--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -282,6 +282,7 @@ $(eval $(call BuildPackage,asterisk13))
 
 $(eval $(call BuildAsterisk13Module,app-alarmreceiver,Alarm receiver,Central Station Alarm receiver for Ademco Contact ID,,,app_alarmreceiver,,))
 $(eval $(call BuildAsterisk13Module,app-authenticate,Authenticate commands,Execute arbitrary authenticate commands,,,app_authenticate,,))
+$(eval $(call BuildAsterisk13Module,app-confbridge,ConfBridge,Software bridge for multi-party audio conferencing,,confbridge.conf,app_confbridge bridge_builtin_features bridge_multiplexed bridge_simple bridge_softmix chan_bridge,,))
 $(eval $(call BuildAsterisk13Module,app-directed_pickup,Directed call pickup,support for directed call pickup,,,app_directed_pickup,,))
 $(eval $(call BuildAsterisk13Module,app-disa,Direct Inward System Access,Direct Inward System Access,,,app_disa,,))
 $(eval $(call BuildAsterisk13Module,app-exec,Exec application,support for application execution,,,app_exec,,))


### PR DESCRIPTION
Add the missing Confbridge and it brings the bridge_simple.so to activate the sip module.
Without the bridge_simple.so can not make calls via sip it.

Signed-off-by: Sven Pietack <redfox1977@users.noreply.github.com>