### PR TITLE
asterisk-11.x: Bump to 11.19.0

### DIFF
--- a/net/asterisk-11.x/Makefile
+++ b/net/asterisk-11.x/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk11
-PKG_VERSION:=11.18.0
-PKG_RELEASE:=3
+PKG_VERSION:=11.19.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://downloads.asterisk.org/pub/telephony/asterisk/releases/
-PKG_MD5SUM:=3ddb42b54db200faccd68906df210a40
+PKG_MD5SUM:=f10259509aeda1e9f47dd57e5cc23680
 
 PKG_BUILD_DIR=$(BUILD_DIR)/asterisk-$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=libxml2/host


### PR DESCRIPTION
Compile-tested on BB 14.07.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>