### PR TITLE
New PR: mostly Asterisk (bumps, fixes, new package too)

### DIFF
--- a/libs/bcg729/Makefile
+++ b/libs/bcg729/Makefile
@@ -1,5 +1,5 @@
 # 
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2017 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcg729
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.0.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://download-mirror.savannah.gnu.org/releases/linphone/plugins/sources/
-PKG_MD5SUM:=5d0c160129c0850c43dd66c78efe429b
+PKG_HASH:=77c923edc57a53014da5f31788b63efbabfc7277c06deaeada06574628e4b03f
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_INSTALL:=1
@@ -43,13 +43,14 @@ endef
 TARGET_CFLAGS += $(FPIC)
 CONFIGURE_ARGS += \
 	--enable-shared \
-	--enable-static
+	--enable-static=no \
+	--disable-msplugin
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) -R $(PKG_INSTALL_DIR)/usr/include/bcg729 $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libbcg729.{a,so*} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libbcg729.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libbcg729.pc $(1)/usr/lib/pkgconfig/
 endef

--- a/libs/pjproject/Makefile
+++ b/libs/pjproject/Makefile
@@ -81,6 +81,7 @@ CONFIGURE_ARGS += \
 	--disable-g7221-codec \
 	--disable-speex-codec \
 	--disable-ilbc-codec \
+	--disable-opus \
 	--disable-resample-dll \
 	--disable-sdl \
 	--disable-ffmpeg \

--- a/net/asterisk-11.x/Makefile
+++ b/net/asterisk-11.x/Makefile
@@ -282,8 +282,8 @@ CONFIGURE_VARS += \
 AST_MENUSELECT_OPTS = \
 	--without-newt \
 	--without-curses \
-	--with-ncurses="$(STAGING_DIR)/host/usr" \
-	--with-libxml2="$(STAGING_DIR)/host/usr"
+	--with-ncurses="$(STAGING_DIR_HOSTPKG)/usr" \
+	--with-libxml2="$(STAGING_DIR_HOSTPKG)/usr"
 
 define Build/Prepare
 	$(call Build/Prepare/Default)
@@ -307,17 +307,18 @@ define Build/Configure
 		>> $(PKG_BUILD_DIR)/res/pjproject/user.mak;
 	$(call Build/Configure/Default,,$(SITE_VARS))
 	(cd $(PKG_BUILD_DIR)/menuselect; \
+		ac_cv_path_ac_pt_CONFIG_LIBXML2=$(STAGING_DIR_HOSTPKG)/bin/xml2-config \
 		./configure \
 		$(HOST_CONFIGURE_ARGS) \
 		$(AST_MENUSELECT_OPTS) \
 		LDFLAGS="$(HOST_LDFLAGS) -lxml2" \
-		CFLAGS="$(HOST_CFLAGS) -I$(STAGING_DIR)/host/include/libxml2" \
+		CFLAGS="$(HOST_CFLAGS) -I$(STAGING_DIR_HOSTPKG)/include/libxml2" \
 	);
 endef
 
 define Build/Compile
 	$(MAKE) -C "$(PKG_BUILD_DIR)/menuselect" \
-		CFLAGS="$(HOST_CFLAGS) -I$(STAGING_DIR)/host/include/libxml2" \
+		CFLAGS="$(HOST_CFLAGS) -I$(STAGING_DIR_HOSTPKG)/include/libxml2" \
 		LDFLAGS="$(HOST_LDFLAGS) -lxml2"
 	$(MAKE) -C "$(PKG_BUILD_DIR)" include/asterisk/version.h \
 		include/asterisk/buildopts.h defaults.h \

--- a/net/asterisk-11.x/Makefile
+++ b/net/asterisk-11.x/Makefile
@@ -323,8 +323,8 @@ define Build/Compile
 	$(MAKE) -C "$(PKG_BUILD_DIR)" include/asterisk/version.h \
 		include/asterisk/buildopts.h defaults.h \
 		makeopts.embed_rules
-	ASTCFLAGS="$(EXTRA_CFLAGS) -DLOW_MEMORY"
-	ASTLDFLAGS="$(EXTRA_LDFLAGS)"
+	ASTCFLAGS="$(EXTRA_CFLAGS) -DLOW_MEMORY" \
+	ASTLDFLAGS="$(EXTRA_LDFLAGS)" \
 	$(MAKE) -C "$(PKG_BUILD_DIR)" \
 		ASTVARLIBDIR="/usr/lib/asterisk" \
 		ASTDATADIR="/usr/lib/asterisk" \

--- a/net/asterisk-11.x/patches/010-asterisk-configure-undef-res-ninit.patch
+++ b/net/asterisk-11.x/patches/010-asterisk-configure-undef-res-ninit.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1175,7 +1175,6 @@ AC_LINK_IFELSE(
+@@ -1168,7 +1168,6 @@ AC_LINK_IFELSE(
  			#include <resolv.h>],
  			[int foo = res_ninit(NULL);])],
  	AC_MSG_RESULT(yes)

--- a/net/asterisk-11.x/patches/052-musl-libcap.patch
+++ b/net/asterisk-11.x/patches/052-musl-libcap.patch
@@ -10,7 +10,7 @@
       kfreebsd*-gnu)
       OSARCH=kfreebsd-gnu
       ;;
-@@ -1285,9 +1288,11 @@ if test "${PBX_BFD}" = "0"; then
+@@ -1278,9 +1281,11 @@ if test "${PBX_BFD}" = "0"; then
    AST_EXT_LIB_CHECK([BFD], [bfd], [bfd_check_format], [bfd.h], [-ldl -liberty -lz])
  fi
  

--- a/net/asterisk-11.x/patches/054-fix-cross-compile.patch
+++ b/net/asterisk-11.x/patches/054-fix-cross-compile.patch
@@ -1,0 +1,14 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -1104,7 +1104,10 @@ fi
+ AC_SUBST(AST_SHADOW_WARNINGS)
+ 
+ AC_MSG_CHECKING(for -march=native support)
+-if $(${CC} -march=native -S -o /dev/null -xc /dev/null > /dev/null 2>&1); then
++if test "${cross_compiling}" = "yes"; then
++	AC_MSG_RESULT(cross-compile)
++	AST_NATIVE_ARCH=0
++elif $(${CC} -march=native -S -o /dev/null -xc /dev/null > /dev/null 2>&1); then
+ 	AC_MSG_RESULT(yes)
+ 	AST_NATIVE_ARCH=1
+ else

--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -10,12 +10,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk13
-PKG_VERSION:=13.15.0
-PKG_RELEASE:=2
+PKG_VERSION:=13.17.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://downloads.asterisk.org/pub/telephony/asterisk/releases/
-PKG_HASH:=8b8a55557d9c882f9b68f61b62f5f8af5c9ad68b6da6a1aa3506fa1894fb5844
+PKG_HASH:=c4a89386d7db58520391fcbd3202902584b4434289094ca2e4a6b8dada1e90a4
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/asterisk-$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=libxml2/host
@@ -231,8 +231,8 @@ CONFIGURE_VARS += \
 AST_MENUSELECT_OPTS = \
 	--without-newt \
 	--without-curses \
-	--with-ncurses="$(STAGING_DIR_HOST)/usr" \
-	--with-libxml2="$(STAGING_DIR_HOST)/usr"
+	--with-ncurses="$(STAGING_DIR_HOSTPKG)/usr" \
+	--with-libxml2="$(STAGING_DIR_HOSTPKG)/usr"
 
 define Build/Prepare
 	$(call Build/Prepare/Default)
@@ -248,22 +248,22 @@ define Build/Configure
 	$(call Build/Configure/Default,,$(SITE_VARS))
 	(cd $(PKG_BUILD_DIR)/menuselect; \
 		./bootstrap.sh; \
+		ac_cv_path_ac_pt_CONFIG_LIBXML2=$(STAGING_DIR_HOSTPKG)/bin/xml2-config \
 		./configure \
 		$(HOST_CONFIGURE_ARGS) \
 		$(AST_MENUSELECT_OPTS) \
 		LDFLAGS="$(HOST_LDFLAGS) -lxml2" \
-		CFLAGS="$(HOST_CFLAGS) -I$(STAGING_DIR)/host/include/libxml2" \
+		CFLAGS="$(HOST_CFLAGS) -I$(STAGING_DIR_HOSTPKG)/include/libxml2" \
 	);
 endef
 
 define Build/Compile
 	$(MAKE) -C "$(PKG_BUILD_DIR)/menuselect" \
-		CFLAGS="$(HOST_CFLAGS) -I$(STAGING_DIR)/host/include/libxml2" \
+		CFLAGS="$(HOST_CFLAGS) -I$(STAGING_DIR_HOSTPKG)/include/libxml2" \
 		LDFLAGS="$(HOST_LDFLAGS) -lxml2"
 	$(MAKE) -C "$(PKG_BUILD_DIR)" \
 		include/asterisk/version.h \
-		include/asterisk/buildopts.h defaults.h \
-		makeopts.embed_rules
+		include/asterisk/buildopts.h defaults.h
 	ASTCFLAGS="$(EXTRA_CFLAGS) -DLOW_MEMORY"
 	ASTLDFLAGS="$(EXTRA_LDFLAGS)"
 	$(MAKE) -C "$(PKG_BUILD_DIR)" \

--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -264,8 +264,8 @@ define Build/Compile
 	$(MAKE) -C "$(PKG_BUILD_DIR)" \
 		include/asterisk/version.h \
 		include/asterisk/buildopts.h defaults.h
-	ASTCFLAGS="$(EXTRA_CFLAGS) -DLOW_MEMORY"
-	ASTLDFLAGS="$(EXTRA_LDFLAGS)"
+	ASTCFLAGS="$(EXTRA_CFLAGS) -DLOW_MEMORY" \
+	ASTLDFLAGS="$(EXTRA_LDFLAGS)" \
 	$(MAKE) -C "$(PKG_BUILD_DIR)" \
 		ASTVARLIBDIR="/usr/lib/asterisk" \
 		ASTDATADIR="/usr/lib/asterisk" \

--- a/net/asterisk-13.x/patches/001-disable-semaphores-check.patch
+++ b/net/asterisk-13.x/patches/001-disable-semaphores-check.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -961,19 +961,6 @@ AC_LINK_IFELSE(
+@@ -962,19 +962,6 @@ AC_LINK_IFELSE(
    ]
  )
  

--- a/net/asterisk-13.x/patches/002-undef-res-ninit.patch
+++ b/net/asterisk-13.x/patches/002-undef-res-ninit.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1291,7 +1291,6 @@ AC_LINK_IFELSE(
+@@ -1279,7 +1279,6 @@ AC_LINK_IFELSE(
  			#include <resolv.h>],
  			[int foo = res_ninit(NULL);])],
  	AC_MSG_RESULT(yes)

--- a/net/asterisk-13.x/patches/052-musl-libcap.patch
+++ b/net/asterisk-13.x/patches/052-musl-libcap.patch
@@ -26,12 +26,12 @@
  AST_C_DEFINE_CHECK([DAHDI], [DAHDI_DEFAULT_MTU_MRU], [dahdi/user.h], [220])
 --- a/main/Makefile
 +++ b/main/Makefile
-@@ -47,7 +47,7 @@ AST_LIBS+=$(UUID_LIB)
+@@ -47,7 +47,7 @@ AST_LIBS+=$(AST_CLANG_BLOCKS_LIBS)
  AST_LIBS+=$(RT_LIB)
  AST_LIBS+=$(SYSTEMD_LIB)
  
 -ifneq ($(findstring $(OSARCH), linux-gnu uclinux linux-uclibc kfreebsd-gnu),)
 +ifneq ($(findstring $(OSARCH), linux-gnu uclinux linux-uclibc linux-musl kfreebsd-gnu),)
-   ifneq ($(findstring LOADABLE_MODULES,$(MENUSELECT_CFLAGS)),)
    AST_LIBS+=-ldl
-   endif
+   ifneq (x$(CAP_LIB),x)
+     AST_LIBS+=$(CAP_LIB)

--- a/net/asterisk-13.x/patches/054-fix-cross-compile.patch
+++ b/net/asterisk-13.x/patches/054-fix-cross-compile.patch
@@ -1,0 +1,14 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -1226,7 +1226,10 @@ fi
+ AC_SUBST(AST_SHADOW_WARNINGS)
+ 
+ AC_MSG_CHECKING(for -march=native support)
+-if $(${CC} -march=native -S -o /dev/null -xc /dev/null > /dev/null 2>&1); then
++if test "${cross_compiling}" = "yes"; then
++	AC_MSG_RESULT(cross-compile)
++	AST_NATIVE_ARCH=0
++elif $(${CC} -march=native -S -o /dev/null -xc /dev/null > /dev/null 2>&1); then
+ 	AC_MSG_RESULT(yes)
+ 	AST_NATIVE_ARCH=1
+ else

--- a/net/asterisk-g72x/Makefile
+++ b/net/asterisk-g72x/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk-g72x
-PKG_VERSION:=1.4
+PKG_VERSION:=1.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=asterisk-g72x-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://asterisk.hosting.lv/src/
-PKG_MD5SUM:=4573a6949cf46dadaf1d0d6bc2ee6755
+PKG_HASH:=1d1356202de12ee3e636d5146e0e905533b4bf4c6b68eaa7d7789cbaa305059c
 
 PKG_BUILD_DIR=$(BUILD_DIR)/asterisk-g72x-$(PKG_VERSION)
 PKG_FIXUP:=autoreconf

--- a/net/freeswitch-stable-mod-bcg729/Makefile
+++ b/net/freeswitch-stable-mod-bcg729/Makefile
@@ -1,0 +1,82 @@
+#
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=freeswitch-stable-mod-bcg729
+
+PKG_VERSION:=20170629
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
+
+PKG_LICENSE:=MPL-1.1
+PKG_LICENSE_FILES:=LICENSE
+
+PRG_URL:=https://github.com/xadhoom/mod_bcg729
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=git://github.com/xadhoom/mod_bcg729.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=686eb06d4a395d94c364efff4b63579af76ebec7
+
+include $(INCLUDE_DIR)/package.mk
+
+BCG729_MOD_DIR:=/usr/lib/freeswitch/mod
+
+BCG729_CFLAGS:=\
+	$(FPIC) \
+	$(TARGET_CFLAGS) \
+	-fno-exceptions \
+	-Wall \
+	-std=c99 \
+	-pedantic
+
+BCG729_INCLUDES:= \
+	$(TARGET_CPPFLAGS) \
+	-I$(STAGING_DIR)/usr/include/bcg729 \
+	-I$(STAGING_DIR)/usr/include/freeswitch
+
+BCG729_LDFLAGS:=-lm -Wl,-shared -lbcg729 -Wl,-Bdynamic
+
+define Package/$(PKG_NAME)
+  TITLE:=bcg729 module
+  SUBMENU:=Telephony
+  SECTION:=net
+  CATEGORY:=Network
+  URL:=https://www.freeswitch.org
+  DEPENDS:=freeswitch-stable +bcg729
+endef
+
+define Package/$(PKG_NAME)/description
+FreeSWITCH G.729 module using the opensource bcg729 implementation by
+Belledonne Communications.
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)$(BCG729_MOD_DIR)
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/mod_bcg729.so $(1)$(BCG729_MOD_DIR)
+endef
+
+define Build/Compile
+	cd $(PKG_BUILD_DIR) && \
+	$(TARGET_CC) \
+		$(BCG729_CFLAGS) \
+		$(BCG729_INCLUDES) \
+		-c mod_bcg729.c && \
+	$(TARGET_CC) \
+		$(BCG729_CFLAGS) \
+		$(BCG729_INCLUDES) \
+		-shared \
+		-Xlinker \
+		-x \
+		-o mod_bcg729.so \
+		mod_bcg729.o \
+		$(BCG729_LDFLAGS)
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
Hello Jiri @jslachta 

I wanted to add a module that links against bcg729, for which I needed a version bump. So I updated the asterisk module along with it. Asterisk didn't really compile in trunk so I went and fixed what I found until it compiled and I could compile-test asterisk-g72x.

I read in some of the issue reports that asterisk has some issues loading modules on musl (missing symbols), but I couldn't reproduce that. I loaded a few modules and it worked fine.

Best regards,
Sebastian