### PR TITLE
CC: kamailio-4.x: upgrade to 4.4.0, fix build

### DIFF
--- a/net/kamailio-4.x/Makefile
+++ b/net/kamailio-4.x/Makefile
@@ -1,5 +1,6 @@
 #
-# Copyright (C) 2015 OpenWrt.org
+# Copyright (C) 2016 OpenWrt.org
+# Copyright (C) 2013-2016 CESNET,z.s.p.o.
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio4
-PKG_VERSION:=4.3.0
-PKG_RELEASE:=2
+PKG_VERSION:=4.4.0
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://www.kamailio.org/pub/kamailio/$(PKG_VERSION)/src/
 PKG_SOURCE:=kamailio-$(PKG_VERSION)$(PKG_VARIANT)_src.tar.gz
-PKG_MD5SUM:=4a6bd2f70f14d94a4ed9a8e6b18f89d7
+PKG_MD5SUM:=e9fa206f67346a6b01c015d76ec2db9d
 PKG_USE_MIPS16:=0
 
 PKG_LICENSE:=GPL-2.0+

--- a/net/kamailio-4.x/Makefile
+++ b/net/kamailio-4.x/Makefile
@@ -33,7 +33,7 @@ define Package/kamailio4/Default
   CATEGORY:=Network
   SUBMENU:=Telephony
   URL:=http://www.kamailio.org/
-  DEPENDS:=$(ICONV_DEPENDS) +libncurses +libpthread +libreadline +libxml2
+  DEPENDS:=$(ICONV_DEPENDS) +libncurses +libpthread +libreadline +libxml2 +hiredis
 endef
 
 define Package/kamailio4
@@ -137,7 +137,6 @@ $(eval $(call BuildKamailio4Module,db_text,Text database-backend,,,dbtext/kamail
 $(eval $(call BuildKamailio4Module,db_unixodbc,UnixODBC Database-backend,,+unixodbc))
 $(eval $(call BuildKamailio4Module,debugger,Interactive config file debugger,,))
 $(eval $(call BuildKamailio4Module,dialog,Dialog support,,+kamailio4-mod-rr +kamailio4-mod-tm))
-$(eval $(call BuildKamailio4Module,dialog_ng,Dialog support,,+kamailio4-mod-rr +kamailio4-mod-tm))
 $(eval $(call BuildKamailio4Module,dialplan,Dialplan management,,))
 $(eval $(call BuildKamailio4Module,dispatcher,Dispatcher,,))
 $(eval $(call BuildKamailio4Module,diversion,Diversion header insertion,,))

--- a/net/kamailio-4.x/patches/050-fix-kamailio-utils.patch
+++ b/net/kamailio-4.x/patches/050-fix-kamailio-utils.patch
@@ -1,13 +1,15 @@
---- a/utils/kamctl/kamctl
-+++ b/utils/kamctl/kamctl
+diff -rupN kamailio4-4.4.0/utils/kamctl/kamctl kam4/utils/kamctl/kamctl
+--- kamailio4-4.4.0/utils/kamctl/kamctl	2016-03-30 15:56:42.000000000 +0200
++++ kam4/utils/kamctl/kamctl	2016-04-07 14:41:45.108118138 +0200
 @@ -1,4 +1,4 @@
 -#!/bin/bash
 +#!/bin/sh
  #
  # control tool for maintaining Kamailio
  #
---- a/utils/kamctl/kamctlrc
-+++ b/utils/kamctl/kamctlrc
+diff -rupN kamailio4-4.4.0/utils/kamctl/kamctlrc kam4/utils/kamctl/kamctlrc
+--- kamailio4-4.4.0/utils/kamctl/kamctlrc	2016-03-30 15:56:42.000000000 +0200
++++ kam4/utils/kamctl/kamctlrc	2016-04-07 14:42:20.348404015 +0200
 @@ -147,3 +147,6 @@
  ## Extra start options - default is: not set
  # example: start Kamailio with 64MB share memory: STARTOPTIONS="-m 64"
@@ -15,16 +17,18 @@
 +
 +# Disable colour printing in terminal
 +NOHLPRINT=1
---- a/utils/kamctl/kamdbctl
-+++ b/utils/kamctl/kamdbctl
+diff -rupN kamailio4-4.4.0/utils/kamctl/kamdbctl kam4/utils/kamctl/kamdbctl
+--- kamailio4-4.4.0/utils/kamctl/kamdbctl	2016-03-30 15:56:42.000000000 +0200
++++ kam4/utils/kamctl/kamdbctl	2016-04-07 14:42:36.204532677 +0200
 @@ -1,4 +1,4 @@
 -#!/bin/bash 
-+#!/bin/sh 
++#!/bin/sh
  #
  # control tool for maintaining Kamailio databases
  #
---- a/utils/kamctl/kamdbctl.base
-+++ b/utils/kamctl/kamdbctl.base
+diff -rupN kamailio4-4.4.0/utils/kamctl/kamdbctl.base kam4/utils/kamctl/kamdbctl.base
+--- kamailio4-4.4.0/utils/kamctl/kamdbctl.base	2016-03-30 15:56:42.000000000 +0200
++++ kam4/utils/kamctl/kamdbctl.base	2016-04-07 14:43:18.180873383 +0200
 @@ -33,18 +33,18 @@ INSTALL_DBUID_TABLES=${INSTALL_DBUID_TAB
  
  # Used by dbtext and db_berkeley to define tables to be created, used by
@@ -37,7 +41,7 @@
 +		grp uri speed_dial lcr_gw lcr_rule lcr_rule_target pdt subscriber \
 +		location location_attrs re_grp trusted address missed_calls \
 +		usr_preferences aliases silo dialog dialog_vars dispatcher dialplan \
- 		acc_cdrs}
+ 		acc_cdrs topos_d topos_t}
 -EXTRA_TABLES=${EXTRA_TABLES:-imc_members imc_rooms cpl sip_trace domainpolicy
 -		carrierroute carrier_name domain_name carrierfailureroute userblacklist
 -		globalblacklist htable purplemap uacreg pl_pipes mtree mtrees
@@ -61,7 +65,7 @@
 -		permissions registrar usrloc msilo alias_db uri_db speeddial
 +STANDARD_MODULES=${STANDARD_MODULES:-standard acc lcr domain group \
 +		permissions registrar usrloc msilo alias_db uri_db speeddial \
- 		avpops auth_db pdt dialog dispatcher dialplan}
+ 		avpops auth_db pdt dialog dispatcher dialplan topos}
  
  PRESENCE_MODULES=${PRESENCE_MODULES:-presence rls}
  

--- a/net/kamailio-4.x/patches/110-include-sys-time-h-in-ld_session-h.patch
+++ b/net/kamailio-4.x/patches/110-include-sys-time-h-in-ld_session-h.patch
@@ -1,0 +1,10 @@
+--- a/modules/ldap/ld_session.h
++++ b/modules/ldap/ld_session.h
+@@ -33,6 +33,7 @@
+ #ifndef LD_SESSION_H
+ #define LD_SESSION_H
+ 
++#include <sys/time.h>
+ #include <ldap.h>
+ 
+ #include "iniparser.h"

--- a/net/kamailio-4.x/patches/110-include-sys-time-h-in-ld_session-h.patch
+++ b/net/kamailio-4.x/patches/110-include-sys-time-h-in-ld_session-h.patch
@@ -1,6 +1,6 @@
 --- a/modules/ldap/ld_session.h
 +++ b/modules/ldap/ld_session.h
-@@ -33,6 +33,7 @@
+@@ -28,6 +28,7 @@
  #ifndef LD_SESSION_H
  #define LD_SESSION_H
  

--- a/net/kamailio-4.x/patches/111-include-sys-time-h-in-sercmd-c.patch
+++ b/net/kamailio-4.x/patches/111-include-sys-time-h-in-sercmd-c.patch
@@ -1,5 +1,5 @@
---- a/utils/sercmd/sercmd.c
-+++ b/utils/sercmd/sercmd.c
+--- a/utils/kamcmd/kamcmd.c
++++ b/utils/kamcmd/kamcmd.c
 @@ -43,6 +43,7 @@
  #include <errno.h>
  #include <ctype.h> /* isprint */

--- a/net/kamailio-4.x/patches/111-include-sys-time-h-in-sercmd-c.patch
+++ b/net/kamailio-4.x/patches/111-include-sys-time-h-in-sercmd-c.patch
@@ -1,0 +1,10 @@
+--- a/utils/sercmd/sercmd.c
++++ b/utils/sercmd/sercmd.c
+@@ -43,6 +43,7 @@
+ #include <errno.h>
+ #include <ctype.h> /* isprint */
+ #include <sys/socket.h>
++#include <sys/time.h> /* struct timeval */
+ #include <sys/un.h> /* unix sock*/
+ #include <netinet/in.h> /* udp sock */
+ #include <sys/uio.h> /* writev */

--- a/net/kamailio-4.x/patches/120-libevent-libs.patch
+++ b/net/kamailio-4.x/patches/120-libevent-libs.patch
@@ -1,20 +1,18 @@
-Index: kamailio4-4.3.0/modules/cnxcc/Makefile
-===================================================================
---- kamailio4-4.3.0.orig/modules/cnxcc/Makefile
-+++ kamailio4-4.3.0/modules/cnxcc/Makefile
-@@ -8,7 +8,7 @@ include ../../Makefile.defs
- auto_gen=
- NAME=cnxcc.so
+diff -rupN kamailio4-4.4.0/modules/cnxcc/Makefile kam4/modules/cnxcc/Makefile
+--- kamailio4-4.4.0/modules/cnxcc/Makefile	2016-04-07 11:26:01.186927107 +0200
++++ kam4/modules/cnxcc/Makefile	2016-04-07 11:25:28.370655776 +0200
+@@ -45,7 +45,7 @@ else
+ endif
  
--LIBS=-lhiredis -levent
-+LIBS=-lhiredis -levent $(EXTRA_LIBS)
+ DEFS+=$(HIREDISDEFS) $(LEVENTDEFS)
+-LIBS=$(HIREDISLIBS) $(LEVENTLIBS)
++LIBS=$(HIREDISLIBS) $(LEVENTLIBS) $(EXTRA_LIBS)
+ 
  DEFS+=-DOPENSER_MOD_INTERFACE
  SERLIBPATH=../../lib
- SER_LIBS+=$(SERLIBPATH)/kmi/kmi
-Index: kamailio4-4.3.0/modules/janssonrpc-c/netstring.h
-===================================================================
---- kamailio4-4.3.0.orig/modules/janssonrpc-c/netstring.h
-+++ kamailio4-4.3.0/modules/janssonrpc-c/netstring.h
+diff -rupN kamailio4-4.4.0/modules/janssonrpc-c/netstring.h kam4/modules/janssonrpc-c/netstring.h
+--- kamailio4-4.4.0/modules/janssonrpc-c/netstring.h	2016-04-07 11:26:24.163117016 +0200
++++ kam4/modules/janssonrpc-c/netstring.h	2016-04-07 11:25:28.070653295 +0200
 @@ -24,6 +24,7 @@
  #define __NETSTRING_STREAM_H
  


### PR DESCRIPTION
Maintainer: @jslachta 
Compile-tested on: CC/adm8668

Description:
Fix build on CC, while at it, upgrade to 4.4.0. mod-dialog-ng had to be pulled from the modules as it's not available in the source, and the sercmd patch had to be manually updated to patch kamcmd instead.