### PR TITLE
siproxd: version bump to 0.8.2 and add available plugins for selection

### DIFF
--- a/net/siproxd/Makefile
+++ b/net/siproxd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=siproxd
-PKG_VERSION:=0.8.1
-PKG_RELEASE:=5
+PKG_VERSION:=0.8.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/siproxd
-PKG_MD5SUM:=1a6f9d13aeb2d650375c9a346ac6cbaf
+PKG_MD5SUM:=e3ec83f66ac880717c98512d89613f42
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -87,3 +87,8 @@ $(eval $(call BuildPlugin,prefix))
 $(eval $(call BuildPlugin,regex))
 $(eval $(call BuildPlugin,shortdial))
 $(eval $(call BuildPlugin,stun))
+$(eval $(call BuildPlugin,siptrunk))
+$(eval $(call BuildPlugin,stripheader))
+$(eval $(call BuildPlugin,codecfilter))
+$(eval $(call BuildPlugin,fix_fbox_anoncall))
+$(eval $(call BuildPlugin,fix_DTAG))

--- a/net/siproxd/patches/010-fix-bogus-libltdl-dependency.patch
+++ b/net/siproxd/patches/010-fix-bogus-libltdl-dependency.patch
@@ -12,14 +12,12 @@
  		  sip_utils.c sip_layer.c log.c readconf.c rtpproxy.c \
  		  rtpproxy_relay.c accessctl.c route_processing.c \
 --- a/src/Makefile.in
-+++ b/src/Makefile.in
-@@ -326,8 +326,8 @@ plugin_prefix_la_LDFLAGS = -module -avoi
- #
- plugin_regex_la_SOURCES = plugin_regex.c
- plugin_regex_la_LDFLAGS = -module -avoid-version -shrext '.so'
--siproxd_LDFLAGS = -export-dynamic
++++ b/src/Makefile.in	
+@@ -378,7 +378,7 @@
+ plugin_fix_fbox_anoncall_la_SOURCES = plugin_fix_fbox_anoncall.c
+ plugin_fix_fbox_anoncall_la_LDFLAGS = -module -avoid-version -shrext '.so'
+ siproxd_LDFLAGS = -export-dynamic
 -siproxd_LDADD = $(LIBLTDL) $(DLOPENPLUGINS)
-+siproxd_LDFLAGS = -export-dynamic -lltdl
 +siproxd_LDADD = $(DLOPENPLUGINS)
  siproxd_SOURCES = siproxd.c proxy.c register.c sock.c utils.c \
  		  sip_utils.c sip_layer.c log.c readconf.c rtpproxy.c \


### PR DESCRIPTION
Some new plugins particularly the stripheader one can be very beneficial to
those using voice service providers who freak out when there are more
than one Via tag, and those who have problems with some VSPs in Germany.
Submitted to package maintainer for approval.

Compile Tested on: openwrt trunk
Run tested on:  TP-Link 1043 ND v3 MIPS32 74Kc

Signed-off-by: Luke McKee <hojuruku@gmail.com>

```
0.8.2
=====
  24-Feb-2016:  - plugin_fix_fbox_anoncall: improved matching and rewriting
                  (="fixing") Contact header on anonymous calls.
  30-Jan-2016:  - added plugin_fix_fbox_anoncall: a plugin to work around
                  some quirks from Fritzboxes when receiving anonymous calls
                  (calls with supressed CLID). Might also work for other UAs.
  11-Oct-2015:  - performance improvement in DNS lookup/caching
  20-Sep-2015:  - added plugin_siptrunk: a plugin to support SIP
                  trunks with multiple numbers within the same SIP account.
  12-Sep-2015:  - added plugin_fix_DTAG: workaround for Deutsche Telekom AG
                  SIP service which has a broken Via Header handling in some
                  regions.
  17-Jul-2015:  - better handling of libltdl bug ("undefined reference to ...")
                  added --with-ltdl-fix to configure)
  12-Jul-2015:  - better handling of URI params (SNOM: ;line=xxxx in Contact
                  header) - URI params are now taken into consideration when
                  masquerading / un-masquerading.
  02-Jul-2015:  - fixed a possible SEGV in sip_find_direction()
                - plugin_stripheader: may now strip just a particular value
                  from the headers
  26-Jan-2015:  - added plugin_codecfilter (remove particular codecs in SDP
                  payloads)
  20-Jan-2015:  - added plugin_stripheader (remove particular SIP headers 
                  from message)
  26-Sep-2014:  - fixed some #include and data-type issues.
  25-May-2014:  - PLUGIN_PROCESS_RAW: properly deal with the situation if a
                  RAW plugin modifies the message length.
  11-Feb-2013:  - plugin_defaulttarget: add "received from" IP to logging
  07-Apr-2012:  - Some compatibility hack with newer libtool versions
  10-Jul-2011:  - Added --with-included-libtool to configure to allow
                  forcing the use of the included libltdl
```