### PR TITLE
PR for freeswitch-stable

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -567,11 +567,15 @@ define Build/Prepare
 		$(PKG_BUILD_DIR)/libs/esl/python/Makefile
 	$(SED) 's|^SITE_DIR=.*|SITE_DIR=$$$$(DESTDIR)$(PYTHON_PKG_DIR)|' \
 		$(PKG_BUILD_DIR)/libs/esl/python/Makefile
-	$(SED)'s|swig2.0|$(STAGING_DIR_HOSTPKG)/bin/swig|' \
+	$(SED) 's|swig2.0|$(STAGING_DIR_HOSTPKG)/bin/swig|' \
 		$(PKG_BUILD_DIR)/libs/esl/python/Makefile
-	$(SED)'s|swig2.0|$(STAGING_DIR_HOSTPKG)/bin/swig|' \
+	$(SED) 's|swig2.0|$(STAGING_DIR_HOSTPKG)/bin/swig|' \
 		$(PKG_BUILD_DIR)/src/mod/languages/mod_python/Makefile.am
-	$(SED)'s|^PYTHON_SITE_DIR=.*|PYTHON_SITE_DIR=$(PYTHON_PKG_DIR)|' \
+	$(SED) 's|^PYTHON_SITE_DIR=.*|PYTHON_SITE_DIR=$(PYTHON_PKG_DIR)|' \
+		$(PKG_BUILD_DIR)/src/mod/languages/mod_python/Makefile.am
+	$(SED) 's|@PYTHON_CFLAGS@|-I$(PYTHON_INC_DIR)|' \
+		$(PKG_BUILD_DIR)/src/mod/languages/mod_python/Makefile.am
+	$(SED) 's|@PYTHON_LDFLAGS@|$(TARGET_LDFLAGS) -lpython$(PYTHON_VERSION)|' \
 		$(PKG_BUILD_DIR)/src/mod/languages/mod_python/Makefile.am
 
 # Hack for mod_unimrcp - it has a build-time dep on mod_sofia

--- a/net/freeswitch-stable/patches/150-erlang-m4.patch
+++ b/net/freeswitch-stable/patches/150-erlang-m4.patch
@@ -1,0 +1,23 @@
+--- a/build/config/erlang.m4
++++ b/build/config/erlang.m4
+@@ -43,9 +43,20 @@ then
+ 			ERLANG_LDFLAGS="-L$ERLANG_LIBDIR $ERLANG_LDFLAGS"
+ 			LIBS="-L$ERLANG_LIBDIR $LIBS"
+ 		fi
++
++		#
++		# Don't use the above ERLANG_LDFLAGS
++		#
++		ERLANG_LIBDIR="$STAGING_DIR/usr/lib"
++		ERLANG_LDFLAGS="-L$ERLANG_LIBDIR"
++		LIBS="-L$ERLANG_LIBDIR $LIBS"
+ 		AC_MSG_RESULT([$ERLANG_LIBDIR])
+ 
+ 		ERLANG_INCDIR=`$ERLANG -noshell -eval 'io:format("~n~s/include~n", [[code:lib_dir("erl_interface")]]).' -s erlang halt | tail -n 1`
++		#
++		# Don't use the above ERLANG_INCDIR
++		#
++		ERLANG_INCDIR="$STAGING_DIR/usr/include"
+ 		AC_MSG_CHECKING([erlang incdir])
+ 		if test -z "`echo $ERLANG_INCDIR`" ; then
+ 			AC_MSG_ERROR([failed])


### PR DESCRIPTION
Now that the swig location is fixed the build dies someplace else, at erlang. I (hopefully) fixed erlang, and I assume with python we would run into the same issue, so here a PR with an erlang and a python fix.

@jow- I know you're busy, but maybe if you get around to it... :) Thank you