### PR TITLE
iksemel: restore package and all dependent asterisk modules

### DIFF
--- a/libs/iksemel/Makefile
+++ b/libs/iksemel/Makefile
@@ -31,7 +31,7 @@ define Package/libiksemel
   CATEGORY:=Libraries
   TITLE:=Iksemel Jabber Library
   URL:=http://code.google.com/p/iksemel/
-  DEPENDS:= +libgnutls +libtasn1 +libgcrypt +libgpg-error @BROKEN
+  DEPENDS:= +libgnutls +libtasn1 +libgcrypt +libgpg-error
 endef
 
 define Package/libiksemel/description

--- a/libs/iksemel/patches/002-use-of-newer-gnutls_priority_set_direct-api.patch
+++ b/libs/iksemel/patches/002-use-of-newer-gnutls_priority_set_direct-api.patch
@@ -1,0 +1,65 @@
+From 6b213b593c5b499679506a8c169ff3f0f4d6a34f Mon Sep 17 00:00:00 2001
+From: John Papandriopoulos <jpap@users.noreply.github.com>
+Date: Thu, 20 Aug 2015 16:55:39 -0700
+Subject: [PATCH] Use of newer gnutls_priority_set_direct API
+
+---
+ configure.ac |  1 +
+ src/stream.c | 13 +++++++++++++
+ 2 files changed, 14 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 91e69e3..281a044 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -46,6 +46,7 @@ AC_CHECK_FUNCS(getopt_long)
+ AC_CHECK_FUNCS(getaddrinfo)
+ 
+ AM_PATH_LIBGNUTLS(,AC_DEFINE(HAVE_GNUTLS,,"Use libgnutls"))
++AM_PATH_LIBGNUTLS(,AC_CHECK_FUNCS(gnutls_priority_set_direct))
+ 
+ dnl Check -Wall flag of GCC
+ if test "x$GCC" = "xyes"; then
+diff --git a/src/stream.c b/src/stream.c
+index e8a1e8c..7d19a82 100644
+--- a/src/stream.c
++++ b/src/stream.c
+@@ -63,11 +63,20 @@ tls_pull (iksparser *prs, char *buffer, size_t len)
+ static int
+ handshake (struct stream_data *data)
+ {
++#if HAVE_GNUTLS_PRIORITY_SET_DIRECT
++	const char *priorities =
++		"NONE"
++		":+VERS-TLS1.0:+VERS-SSL3.0"
++		":+RSA"
++		":+3DES-CBC:+ARCFOUR-128"
++		":+SHA1:+SHA256:+SHA384:+MD5";
++#else
+ 	const int protocol_priority[] = { GNUTLS_TLS1, GNUTLS_SSL3, 0 };
+ 	const int kx_priority[] = { GNUTLS_KX_RSA, 0 };
+ 	const int cipher_priority[] = { GNUTLS_CIPHER_3DES_CBC, GNUTLS_CIPHER_ARCFOUR, 0};
+ 	const int comp_priority[] = { GNUTLS_COMP_ZLIB, GNUTLS_COMP_NULL, 0 };
+ 	const int mac_priority[] = { GNUTLS_MAC_SHA, GNUTLS_MAC_MD5, 0 };
++#endif
+ 	int ret;
+ 
+ 	if (gnutls_global_init () != 0)
+@@ -80,11 +89,15 @@ handshake (struct stream_data *data)
+ 		gnutls_certificate_free_credentials (data->cred);
+ 		return IKS_NOMEM;
+ 	}
++#if HAVE_GNUTLS_PRIORITY_SET_DIRECT
++	gnutls_priority_set_direct (data->sess, priorities, NULL);
++#else
+ 	gnutls_protocol_set_priority (data->sess, protocol_priority);
+ 	gnutls_cipher_set_priority(data->sess, cipher_priority);
+ 	gnutls_compression_set_priority(data->sess, comp_priority);
+ 	gnutls_kx_set_priority(data->sess, kx_priority);
+ 	gnutls_mac_set_priority(data->sess, mac_priority);
++#endif
+ 	gnutls_credentials_set (data->sess, GNUTLS_CRD_CERTIFICATE, data->cred);
+ 
+ 	gnutls_transport_set_push_function (data->sess, (gnutls_push_func) tls_push);
+-- 
+2.1.4

--- a/net/asterisk-1.8.x/Makefile
+++ b/net/asterisk-1.8.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk18
 PKG_VERSION:=1.8.32.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://downloads.asterisk.org/pub/telephony/asterisk/releases/
@@ -146,15 +146,15 @@ define Package/asterisk18-sounds/install
 	rm -f $(1)/usr/lib/asterisk/sounds/conf-*
 endef
 
-#ifneq ($(SDK)$(CONFIG_PACKAGE_asterisk18-chan-gtalk),)
-#  CONFIGURE_ARGS+= \
-#	--with-iksemel="$(STAGING_DIR)/usr"
-#  SITE_VARS+= \
-#	ac_cv_lib_iksemel_iks_start_sasl=yes
-#else
+ifneq ($(SDK)$(CONFIG_PACKAGE_asterisk18-chan-gtalk),)
+  CONFIGURE_ARGS+= \
+	--with-iksemel="$(STAGING_DIR)/usr"
+  SITE_VARS+= \
+	ac_cv_lib_iksemel_iks_start_sasl=yes
+else
   CONFIGURE_ARGS+= \
 	--without-iksemel
-#endif
+endif
 
 ifneq ($(SDK)$(CONFIG_PACKAGE_asterisk18-curl),)
   CONFIGURE_ARGS+= \
@@ -345,7 +345,7 @@ $(eval $(call BuildAsterisk18Module,func-shell,Shell,support for shell execution
 $(eval $(call BuildAsterisk18Module,func-uri,URI encoding and decoding,Encodes and decodes URI-safe strings,,,,func_uri,))
 $(eval $(call BuildAsterisk18Module,func-vmcount,vmcount dialplan,a vmcount dialplan function,,,,func_vmcount,))
 $(eval $(call BuildAsterisk18Module,chan-agent,Agents proxy channel,An implementation of agents proxy channel,,,,chan_agent,))
-#$(eval $(call BuildAsterisk18Module,chan-gtalk,GTalk,An implementation of chan_gtalk and res_jabber for GTalk support,+libiksemel,/etc/asterisk/gtalk.conf /etc/asterisk/jabber.conf,gtalk.conf jabber.conf,chan_gtalk res_jabber,))
+$(eval $(call BuildAsterisk18Module,chan-gtalk,GTalk,An implementation of chan_gtalk and res_jabber for GTalk support,+libiksemel,/etc/asterisk/gtalk.conf /etc/asterisk/jabber.conf,gtalk.conf jabber.conf,chan_gtalk res_jabber,))
 $(eval $(call BuildAsterisk18Module,chan-iax2,IAX2 channel,An implementation of IAX2 channel,+asterisk18-res-timing-timerfd,/etc/asterisk/iax.conf /etc/asterisk/iaxprov.conf,iax.conf iaxprov.conf,chan_iax2,))
 $(eval $(call BuildAsterisk18Module,chan-lantiq,Lantiq TAPI channel,An implementation of Lantiq TAPI channel,@TARGET_lantiq @!TARGET_lantiq_xrx200 +kmod-ltq-vmmc,/etc/asterisk/lantiq.conf,lantiq.conf,chan_lantiq,))
 $(eval $(call BuildAsterisk18Module,chan-local,Local proxy channel,An implementation of local proxy channel,,,,chan_local,))

--- a/net/asterisk-11.x/Makefile
+++ b/net/asterisk-11.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk11
 PKG_VERSION:=11.19.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://downloads.asterisk.org/pub/telephony/asterisk/releases/
@@ -221,6 +221,16 @@ else
 	--without-srtp
 endif
 
+ifneq ($(SDK)$(CONFIG_PACKAGE_asterisk11-res-xmpp),)
+  CONFIGURE_ARGS+= \
+	--with-iksemel="$(STAGING_DIR)/usr"
+  SITE_VARS+= \
+	ac_cv_lib_iksemel_iks_start_sasl=yes
+else
+  CONFIGURE_ARGS+= \
+	--without-iksemel
+endif
+
 EXTRA_CFLAGS+= $(TARGET_CPPFLAGS)
 EXTRA_LDFLAGS+= $(TARGET_LDFLAGS) -Wl,-rpath-link,$(STAGING_DIR)/usr/lib
 CONFIGURE_ARGS+= \
@@ -233,7 +243,6 @@ CONFIGURE_ARGS+= \
 	--with-gsm=internal \
 	--without-gtk2 \
 	--with-ilbc=internal \
-	--without-iksemel \
 	--without-isdnnet \
 	--without-libxml2 \
 	--without-misdn \
@@ -410,6 +419,7 @@ $(eval $(call BuildAsterisk11Module,chan-agent,Agents proxy channel,an implement
 $(eval $(call BuildAsterisk11Module,chan-dahdi,DAHDI channel,DAHDI channel support,+dahdi-tools-libtonezone +kmod-dahdi,/etc/asterisk/chan_dahdi.conf,chan_dahdi.conf,chan_dahdi,))
 $(eval $(call BuildAsterisk11Module,chan-iax2,IAX2 channel,IAX support,+asterisk11-res-timing-timerfd,/etc/asterisk/iax.conf /etc/asterisk/iaxprov.conf,iax.conf iaxprov.conf,chan_iax2,))
 $(eval $(call BuildAsterisk11Module,chan-mgcp,MGCP channel,the channel chan_mgcp,,/etc/asterisk/mgcp.conf,mgcp.conf,chan_mgcp,))
+$(eval $(call BuildAsterisk11Module,chan-motif,Jingle channel,Motif Jingle Channel Driver,+asterisk11-res-xmpp,/etc/asterisk/motif.conf /etc/asterisk/jingle.conf,motif.conf jingle.conf,chan_motif,))
 $(eval $(call BuildAsterisk11Module,chan-ooh323,ooH323 channel,the channel chan_ooh323,,/etc/asterisk/ooh323.conf,ooh323.conf,chan_ooh323,))
 $(eval $(call BuildAsterisk11Module,chan-skinny,Skinny channel,the channel chan_skinny,,/etc/asterisk/skinny.conf,skinny.conf,chan_skinny,))
 $(eval $(call BuildAsterisk11Module,chan-unistim,Unistim channel,channel driver for the UNISTIM (Unified Networks IP Stimulus) protocol,,/etc/asterisk/unistim.conf,unistim.conf,chan_unistim,))
@@ -437,5 +447,6 @@ $(eval $(call BuildAsterisk11Module,res-srtp,SRTP,Secure RTP,+libsrtp,,,res_srtp
 $(eval $(call BuildAsterisk11Module,res-timing-dahdi,DAHDI Timing Interface,,+asterisk11-chan-dahdi,,,res_timing_dahdi,))
 $(eval $(call BuildAsterisk11Module,res-timing-pthread,pthread Timing Interface,,,,,res_timing_pthread,))
 $(eval $(call BuildAsterisk11Module,res-timing-timerfd,Timerfd Timing Interface,,,,,res_timing_timerfd,))
+$(eval $(call BuildAsterisk11Module,res-xmpp,XMPP client and component module,reference module for interfacting Asterisk directly as a client or component with XMPP server,+libiksemel +libopenssl,/etc/asterisk/xmpp.conf,xmpp.conf,res_xmpp,))
 $(eval $(call BuildAsterisk11Module,res-realtime,Realtime Interface,,,,,res_realtime,))
 $(eval $(call BuildAsterisk11Module,voicemail,Voicemail,voicemail related modules,+asterisk11-res-adsi +asterisk11-res-smdi,/etc/asterisk/voicemail.conf,voicemail.conf,*voicemail,vm-*)) 

--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk13
 PKG_VERSION:=13.4.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://downloads.asterisk.org/pub/telephony/asterisk/releases/
@@ -197,7 +197,7 @@ CONFIGURE_ARGS+= \
 	--without-pwlib \
 	--without-radius \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-res-fax-spandsp),--with-spandsp="$(STAGING_DIR)/usr",--without-spandsp) \
-	--without-iksemel \
+	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-res-xmpp),--with-iksemel="$(STAGING_DIR)/usr",--without-iksemel) \
 	--without-sdl \
 	--without-sqlite \
 	--with-sqlite3="$(STAGING_DIR)/usr" \


### PR DESCRIPTION
Added a patch to iksemel that allows it compile against gnutls 3.4.x.  It was previously broken because it used some depreciated APIs.

I've tested this patch on asterisk-11, running on my Netgear R7000 (armv7).  It restores my Asterisk connectivity with Google Voice.

I'd love to see it included in the `telephony` feed and future updates.