### PR TITLE
libs/re: Add zlib dependency

### DIFF
--- a/libs/re/Makefile
+++ b/libs/re/Makefile
@@ -26,7 +26,7 @@ define Package/libre
   SUBMENU:=Telephony
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libopenssl +libpthread
+  DEPENDS:=+libopenssl +libpthread +zlib
   TITLE:=Generic library for real-time communications with async IO support
   URL:=http://www.creytiv.com/
 endef


### PR DESCRIPTION
Compile tested on: Kirkwood, LEDE trunk

Adds missing zlib dependency

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>