### PR TITLE
siproxd: fix musl compatibility

### DIFF
--- a/net/siproxd/Makefile
+++ b/net/siproxd/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 OpenWrt.org
+# Copyright (C) 2014-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=siproxd
 PKG_VERSION:=0.8.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/siproxd

--- a/net/siproxd/patches/100-musl-compat.patch
+++ b/net/siproxd/patches/100-musl-compat.patch
@@ -1,0 +1,31 @@
+--- a/src/resolve.c
++++ b/src/resolve.c
+@@ -30,6 +30,7 @@
+ 
+ #include <resolv.h>
+ #include <string.h>
++#include <sys/types.h>
+ 
+ #include "log.h"
+ 
+--- a/src/dejitter.c
++++ b/src/dejitter.c
+@@ -21,6 +21,7 @@
+ #include "config.h"
+ 
+ #include <errno.h>
++#include <string.h>
+ 
+ #include <sys/types.h>
+ #include <sys/socket.h>
+--- a/src/plugins.c
++++ b/src/plugins.c
+@@ -20,6 +20,8 @@
+ 
+ #include "config.h"
+ 
++#include <string.h>
++
+ #include <sys/types.h>
+ #include <netinet/in.h>
+ #include <arpa/inet.h>


### PR DESCRIPTION
 - Add missing `sys/types.h` include to provide `u_short` type under musl
 - Add missing `string.h` includes to avoid implicit function declarations

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>