### PR TITLE
asterisk-chan-lantiq: remove nonshared hack

### DIFF
--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -26,7 +26,6 @@ PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
-include $(INCLUDE_DIR)/version.mk
 
 define Package/asterisk13/install/module
 	$(INSTALL_DIR) $(1)/usr/lib/asterisk/modules
@@ -281,25 +280,10 @@ define Build/Compile
 	$(call Build/Compile/Default,all install samples)
 endef
 
-# Tar up the headers for chan-lantiq and store them in $(DL_DIR). This is a
-# workaround for a hen and egg problem: chan-lantiq is a nonshared (target
-# specific) package. It depends on both kernel module and asterisk headers. But
-# the build bots will not build shared packages (e.g. asterisk) when building
-# the target specific packages because the shared packages are not selected by
-# CONFIG_ALL_NONSHARED=y.
-
-# The workaround stores the asterisk headers in $(DL_DIR) where chan-lantiq can
-# access them.
-
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/asterisk-13/include/asterisk/
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/asterisk/*.h $(1)/usr/include/asterisk-13/include/asterisk/
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/asterisk.h $(1)/usr/include/asterisk-13/include/
-ifeq ($(CONFIG_TARGET_ARCH_PACKAGES),"mips_24kc")
-	$(TAR) --create --xz \
-		--file=$(DL_DIR)/$(PKG_NAME)-$(call qstrip,$(CONFIG_TARGET_ARCH_PACKAGES))-headers-for-chan-lantiq-$(VERSION_NUMBER).tar.xz \
-		--directory=$(PKG_INSTALL_DIR)/usr include
-endif
 endef
 
 $(eval $(call BuildPackage,asterisk13))

--- a/net/asterisk-15.x/Makefile
+++ b/net/asterisk-15.x/Makefile
@@ -24,7 +24,6 @@ PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
-include $(INCLUDE_DIR)/version.mk
 
 define Package/asterisk15/install/module
 	$(INSTALL_DIR) $(1)/usr/lib/asterisk/modules
@@ -281,25 +280,10 @@ define Build/Compile
 	$(call Build/Compile/Default,all install samples)
 endef
 
-# Tar up the headers for chan-lantiq and store them in $(DL_DIR). This is a
-# workaround for a hen and egg problem: chan-lantiq is a nonshared (target
-# specific) package. It depends on both kernel module and asterisk headers. But
-# the build bots will not build shared packages (e.g. asterisk) when building
-# the target specific packages because the shared packages are not selected by
-# CONFIG_ALL_NONSHARED=y.
-
-# The workaround stores the asterisk headers in $(DL_DIR) where chan-lantiq can
-# access them.
-
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/asterisk-15/include/asterisk/
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/asterisk/*.h $(1)/usr/include/asterisk-15/include/asterisk/
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/asterisk.h $(1)/usr/include/asterisk-15/include/
-ifeq ($(CONFIG_TARGET_ARCH_PACKAGES),"mips_24kc")
-	$(TAR) --create --xz \
-		--file=$(DL_DIR)/$(PKG_NAME)-$(call qstrip,$(CONFIG_TARGET_ARCH_PACKAGES))-headers-for-chan-lantiq-$(VERSION_NUMBER).tar.xz \
-		--directory=$(PKG_INSTALL_DIR)/usr include
-endif
 endef
 
 $(eval $(call BuildPackage,asterisk15))

--- a/net/asterisk-chan-lantiq/Makefile
+++ b/net/asterisk-chan-lantiq/Makefile
@@ -16,14 +16,7 @@ PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
-PKG_FLAGS:=nonshared
-
-# WARNING: Because this module is target specific ("nonshared") it cannot depend
-# on the shared Asterisk package. Asterisk needs to be built _before_ this
-# package, though, to generate the necessary headers.
-
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/version.mk
 
 define Package/$(PKG_NAME)/Default
   SUBMENU:=Telephony
@@ -31,11 +24,12 @@ define Package/$(PKG_NAME)/Default
   CATEGORY:=Network
   TITLE:=Lantiq channel driver
   URL:=https://github.com/kochstefan/asterisk_channel_lantiq
-  DEPENDS:=@(TARGET_lantiq_falcon||TARGET_lantiq_xway||TARGET_lantiq_xrx200) +kmod-ltq-vmmc
+  DEPENDS:=+kmod-ltq-vmmc
 endef
 
-define Package/$(PKG_NAME)-asterisk13
+define Package/asterisk13-$(PKG_NAME)
 $(call Package/$(PKG_NAME)/Default)
+  DEPENDS+=asterisk13
   VARIANT:=asterisk13
 endef
 
@@ -43,13 +37,13 @@ define Package/description/Default
 An implementation of a Lantiq TAPI channel driver for Asterisk.
 endef
 
-Package/$(PKG_NAME)-asterisk13/description = $(Package/description/Default)
+Package/asterisk13-$(PKG_NAME)/description = $(Package/description/Default)
 
 define Package/conffiles/Default
 /etc/asterisk/lantiq.conf
 endef
 
-Package/$(PKG_NAME)-asterisk13/conffiles = $(Package/conffiles/Default)
+Package/asterisk13-$(PKG_NAME)/conffiles = $(Package/conffiles/Default)
 
 define Package/Install/Default
 	$(INSTALL_DIR) $(1)/etc/asterisk
@@ -60,14 +54,15 @@ define Package/Install/Default
 		$(1)/usr/lib/asterisk/modules
 endef
 
-Package/$(PKG_NAME)-asterisk13/install = $(Package/Install/Default)
+Package/asterisk13-$(PKG_NAME)/install = $(Package/Install/Default)
+
+ifeq ($(BUILD_VARIANT),asterisk13)
+CHAN_LANTIQ_AST_INCLUDES:=-I$(STAGING_DIR)/usr/include/asterisk-13/include
+endif
 
 define Build/Prepare
 	$(CP) ./files/chan_lantiq-$(BUILD_VARIANT).c $(PKG_BUILD_DIR)/chan_lantiq.c
 	$(CP) ./files/default.exports $(PKG_BUILD_DIR)/chan_lantiq.exports
-	$(TAR) --extract --no-same-owner --no-same-permissions --xz \
-		--file=$(DL_DIR)/$(BUILD_VARIANT)-$(call qstrip,$(CONFIG_TARGET_ARCH_PACKAGES))-headers-for-chan-lantiq-$(VERSION_NUMBER).tar.xz \
-		--directory=$(PKG_BUILD_DIR)
 endef
 
 define Build/Configure
@@ -78,7 +73,7 @@ define Build/Compile
 	$(TARGET_CC) -o chan_lantiq.o -c chan_lantiq.c -MD -MT chan_lantiq.o \
 		-MF .chan_lantiq.o.d -MP -pthread \
 		$(TARGET_CFLAGS) \
-		-I$(PKG_BUILD_DIR)/include \
+		$(CHAN_LANTIQ_AST_INCLUDES) \
 		$(TARGET_CPPFLAGS) \
 		-Wall -Wstrict-prototypes -Wmissing-prototypes \
 		-Wmissing-declarations $(FPIC) -DAST_MODULE=\"chan_lantiq\" && \
@@ -87,4 +82,4 @@ define Build/Compile
 		chan_lantiq.o
 endef
 
-$(eval $(call BuildPackage,$(PKG_NAME)-asterisk13))
+$(eval $(call BuildPackage,asterisk13-$(PKG_NAME)))


### PR DESCRIPTION
Hello @jslachta 

I'm not sure what you got queued up for chan-lantiq. If this doesn't get in the way of anything please consider merging it.

Kind regards,
Seb

The previously conceived hack - to make the buildbots actually build
this package during the target phase - does not work. This patch removes
the hack. This includes removing the lines from the asterisk Makefiles
that tar up the asterisk headers.

The upside of removing the hack is that the package name can be reverted
to what it was before, so it can be found in the same place like all the
other asterisk modules, i.e. below its asterisk version.

Another upside is that the Makefile does not pretend to solve the
problem anymore. Issue #193 is still open for the same. Maybe some day
somebody can figure out how to resolve the problem properly.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>