### PR TITLE
New PR: re, rem, restund and baresip

### DIFF
--- a/libs/re/Makefile
+++ b/libs/re/Makefile
@@ -28,9 +28,9 @@ define Package/libre
   SUBMENU:=Telephony
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libopenssl +libpthread +zlib
+  DEPENDS:=+libopenssl +zlib
   TITLE:=Generic library for real-time communications with async IO support
-  URL:=http://www.creytiv.com/
+  URL:=http://www.creytiv.com
 endef
 
 # re.mk is used for this and all related packages (rem, restund and baresip).
@@ -43,29 +43,27 @@ endef
 # EXTRA_LFLAGS.
 
 ifneq ($(CONFIG_USE_GLIBC)$(CONFIG_USE_MUSL),)
-TARGET_CFLAGS += -D_GNU_SOURCE
+TARGET_CFLAGS+=-D_GNU_SOURCE
 endif
 
 MAKE_FLAGS+= \
-	HAVE_LIBRESOLV= \
 	EXTRA_LFLAGS="$(TARGET_LDFLAGS)" \
 	SYSROOT="$(shell $(FIND) $(TOOLCHAIN_DIR) -path '*/include/pthread.h' | sed -ne '1s|/include/pthread.h||p')" \
 	SYSROOT_ALT="$(STAGING_DIR)/usr" \
-	RELEASE=1 \
-	OS=linux
+	RELEASE=1
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/share/re
-	$(CP) $(PKG_BUILD_DIR)/mk/re.mk $(1)/usr/share/re/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/re/re.mk $(1)/usr/share/re
 	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/re $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/re $(1)/usr/include
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libre.{a,so} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libre.{a,so} $(1)/usr/lib
 endef
 
 define Package/libre/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libre.so $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libre.so $(1)/usr/lib
 endef
 
 $(eval $(call BuildPackage,libre))

--- a/libs/re/Makefile
+++ b/libs/re/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=re
 PKG_VERSION:=0.5.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.creytiv.com/pub
@@ -19,6 +19,8 @@ PKG_HASH:=a3119826ad162f898ada734d093f565824a018df395b4517549915b00e2bdf69
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=docs/COPYING
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
+
+PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -31,26 +33,26 @@ define Package/libre
   URL:=http://www.creytiv.com/
 endef
 
-TARGET_CFLAGS += $(FPIC)
+# re.mk is used for this and all related packages (rem, restund and baresip).
+# It relies on SYSROOT and SYSROOT_ALT being set. SYSROOT is used for finding
+# toolchain headers (like pthread.h). SYSROOT_ALT is used for finding headers
+# from other packages, like openssl etc.
+#
+# CFLAGS are picked up from the environment, as well as CPPFLAGS (and LD etc.).
+# But LDFLAGS aren't picked up, so they need to be handed over via
+# EXTRA_LFLAGS.
 
 ifneq ($(CONFIG_USE_GLIBC)$(CONFIG_USE_MUSL),)
 TARGET_CFLAGS += -D_GNU_SOURCE
 endif
 
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		HAVE_LIBRESOLV= \
-		CC="$(TARGET_CC)" \
-		EXTRA_CFLAGS="$(TARGET_CFLAGS) -DOPENWRT" \
-		EXTRA_LFLAGS="-lm" \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		SYSROOT="$$$$($(FIND) $(TOOLCHAIN_DIR) -path '*/include/pthread.h' | sed -ne '1s#/include/pthread.h##p')" \
-		SYSROOT_ALT="$(STAGING_DIR)/usr" \
-		RELEASE=1 \
-		CROSS_COMPILE="$(TARGET_CROSS)" \
-		OS=linux \
-		all install
-endef
+MAKE_FLAGS+= \
+	HAVE_LIBRESOLV= \
+	EXTRA_LFLAGS="$(TARGET_LDFLAGS)" \
+	SYSROOT="$(shell $(FIND) $(TOOLCHAIN_DIR) -path '*/include/pthread.h' | sed -ne '1s|/include/pthread.h||p')" \
+	SYSROOT_ALT="$(STAGING_DIR)/usr" \
+	RELEASE=1 \
+	OS=linux
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/share/re

--- a/libs/re/patches/002-fix-redefine-ssize_t.patch
+++ b/libs/re/patches/002-fix-redefine-ssize_t.patch
@@ -1,0 +1,11 @@
+--- a/include/re_types.h
++++ b/include/re_types.h
+@@ -47,7 +47,7 @@ typedef unsigned long long int    uint64
+ #endif /* __BIT_TYPES_DEFINED__ */
+ 
+ #endif /* __int8_t_defined */
+-#ifndef __ssize_t_defined
++#if !defined(__ssize_t_defined) && !defined(__DEFINED_ssize_t)
+ typedef long     ssize_t;
+ #define __ssize_t_defined
+ #endif

--- a/libs/re/patches/003-fix-linker-call.patch
+++ b/libs/re/patches/003-fix-linker-call.patch
@@ -1,0 +1,11 @@
+--- a/mk/re.mk
++++ b/mk/re.mk
+@@ -235,7 +235,7 @@ ifeq ($(OS),linux)
+ 	LFLAGS		+= -fPIC
+ 	SH_LFLAGS	+= -shared
+ 	MOD_LFLAGS	+=
+-	APP_LFLAGS	+= -rdynamic
++	APP_LFLAGS	+= --export-dynamic
+ 	AR		:= ar
+ 	AFLAGS		:= crD
+ endif

--- a/libs/re/patches/004-prevent-optimization-meddling.patch
+++ b/libs/re/patches/004-prevent-optimization-meddling.patch
@@ -1,0 +1,10 @@
+--- a/mk/re.mk
++++ b/mk/re.mk
+@@ -43,7 +43,6 @@
+ 
+ ifneq ($(RELEASE),)
+ CFLAGS  += -DRELEASE
+-OPT_SPEED=1
+ endif
+ 
+ 

--- a/libs/rem/Makefile
+++ b/libs/rem/Makefile
@@ -28,9 +28,9 @@ define Package/librem
   SUBMENU:=Telephony
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libre +libpthread
+  DEPENDS:=+libre
   TITLE:=Audio and video processing media library
-  URL:=http://www.creytiv.com/
+  URL:=http://www.creytiv.com
 endef
 
 MAKE_FLAGS+= \
@@ -40,21 +40,18 @@ MAKE_FLAGS+= \
 	LIBRE_SO="$(STAGING_DIR)/usr/lib" \
 	SYSROOT="$(shell $(FIND) $(TOOLCHAIN_DIR) -path '*/include/pthread.h' | sed -ne '1s|/include/pthread.h||p')" \
 	SYSROOT_ALT="$(STAGING_DIR)/usr" \
-	RELEASE=1 \
-	OS=linux
+	RELEASE=1
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
-	$(CP) $(PKG_INSTALL_DIR)/usr/include/rem $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/rem $(1)/usr/include
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/librem.{a,so} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/librem.{a,so} $(1)/usr/lib
 endef
 
 define Package/librem/install
-	rm -f $(BUILD_DIR)/$(PKG_NAME)
-	ln -sf $(PKG_NAME)-$(PKG_VERSION) $(BUILD_DIR)/$(PKG_NAME)
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/librem.so $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/librem.so $(1)/usr/lib
 endef
 
 $(eval $(call BuildPackage,librem))

--- a/libs/rem/Makefile
+++ b/libs/rem/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rem
 PKG_VERSION:=0.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.creytiv.com/pub
@@ -19,6 +19,8 @@ PKG_HASH:=fbc54e81ed4fd28a11d525f4384d06bee4c11e10975395668e8260ef0d4a64eb
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=docs/COPYING
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
+
+PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -31,24 +33,15 @@ define Package/librem
   URL:=http://www.creytiv.com/
 endef
 
-TARGET_CFLAGS+=$(FPIC)
-
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		LIBRE_MK=$(STAGING_DIR)/usr/share/re/re.mk \
-		LIBRE_INC=$(STAGING_DIR)/usr/include/re \
-		LIBRE_SO=$(STAGING_DIR)/usr/lib \
-		CC="$(TARGET_CC)" \
-		EXTRA_CFLAGS="$(TARGET_CFLAGS) -DOPENWRT" \
-		EXTRA_LFLAGS="-lm" \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		SYSROOT="$$$$($(FIND) $(TOOLCHAIN_DIR) -path '*/include/pthread.h' | sed -ne '1s#/include/pthread.h##p')" \
-		SYSROOT_ALT="$(STAGING_DIR)/usr" \
-		RELEASE=1 \
-		CROSS_COMPILE="$(TARGET_CROSS)" \
-		OS=linux \
-		all install
-endef
+MAKE_FLAGS+= \
+	EXTRA_LFLAGS="$(TARGET_LDFLAGS)" \
+	LIBRE_MK="$(STAGING_DIR)/usr/share/re/re.mk" \
+	LIBRE_INC="$(STAGING_DIR)/usr/include/re" \
+	LIBRE_SO="$(STAGING_DIR)/usr/lib" \
+	SYSROOT="$(shell $(FIND) $(TOOLCHAIN_DIR) -path '*/include/pthread.h' | sed -ne '1s|/include/pthread.h||p')" \
+	SYSROOT_ALT="$(STAGING_DIR)/usr" \
+	RELEASE=1 \
+	OS=linux
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include

--- a/net/baresip/Makefile
+++ b/net/baresip/Makefile
@@ -102,7 +102,7 @@ define Package/baresip/install
 endef
 
 ##################
-# Baresip modules
+# bareSIP modules
 # 1. Name
 # 2. Title
 # 3. Files
@@ -113,8 +113,8 @@ define BuildPlugin
 
   define Package/baresip-mod-$(1)
     $$(call Package/baresip/Default)
-    TITLE:= baresip $(2) module
-    DEPENDS:= baresip $(4)
+    TITLE:=$(2)
+    DEPENDS:=baresip $(patsubst +%,+PACKAGE_$(PKG_NAME)-mod-$(1):%,$(4))
   endef
 
   define Package/baresip-mod-$(1)/install
@@ -131,18 +131,18 @@ endef
 
 $(eval $(call BuildPackage,baresip))
 
-$(eval $(call BuildPlugin,alsa,ALSA audio driver,alsa,+PACKAGE_baresip-mod-alsa:alsa-lib))
-$(eval $(call BuildPlugin,avcodec,FFmpeg video codecs,avcodec,+PACKAGE_baresip-mod-avcodec:libffmpeg-full))
-$(eval $(call BuildPlugin,avformat,FFmpeg video source,avformat,+PACKAGE_baresip-mod-avformat:libffmpeg-full))
-$(eval $(call BuildPlugin,cons,console UI,cons,))
+$(eval $(call BuildPlugin,alsa,ALSA audio driver,alsa,+alsa-lib))
+$(eval $(call BuildPlugin,avcodec,Video codec using FFmpeg,avcodec,+libffmpeg-full))
+$(eval $(call BuildPlugin,avformat,Video source using FFmpeg,avformat,+libffmpeg-full))
+$(eval $(call BuildPlugin,cons,UDP/TCP console UI driver,cons,))
 $(eval $(call BuildPlugin,dtmfio,DTMF input/output,dtmfio,))
-$(eval $(call BuildPlugin,evdev,input event device UI,evdev,))
+$(eval $(call BuildPlugin,evdev,Linux input driver,evdev,))
 $(eval $(call BuildPlugin,g711,G.711 audio codec,g711,))
-$(eval $(call BuildPlugin,g722,G.722 audio codec,g722,+PACKAGE_baresip-mod-g722:libspandsp))
-$(eval $(call BuildPlugin,g726,G.726 audio codec,g726,+PACKAGE_baresip-mod-g726:libspandsp))
-$(eval $(call BuildPlugin,httpd,Webserver UI module,httpd,))
-$(eval $(call BuildPlugin,opus,Opus audio codec,opus,+PACKAGE_baresip-mod-opus:libopus))
+$(eval $(call BuildPlugin,g722,G.722 audio codec,g722,+libspandsp))
+$(eval $(call BuildPlugin,g726,G.726 audio codec,g726,+libspandsp))
+$(eval $(call BuildPlugin,httpd,HTTP webserver UI-module,httpd,))
+$(eval $(call BuildPlugin,opus,OPUS Interactive audio codec,opus,+libopus))
 $(eval $(call BuildPlugin,oss,OSS audio driver,oss,))
-$(eval $(call BuildPlugin,stdio,standard I/O UI,stdio,))
-$(eval $(call BuildPlugin,v4l,Video4Linux video source,v4l,+PACKAGE_baresip-mod-v4l:libv4l))
-$(eval $(call BuildPlugin,v4l2,Video4Linux2 video source,v4l2,+PACKAGE_baresip-mod-v4l2:libv4l))
+$(eval $(call BuildPlugin,stdio,Standard input/output UI driver,stdio,))
+$(eval $(call BuildPlugin,v4l,Video4Linux video source,v4l,+libv4l))
+$(eval $(call BuildPlugin,v4l2,Video4Linux2 video source,v4l2,+libv4l))

--- a/net/baresip/Makefile
+++ b/net/baresip/Makefile
@@ -13,7 +13,7 @@ PKG_VERSION:=0.5.6
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.creytiv.com/pub/
+PKG_SOURCE_URL:=http://www.creytiv.com/pub
 PKG_HASH:=148defef160842e0247af92c84bb0c8de4b36ffa68cf3a87c4cd7e510cddd00c
 
 PKG_LICENSE:=BSD-3-Clause
@@ -46,13 +46,13 @@ define Package/baresip/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Telephony
-  URL:=http://www.creytiv.com/
+  URL:=http://www.creytiv.com
 endef
 
 define Package/baresip
 $(call Package/baresip/Default)
   TITLE:=Portable and modular SIP User-Agent with A/V support
-  DEPENDS:=+libre +librem +libpthread
+  DEPENDS:=+libre +librem
   MENU:=1
 endef
 
@@ -75,8 +75,6 @@ BARESIP_MOD_OPTIONS:= \
 	EXTRA_MODULES="dtmfio" \
 	$(foreach m,$(baresip-mods),$(baresip-mod-$(m))=$(if $(CONFIG_PACKAGE_baresip-mod-$(m)),1))
 
-TARGET_CFLAGS += $(FPIC) -D_GNU_SOURCE
-
 MAKE_FLAGS+= \
 	EXTRA_LFLAGS="$(TARGET_LDFLAGS)" \
 	LIBRE_MK="$(STAGING_DIR)/usr/share/re/re.mk" \
@@ -86,18 +84,19 @@ MAKE_FLAGS+= \
 	SYSROOT="$(shell $(FIND) $(TOOLCHAIN_DIR) -path '*/include/pthread.h' | sed -ne '1s|/include/pthread.h||p')" \
 	SYSROOT_ALT="$(STAGING_DIR)/usr" \
 	RELEASE=1 \
-	OS="linux" \
 	$(BARESIP_MOD_OPTIONS)
+
+TARGET_CFLAGS+=-D_GNU_SOURCE
 
 define Package/baresip/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(CP) $(PKG_INSTALL_DIR)/usr/bin/baresip $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/baresip $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/usr/lib/baresip/modules
 	$(INSTALL_BIN) \
 		$(PKG_INSTALL_DIR)/usr/lib/baresip/modules/{account,auloop,contact,ice,menu,stun,turn}.so \
-		$(1)/usr/lib/baresip/modules/.
+		$(1)/usr/lib/baresip/modules
 	$(INSTALL_DIR) $(1)/usr/share/baresip
-	$(CP) $(PKG_INSTALL_DIR)/usr/share/baresip/* $(1)/usr/share/baresip/.
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/baresip/* $(1)/usr/share/baresip
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/baresip.init $(1)/etc/init.d/baresip
 endef
@@ -121,9 +120,9 @@ define BuildPlugin
   define Package/baresip-mod-$(1)/install
 	[ -z "$(3)" ] || $(INSTALL_DIR) $$(1)/usr/lib/baresip/modules
 	for f in $(3); do \
-		$(CP) \
+		$(INSTALL_DATA) \
 			$(PKG_INSTALL_DIR)/usr/lib/baresip/modules/$$$$$$$${f}.so \
-			$$(1)/usr/lib/baresip/modules/ ; \
+			$$(1)/usr/lib/baresip/modules; \
 	done
   endef
 

--- a/net/baresip/Makefile
+++ b/net/baresip/Makefile
@@ -33,6 +33,14 @@ baresip-mods:= \
 	g726 \
 	opus \
 	oss \
+	plc \
+	portaudio \
+	pulse \
+	sndfile \
+	speex \
+	speex_aec \
+	speex_pp \
+	srtp \
 	stdio \
 	v4l \
 	v4l2
@@ -66,6 +74,14 @@ baresip-mod-g722      := USE_G722
 baresip-mod-g726      := USE_G726
 baresip-mod-opus      := USE_OPUS
 baresip-mod-oss       := USE_OSS
+baresip-mod-plc       := USE_PLC
+baresip-mod-portaudio := USE_PORTAUDIO
+baresip-mod-pulse     := USE_PULSE
+baresip-mod-sndfile   := USE_SNDFILE
+baresip-mod-speex     := USE_SPEEX
+baresip-mod-speex_aec := USE_SPEEX_AEC
+baresip-mod-speex_pp  := USE_SPEEX_PP
+baresip-mod-srtp      := USE_SRTP
 baresip-mod-stdio     := USE_STDIO
 baresip-mod-v4l       := USE_V4L
 baresip-mod-v4l2      := USE_V4L2
@@ -132,17 +148,40 @@ endef
 $(eval $(call BuildPackage,baresip))
 
 $(eval $(call BuildPlugin,alsa,ALSA audio driver,alsa,+alsa-lib))
+$(eval $(call BuildPlugin,aubridge,Audio bridge module,aubridge,))
+$(eval $(call BuildPlugin,aufile,Audio module for using a WAV-file as audio input,aufile,))
 $(eval $(call BuildPlugin,avcodec,Video codec using FFmpeg,avcodec,+libffmpeg-full))
 $(eval $(call BuildPlugin,avformat,Video source using FFmpeg,avformat,+libffmpeg-full))
 $(eval $(call BuildPlugin,cons,UDP/TCP console UI driver,cons,))
+$(eval $(call BuildPlugin,debug_cmd,Debug commands,debug_cmd,))
+$(eval $(call BuildPlugin,dtls_srtp,DTLS-SRTP end-to-end encryption,dtls_srtp,))
 $(eval $(call BuildPlugin,dtmfio,DTMF input/output,dtmfio,))
 $(eval $(call BuildPlugin,evdev,Linux input driver,evdev,))
+$(eval $(call BuildPlugin,fakevideo,Fake video input/output driver,fakevideo,))
 $(eval $(call BuildPlugin,g711,G.711 audio codec,g711,))
 $(eval $(call BuildPlugin,g722,G.722 audio codec,g722,+libspandsp))
 $(eval $(call BuildPlugin,g726,G.726 audio codec,g726,+libspandsp))
 $(eval $(call BuildPlugin,httpd,HTTP webserver UI-module,httpd,))
+$(eval $(call BuildPlugin,mwi,Message Waiting Indication,mwi,))
+$(eval $(call BuildPlugin,natbd,NAT Behavior Discovery Module,natbd,))
+$(eval $(call BuildPlugin,natpmp,NAT Port Mapping Protocol module,natpmp,))
 $(eval $(call BuildPlugin,opus,OPUS Interactive audio codec,opus,+libopus))
 $(eval $(call BuildPlugin,oss,OSS audio driver,oss,))
+$(eval $(call BuildPlugin,plc,Packet Loss Concealment,plc,+libspandsp))
+$(eval $(call BuildPlugin,portaudio,Portaudio audio driver,portaudio,+portaudio))
+$(eval $(call BuildPlugin,presence,Presence module,presence,))
+$(eval $(call BuildPlugin,pulse,Pulseaudio audio driver,pulse,+pulseaudio-daemon))
+$(eval $(call BuildPlugin,selfview,Video selfview module,selfview,))
+$(eval $(call BuildPlugin,sndfile,Audio dumper using libsndfile,sndfile,+libsndfile))
+$(eval $(call BuildPlugin,speex,Speex audio codec,speex,+libspeex))
+$(eval $(call BuildPlugin,speex_aec,Speex Acoustic Echo Canceller,speex_aec,+libspeex +libspeexdsp))
+$(eval $(call BuildPlugin,speex_pp,Speex preprocessor,speex_pp,+libspeex +libspeexdsp))
+$(eval $(call BuildPlugin,srtp,Secure RTP module using libre,srtp,))
 $(eval $(call BuildPlugin,stdio,Standard input/output UI driver,stdio,))
+$(eval $(call BuildPlugin,uuid,UUID generator and loader,uuid,))
 $(eval $(call BuildPlugin,v4l,Video4Linux video source,v4l,+libv4l))
 $(eval $(call BuildPlugin,v4l2,Video4Linux2 video source,v4l2,+libv4l))
+$(eval $(call BuildPlugin,v4l2_codec,Video4Linux2 video codec module,v4l2_codec,))
+$(eval $(call BuildPlugin,vidbridge,Video bridge module,vidbridge,))
+$(eval $(call BuildPlugin,vidloop,Video-loop test module,vidloop,))
+$(eval $(call BuildPlugin,vumeter,Display audio levels in console,vumeter,))

--- a/net/baresip/Makefile
+++ b/net/baresip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=baresip
 PKG_VERSION:=0.5.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.creytiv.com/pub/
@@ -19,6 +19,8 @@ PKG_HASH:=148defef160842e0247af92c84bb0c8de4b36ffa68cf3a87c4cd7e510cddd00c
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=docs/COPYING
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
+
+PKG_INSTALL:=1
 
 baresip-mods:= \
 	alsa \
@@ -75,23 +77,17 @@ BARESIP_MOD_OPTIONS:= \
 
 TARGET_CFLAGS += $(FPIC) -D_GNU_SOURCE
 
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		LIBRE_MK="$(STAGING_DIR)/usr/share/re/re.mk" \
-		LIBRE_INC="$(STAGING_DIR)/usr/include/re" \
-		LIBRE_SO="$(STAGING_DIR)/usr/lib" \
-		LIBREM_PATH="../rem" \
-		CC="$(TARGET_CC)" \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		EXTRA_CFLAGS="$(TARGET_CFLAGS) -DOPENWRT" \
-		SYSROOT="$$$$($(FIND) $(TOOLCHAIN_DIR) -path '*/include/pthread.h' | sed -ne '1s#/include/pthread.h##p')" \
-		SYSROOT_ALT="$(STAGING_DIR)/usr" \
-		RELEASE=1 \
-		CROSS_COMPILE="$(TARGET_CROSS)" \
-		OS="linux" \
-		$(BARESIP_MOD_OPTIONS) \
-		all install
-endef
+MAKE_FLAGS+= \
+	EXTRA_LFLAGS="$(TARGET_LDFLAGS)" \
+	LIBRE_MK="$(STAGING_DIR)/usr/share/re/re.mk" \
+	LIBRE_INC="$(STAGING_DIR)/usr/include/re" \
+	LIBRE_SO="$(STAGING_DIR)/usr/lib" \
+	LIBREM_PATH="$(STAGING_DIR)/usr" \
+	SYSROOT="$(shell $(FIND) $(TOOLCHAIN_DIR) -path '*/include/pthread.h' | sed -ne '1s|/include/pthread.h||p')" \
+	SYSROOT_ALT="$(STAGING_DIR)/usr" \
+	RELEASE=1 \
+	OS="linux" \
+	$(BARESIP_MOD_OPTIONS)
 
 define Package/baresip/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/net/baresip/patches/001-fix-linker-call.patch
+++ b/net/baresip/patches/001-fix-linker-call.patch
@@ -1,0 +1,14 @@
+--- a/Makefile
++++ b/Makefile
+@@ -199,9 +199,9 @@ libbaresip.pc:
+ $(BIN):	$(APP_OBJS)
+ 	@echo "  LD      $@"
+ ifneq ($(GPROF),)
+-	$(HIDE)$(LD) $(LFLAGS) $(APP_LFLAGS) $^ ../re/libre.a $(LIBS) -o $@
++	$(HIDE)$(LD) $(LFLAGS) $(SH_LFLAGS) $(APP_LFLAGS) $^ ../re/libre.a $(LIBS) -o $@
+ else
+-	$(HIDE)$(LD) $(LFLAGS) $(APP_LFLAGS) $^ \
++	$(HIDE)$(LD) $(LFLAGS) $(SH_LFLAGS) $(APP_LFLAGS) $^ \
+ 		-L$(LIBRE_SO) -lre $(LIBS) -o $@
+ endif
+ 

--- a/net/baresip/patches/002-fix-rem-include.patch
+++ b/net/baresip/patches/002-fix-rem-include.patch
@@ -1,0 +1,16 @@
+--- a/Makefile
++++ b/Makefile
+@@ -48,11 +48,11 @@ endif
+ 
+ CFLAGS    += -I. -Iinclude -I$(LIBRE_INC) -I$(SYSROOT)/include
+ CFLAGS    += -I$(LIBREM_PATH)/include
+-CFLAGS    += -I$(SYSROOT)/local/include/rem -I$(SYSROOT)/include/rem
++CFLAGS    += -I$(SYSROOT)/local/include/rem -I$(SYSROOT_ALT)/include/rem
+ 
+ CXXFLAGS  += -I. -Iinclude -I$(LIBRE_INC)
+ CXXFLAGS  += -I$(LIBREM_PATH)/include
+-CXXFLAGS  += -I$(SYSROOT)/local/include/rem -I$(SYSROOT)/include/rem
++CXXFLAGS  += -I$(SYSROOT)/local/include/rem -I$(SYSROOT_ALT)/include/rem
+ CXXFLAGS  += $(EXTRA_CXXFLAGS)
+ 
+ # XXX: common for C/C++

--- a/net/restund/Makefile
+++ b/net/restund/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010-2016 OpenWrt.org
+# Copyright (C) 2010-2017 OpenWrt.org
 # Copyright (C) 2010 Alfred E. Heggestad
 #
 # This is free software, licensed under the GNU General Public License v2.
@@ -13,7 +13,7 @@ PKG_VERSION:=0.4.12
 PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.creytiv.com/pub/
+PKG_SOURCE_URL:=http://www.creytiv.com/pub
 PKG_HASH:=3170441dc882352ab0275556b6fc889b38b14203d936071b5fa12f39a5c86d47
 
 PKG_LICENSE:=BSD-3-Clause
@@ -22,9 +22,9 @@ PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
 PKG_INSTALL:=1
 
-restund-mods:= mysql
+restund-mods:=mysql
 
-PKG_CONFIG_DEPENDS:= $(patsubst %,CONFIG_PACKAGE_restund-mod-%,$(restund-mods))
+PKG_CONFIG_DEPENDS:=$(patsubst %,CONFIG_PACKAGE_restund-mod-%,$(restund-mods))
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -32,16 +32,16 @@ define Package/restund/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Telephony
-  URL:=http://www.creytiv.com/
+  URL:=http://www.creytiv.com
 endef
 
 define Package/restund
 $(call Package/restund/Default)
   TITLE:=Modular STUN/TURN server
-  DEPENDS:=+libre +libpthread
+  DEPENDS:=+libre
 endef
 
-restund-mod-mysql:= USE_MYSQL
+restund-mod-mysql:=USE_MYSQL
 
 RESTUND_MOD_OPTIONS:= \
 	$(foreach m,$(restund-mods),$(restund-mod-$(m))=$(if $(CONFIG_PACKAGE_restund-mod-$(m)),1))
@@ -54,23 +54,22 @@ MAKE_FLAGS+= \
 	SYSROOT="$(shell $(FIND) $(TOOLCHAIN_DIR) -path '*/include/pthread.h' | sed -ne '1s|/include/pthread.h||p')" \
 	SYSROOT_ALT="$(STAGING_DIR)/usr" \
 	RELEASE=1 \
-	OS="linux" \
 	$(RESTUND_MOD_OPTIONS)
 
 define Package/restund/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/restund $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/restund $(1)/usr/sbin
 	$(INSTALL_DIR) $(1)/usr/lib/restund/modules
-	$(CP) \
+	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/lib/restund/modules/auth.so \
 		$(PKG_INSTALL_DIR)/usr/lib/restund/modules/binding.so \
 		$(PKG_INSTALL_DIR)/usr/lib/restund/modules/stat.so \
 		$(PKG_INSTALL_DIR)/usr/lib/restund/modules/status.so \
 		$(PKG_INSTALL_DIR)/usr/lib/restund/modules/syslog.so \
 		$(PKG_INSTALL_DIR)/usr/lib/restund/modules/turn.so \
-		$(1)/usr/lib/restund/modules/
+		$(1)/usr/lib/restund/modules
 	$(INSTALL_DIR) $(1)/etc
-	$(INSTALL_CONF) $(PKG_BUILD_DIR)/etc/restund.conf $(1)/etc/
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/etc/restund.conf $(1)/etc
 	$(SED) \
 		's|^\(module_path\)\([ \t]\+\).*$$$$|\1\2/usr/lib/restund/modules|g' \
 		$(1)/etc/restund.conf
@@ -92,16 +91,16 @@ define BuildPlugin
 
   define Package/restund-mod-$(1)
     $$(call Package/restund/Default)
-    TITLE:= restund $(2) module
-    DEPENDS:= restund $(4)
+    TITLE:=restund $(2) module
+    DEPENDS:=restund $(4)
   endef
 
   define Package/restund-mod-$(1)/install
 	[ -z "$(3)" ] || $(INSTALL_DIR) $$(1)/usr/lib/restund/modules
 	for f in $(3); do \
-		$(CP) \
+		$(INSTALL_DATA) \
 			$(PKG_INSTALL_DIR)/usr/lib/restund/modules/$$$$$$$${f}.so \
-			$$(1)/usr/lib/restund/modules/ ; \
+			$$(1)/usr/lib/restund/modules; \
 	done
   endef
 

--- a/net/restund/Makefile
+++ b/net/restund/Makefile
@@ -63,6 +63,8 @@ define Package/restund/install
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)/usr/lib/restund/modules/auth.so \
 		$(PKG_INSTALL_DIR)/usr/lib/restund/modules/binding.so \
+		$(PKG_INSTALL_DIR)/usr/lib/restund/modules/filedb.so \
+		$(PKG_INSTALL_DIR)/usr/lib/restund/modules/restauth.so \
 		$(PKG_INSTALL_DIR)/usr/lib/restund/modules/stat.so \
 		$(PKG_INSTALL_DIR)/usr/lib/restund/modules/status.so \
 		$(PKG_INSTALL_DIR)/usr/lib/restund/modules/syslog.so \
@@ -92,7 +94,7 @@ define BuildPlugin
   define Package/restund-mod-$(1)
     $$(call Package/restund/Default)
     TITLE:=restund $(2) module
-    DEPENDS:=restund $(4)
+    DEPENDS:=restund $(patsubst +%,+PACKAGE_$(PKG_NAME)-mod-$(1):%,$(4))
   endef
 
   define Package/restund-mod-$(1)/install
@@ -109,4 +111,4 @@ endef
 
 $(eval $(call BuildPackage,restund))
 
-$(eval $(call BuildPlugin,mysql,MySQL database backend,mysql_ser,+PACKAGE_restund-mod-mysql:libmysqlclient))
+$(eval $(call BuildPlugin,mysql,MySQL database backend,mysql_ser,+libmysqlclient))

--- a/net/restund/Makefile
+++ b/net/restund/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=restund
 PKG_VERSION:=0.4.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.creytiv.com/pub/
@@ -19,6 +19,8 @@ PKG_HASH:=3170441dc882352ab0275556b6fc889b38b14203d936071b5fa12f39a5c86d47
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=docs/COPYING
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
+
+PKG_INSTALL:=1
 
 restund-mods:= mysql
 
@@ -44,22 +46,16 @@ restund-mod-mysql:= USE_MYSQL
 RESTUND_MOD_OPTIONS:= \
 	$(foreach m,$(restund-mods),$(restund-mod-$(m))=$(if $(CONFIG_PACKAGE_restund-mod-$(m)),1))
 
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		LIBRE_MK="$(STAGING_DIR)/usr/share/re/re.mk" \
-		LIBRE_INC="$(STAGING_DIR)/usr/include/re" \
-		LIBRE_SO="$(STAGING_DIR)/usr/lib" \
-		CC="$(TARGET_CC)" \
-		EXTRA_CFLAGS="$(TARGET_CFLAGS)" \
-		DESTDIR="$(PKG_INSTALL_DIR)" \
-		SYSROOT="$$$$($(FIND) $(TOOLCHAIN_DIR) -path '*/include/pthread.h' | sed -ne '1s#/include/pthread.h##p')" \
-		SYSROOT_ALT="$(STAGING_DIR)/usr" \
-		RELEASE=1 \
-		CROSS_COMPILE="$(TARGET_CROSS)" \
-		OS="linux" \
-		$(RESTUND_MOD_OPTIONS) \
-		all install
-endef
+MAKE_FLAGS+= \
+	EXTRA_LFLAGS="$(TARGET_LDFLAGS)" \
+	LIBRE_MK="$(STAGING_DIR)/usr/share/re/re.mk" \
+	LIBRE_INC="$(STAGING_DIR)/usr/include/re" \
+	LIBRE_SO="$(STAGING_DIR)/usr/lib" \
+	SYSROOT="$(shell $(FIND) $(TOOLCHAIN_DIR) -path '*/include/pthread.h' | sed -ne '1s|/include/pthread.h||p')" \
+	SYSROOT_ALT="$(STAGING_DIR)/usr" \
+	RELEASE=1 \
+	OS="linux" \
+	$(RESTUND_MOD_OPTIONS)
 
 define Package/restund/install
 	$(INSTALL_DIR) $(1)/usr/sbin

--- a/net/restund/patches/001-fix-linker-call.patch
+++ b/net/restund/patches/001-fix-linker-call.patch
@@ -1,0 +1,14 @@
+--- a/Makefile
++++ b/Makefile
+@@ -99,9 +99,9 @@ all: $(MOD_BINS) $(BIN)
+ $(BIN): $(OBJS)
+ 	@echo "  LD      $@"
+ ifneq ($(GPROF),)
+-	@$(LD) $(LFLAGS) $(APP_LFLAGS) $^ ../re/libre.a $(LIBS) -o $@
++	@$(LD) $(LFLAGS) $(SH_LFLAGS) $(APP_LFLAGS) $^ ../re/libre.a $(LIBS) -o $@
+ else
+-	@$(LD) $(LFLAGS) $(APP_LFLAGS) $^ -L$(LIBRE_SO) -lre $(LIBS) -o $@
++	@$(LD) $(LFLAGS) $(SH_LFLAGS) $(APP_LFLAGS) $^ -L$(LIBRE_SO) -lre $(LIBS) -o $@
+ endif
+ 
+ $(BUILD)/%.o: %.c $(BUILD) Makefile $(APP_MK)


### PR DESCRIPTION
Hello Jiri @jslachta 

These commits change the Build/Compile routine to the default one for all four packages. This has the benefit of using the standard features like FORTIFY_SOURCE and RELRO. Also cleanups where done, modules added and the build failure of baresip that is currently happening is also fixed.

Best regards,
Seb