### PR TITLE
sipp: fix musl compatibility

### DIFF
--- a/net/sipp/Makefile
+++ b/net/sipp/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013 OpenWrt.org
+# Copyright (C) 2013-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sipp
 PKG_VERSION:=3.3.990
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/sipp

--- a/net/sipp/patches/100-musl-compat.patch
+++ b/net/sipp/patches/100-musl-compat.patch
@@ -1,0 +1,12 @@
+--- a/src/auth.c
++++ b/src/auth.c
+@@ -22,9 +22,7 @@
+  *           Frederique Aurouet
+  */
+ 
+-#if defined( __FreeBSD__) || defined(__DARWIN) || defined(__SUNOS)
+ #include <sys/types.h>
+-#endif
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <string.h>


### PR DESCRIPTION
Always include `sys/types.h` as it is basically required by anything besides
Glibc and uClibc. Fixes build against musl.

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>