### PR TITLE
yate-scripts-perl: Add dependency on perlbase-data

### DIFF
--- a/net/yate/Makefile
+++ b/net/yate/Makefile
@@ -56,7 +56,7 @@ endef
 
 define Package/$(PKG_NAME)-scripts-perl
   $(call Package/yate/Default)
-  DEPENDS += $(PKG_NAME) $(PKG_NAME)-mod-extmodule +perl
+  DEPENDS += $(PKG_NAME) $(PKG_NAME)-mod-extmodule +perlbase-data
   TITLE:= Perl module for Yate
 endef
 


### PR DESCRIPTION
Yate.pm that is included in yate-scripts-perl uses perl package Data::Dumper
which is provided by openwrt package perlbase-data. Update dependency to
reflect this.

Signed-off-by: Robert Högberg robert.hogberg@gmail.com
