### PR TITLE
asterisk-15.x: add 053-musl-mutex-init.patch

### DIFF
--- a/net/asterisk-15.x/Makefile
+++ b/net/asterisk-15.x/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk15
 PKG_VERSION:=15.1.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk-15.x/patches/053-musl-mutex-init.patch
+++ b/net/asterisk-15.x/patches/053-musl-mutex-init.patch
@@ -1,0 +1,11 @@
+--- a/include/asterisk/lock.h
++++ b/include/asterisk/lock.h
+@@ -66,7 +66,7 @@
+ #define AST_PTHREADT_NULL (pthread_t) -1
+ #define AST_PTHREADT_STOP (pthread_t) -2
+ 
+-#if (defined(SOLARIS) || defined(BSD))
++#if (defined(SOLARIS) || defined(BSD) || !defined(HAVE_PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP))
+ #define AST_MUTEX_INIT_W_CONSTRUCTORS
+ #endif /* SOLARIS || BSD */
+ 


### PR DESCRIPTION
@kochstefan pointed out that asterisk 15 doesn't load any modules. It
turned out that this happens because of patch that was dropped. Add the
patch again.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>