### PR TITLE
yate-scripts-perl: Make perlbase-data optional

### DIFF
--- a/net/yate/Makefile
+++ b/net/yate/Makefile
@@ -56,7 +56,7 @@ endef
 
 define Package/$(PKG_NAME)-scripts-perl
   $(call Package/yate/Default)
-  DEPENDS += $(PKG_NAME) $(PKG_NAME)-mod-extmodule +perlbase-data
+  DEPENDS += $(PKG_NAME) $(PKG_NAME)-mod-extmodule +perlbase-essential
   TITLE:= Perl module for Yate
 endef
 

--- a/net/yate/patches/130-perl-data-dumper-optional.patch
+++ b/net/yate/patches/130-perl-data-dumper-optional.patch
@@ -1,0 +1,19 @@
+--- a/share/scripts/Yate.pm
++++ b/share/scripts/Yate.pm
+@@ -32,7 +32,6 @@ use warnings;
+ BEGIN {
+     # Have at least perl 5.6.1 to use this module.
+     use 5.006_001;
+-    use Data::Dumper;
+ 
+     # Set version && disable output buffering.
+     our $VERSION = '0.22';
+@@ -674,6 +673,8 @@ sub setlocal($$$) {
+ sub dump($) {
+     my ($self) = @_;
+ 
++    require Data::Dumper;
++    Data::Dumper->import();
+     $self->debug(Dumper($self));
+ }
+ 


### PR DESCRIPTION
Package yate-scripts-perl requires package perlbase-data to work
properly, but perlbase-data is only needed for function dump() which I
expect to be used only when debugging YATE modules. It's possible to
write YATE modules without using the dump() function and then it's a
waste of resources to require the user to have perlbase-data installed
since it will consume memory while the YATE module is running and disk
space for the package installation.

So, let's change Yate.pm to only load Data::Dumper (from perlbase-data)
when the dump() function is called. This way Yate.pm can be used even
if perlbase-data isn't installed, but if you want to use the dump()
function you of course need to install perlbase-data.

This is an alternative to #86 and I suggest that #86 is discarded and this change is taken instead, but I'll let you make the decision.

Signed-off-by: Robert Högberg robert.hogberg@gmail.com
