### PR TITLE
asterisk-11.x: Don't bootstrap menuselect

### DIFF
--- a/net/asterisk-11.x/Makefile
+++ b/net/asterisk-11.x/Makefile
@@ -296,7 +296,6 @@ define Build/Configure
 		>> $(PKG_BUILD_DIR)/res/pjproject/user.mak;
 	$(call Build/Configure/Default,,$(SITE_VARS))
 	(cd $(PKG_BUILD_DIR)/menuselect; \
-		./bootstrap.sh; \
 		./configure \
 		$(HOST_CONFIGURE_ARGS) \
 		$(AST_MENUSELECT_OPTS) \


### PR DESCRIPTION
The configure script generated by bootstrap.sh in the menuselect folder doesn't work properly. It doesn't check for 'sed', for instance, resulting in './configure: line 4622: -e: command not found'. The build works well without the bootstrap.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>