### PR TITLE
pcapsipdump: Pass down TARGET_CPPFLAGS and TARGET_LDFLAGS

### DIFF
--- a/net/pcapsipdump/Makefile
+++ b/net/pcapsipdump/Makefile
@@ -41,7 +41,8 @@ TARGET_CC=$(TARGET_CXX)
 define Build/Compile
 	$(TARGET_CONFIGURE_OPTS) \
 		$(MAKE) -C $(PKG_BUILD_DIR) \
-		CPPFLAGS="$(TARGET_CXXFLAGS) -fno-rtti"  \
+		CPPFLAGS="$(TARGET_CXXFLAGS) $(TARGET_CPPFLAGS) -fno-rtti"  \
+		LDFLAGS="$(TARGET_LDFLAGS)" \
 		LIBS="-lpcap"
 endef
 


### PR DESCRIPTION
Make sure that we properly pass down both TARGET_CPPFLAGS and
TARGET_LDFLAGS in order to fix build failures with external toolchains
that don't automatically search for headers and libraries in
$(STAGING_DIR).

Signed-off-by: Florian Fainelli <f.fainelli@gmail.com>