### PR TITLE
spandsp: disable fixed point implementation

### DIFF
--- a/libs/spandsp/Makefile
+++ b/libs/spandsp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=spandsp
 PKG_VERSION:=0.0.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.soft-switch.org/downloads/spandsp/

--- a/libs/spandsp/patches/101-disable-fixed-point.patch
+++ b/libs/spandsp/patches/101-disable-fixed-point.patch
@@ -1,0 +1,14 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -435,10 +435,7 @@ if test "$enable_fixed_point" = "yes" ; then
+     AC_DEFINE([SPANDSP_USE_FIXED_POINT], [1], [Enable fixed point processing, where possible, instead of floating point])
+     SPANDSP_USE_FIXED_POINT="#define SPANDSP_USE_FIXED_POINT 1"
+ else
+-    AX_FIXED_POINT_MACHINE([$host],
+-        [AC_DEFINE([SPANDSP_USE_FIXED_POINT], [1], [Enable fixed point processing, where possible, instead of floating point])
+-        SPANDSP_USE_FIXED_POINT="#define SPANDSP_USE_FIXED_POINT 1"],
+-        [SPANDSP_USE_FIXED_POINT="#undef SPANDSP_USE_FIXED_POINT"])
++    SPANDSP_USE_FIXED_POINT="#undef SPANDSP_USE_FIXED_POINT"]
+ fi
+ AX_MISALIGNED_ACCESS_FAILS([$host],
+     [AC_DEFINE([SPANDSP_MISALIGNED_ACCESS_FAILS], [1], [Do not expect a misaligned memory access to work correctly])


### PR DESCRIPTION
On a Netgear R7000 (ARMv7) without floating point, using SpanDSP with
fixed point to send/receive fax on Asterisk resulted in repeated
failure and intermittent performance.  Disabling fixed point fixed
these issues; the software floating point implementation was fine for
real-time use.

Now on a Netgear R7800 (ARMv7) with hardware floating point, the
autoconf auto-detect will say no floating point is available, and
again enables the poor performing fixed point implementation.  Ouch!