### PR TITLE
Fix build of FreeSWITCH due to missing libedit

### DIFF
--- a/net/freeswitch/Makefile
+++ b/net/freeswitch/Makefile
@@ -573,6 +573,7 @@ CONFIGURE_ARGS+= \
 	--sysconfdir="/etc" \
 	--with-modinstdir="/usr/lib/$(PKG_NAME)" \
 	--with-random="/dev/urandom" \
+	--disable-core-libedit-support \
 	$(call autoconf_bool,CONFIG_FS_WITH_BUILTIN_ZRTP,zrtp) \
 	$(call autoconf_bool,CONFIG_FS_WITH_FHS,fhs) \
 	$(call autoconf_bool,CONFIG_FS_WITH_APR_IPV6,ipv6) \


### PR DESCRIPTION
libedit is not available in 15.05. Add --disable-core-libedit-support
to configure flags to fix build error

Fixes #118

Signed-Off-By: Bernhard Schmidt berni@birkenwald.de
