### PR TITLE
yate-scripts-perl: Add script to block phones which fail to authenticate

### DIFF
--- a/net/yate/Makefile
+++ b/net/yate/Makefile
@@ -147,6 +147,7 @@ endef
 define Package/$(PKG_NAME)-scripts-perl/install
 	$(INSTALL_DIR) $(1)/usr/share/yate/scripts
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/yate/scripts/Yate.pm $(1)/usr/share/yate/scripts/
+	$(INSTALL_BIN) ./files/banbrutes.pl $(1)/usr/share/yate/scripts/
 endef
 
 define Package/$(PKG_NAME)-sounds/install

--- a/net/yate/files/banbrutes.pl
+++ b/net/yate/files/banbrutes.pl
@@ -1,0 +1,50 @@
+#!/usr/bin/perl
+
+# This yate module will monitor failed authentications and send the source
+# IP addresses of users who fail to authenticate to the iptables extension
+# "recent" for filtering.
+#
+# You have to have the iptables extension "recent" installed and you need to
+# create and reference a "recent" list in your firewall configuration.
+# For most people it's probably enough to add this custom firewall rule
+# to /etc/firewall.user:
+#
+#  iptables -A input_rule -m recent --name yate_auth_failures --rcheck --seconds 3600 --hitcount 5 -j DROP
+#
+# This line will drop all incoming traffic from users who have failed to
+# authenticate 5 consecutive times within the last hour.
+#
+# To enable this script in yate, add this script to the [scripts] section
+# in /etc/yate/extmodule.conf.
+
+
+use strict;
+use warnings;
+use lib '/usr/share/yate/scripts';
+use Yate;
+
+my $RECENT_LIST_NAME = '/proc/net/xt_recent/yate_auth_failures';
+
+sub OnAuthenticationRequest($) {
+  my $yate = shift;
+  my $remote_ip = $yate->param('ip_host');
+
+  if ($yate->header('processed') eq 'true') {
+    # Successful authentication, forget previous failures
+    `echo -$remote_ip > $RECENT_LIST_NAME`;
+    return;
+  }
+
+  `echo +$remote_ip > $RECENT_LIST_NAME`;
+}
+
+
+my $yate = new Yate();
+
+if (! -f $RECENT_LIST_NAME) {
+  $yate->output("iptables recent list $RECENT_LIST_NAME does not exist");
+  exit 1;
+}
+
+$yate->install_watcher('user.auth', \&OnAuthenticationRequest);
+$yate->listen();


### PR DESCRIPTION
Yate ships with a php script (banbrutes.php) which can help block brute
force login/password attacks. Since Yate for OpenWrt doesn't support
php scripts I've written a similar script in perl that's easier to use
with OpenWrt.

The script uses the iptables extension "recent" to keep track of
authentication failures and block users after too many authentication
failures.

This is an alternative to #87. The functionality is mostly the same,
but this is a slightly simplified, more light-weight version since
IP sets aren't used.

Signed-off-by: Robert Högberg robert.hogberg@gmail.com
