### PR TITLE
Fix PKG_SOURCE_URL for libpri 1.4.15

### DIFF
--- a/libs/libpri/Makefile
+++ b/libs/libpri/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.4.15
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://downloads.asterisk.org/pub/telephony/libpri/
+PKG_SOURCE_URL:=http://downloads.asterisk.org/pub/telephony/libpri/old/
 PKG_MD5SUM:=206fbcf014ad85bf6613f169ca425e7f
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 


### PR DESCRIPTION
The 1.4.15 file has been moved into an /old/ subfolder