### PR TITLE
yate-mod-extmodule: Include and install script echo.sh

### DIFF
--- a/net/yate/Makefile
+++ b/net/yate/Makefile
@@ -224,7 +224,7 @@ $(eval $(call BuildPlugin,dbwave,server,Wav Media for DB Storage,+$(PKG_NAME)-mo
 $(eval $(call BuildPlugin,dumbchan,,Dummy Channel,))
 $(eval $(call BuildPlugin,enumroute,,ENUM Routing,))
 $(eval $(call BuildPlugin,eventlogs,server,Write events and alarms to log files,))
-$(eval $(call BuildPlugin,extmodule,,External Module Handler,))
+$(eval $(call BuildPlugin,extmodule,,External Module Handler,,/usr/share/yate/scripts/echo.sh))
 $(eval $(call BuildPlugin,faxchan,,Spandsp Fax Channel,+libspandsp))
 $(eval $(call BuildPlugin,filetransfer,,File Transfer Driver,))
 $(eval $(call BuildPlugin,gvoice,,Google Voice support,))


### PR DESCRIPTION
echo.sh is a simple yate script which can be used to echo back audio to a
caller. It's useful for testing purposes.

Since the script is a basic shell script it has no specific dependencies.

Signed-off-by: Robert Högberg robert.hogberg@gmail.com

---

I think it would be good to include this script by default in the package because:
- It's small
- It has no dependencies
- It's useful to verify two-way audio

There are other shell scripts shipped with yate which could be included also (noise.sh, play.sh and test.sh) but I don't find them as useful and play.sh has a dependency on sox.
