### PR TITLE
asterisk-11x: Update 010-asterisk-configure-undef-res-ninit.patch

### DIFF
--- a/net/asterisk-11.x/patches/010-asterisk-configure-undef-res-ninit.patch
+++ b/net/asterisk-11.x/patches/010-asterisk-configure-undef-res-ninit.patch
@@ -1,10 +1,10 @@
---- a/configure
-+++ b/configure
-@@ -16606,7 +16606,6 @@ if ac_fn_c_try_link "$LINENO"; then :
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
- $as_echo "yes" >&6; }
- 
--$as_echo "#define HAVE_RES_NINIT 1" >>confdefs.h
- 
- 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing res_9_ndestroy" >&5
- $as_echo_n "checking for library containing res_9_ndestroy... " >&6; }
+--- a/configure.ac
++++ b/configure.ac
+@@ -1110,7 +1110,6 @@ AC_LINK_IFELSE(
+ 			#include <resolv.h>],
+ 			[int foo = res_ninit(NULL);])],
+ 	AC_MSG_RESULT(yes)
+-	AC_DEFINE([HAVE_RES_NINIT], 1, [Define to 1 if your system has the re-entrant resolver functions.])
+ 	AC_SEARCH_LIBS(res_9_ndestroy, resolv)
+ 	AC_MSG_CHECKING(for res_ndestroy)
+ 	AC_LINK_IFELSE(


### PR DESCRIPTION
Lately configure is recreated from configure.ac. The current patch changes configure. So we patch it, then it gets recreated and our change is gone. So patch configure.ac instead. Without this change the build fails due to an undefined reference to res_nsearch.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>