### PR TITLE
Asterisk: Prevent building of all default modules

### DIFF
--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -24,6 +24,23 @@ PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING LICENSE
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
+MENUSELECT_CATEGORIES:= \
+	MENUSELECT_ADDONS \
+	MENUSELECT_APPS \
+	MENUSELECT_BRIDGES \
+	MENUSELECT_CDR \
+	MENUSELECT_CEL \
+	MENUSELECT_CHANNELS \
+	MENUSELECT_CODECS \
+	MENUSELECT_FORMATS \
+	MENUSELECT_FUNCS \
+	MENUSELECT_PBX \
+	MENUSELECT_RES \
+	MENUSELECT_UTILS \
+	MENUSELECT_AGIS
+
+AST_ENABLE:=
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 
@@ -61,6 +78,9 @@ define BuildAsterisk13Module
   $$(call Package/asterisk13/Default)
     TITLE:=$(2) support
     DEPENDS:= asterisk13 $(patsubst +%,+PACKAGE_asterisk13-$(1):%,$(4))
+    ifneq ($$(CONFIG_PACKAGE_asterisk13-$(1)),)
+    AST_ENABLE+=$(6)
+    endif
   endef
 
   define Package/asterisk13-$(1)/conffiles
@@ -305,6 +325,18 @@ define Build/Compile
 	LDFLAGS="$(HOST_LDFLAGS) -Wl,-rpath,$(STAGING_DIR_HOSTPKG)/lib" \
 	$(MAKE) -C "$(PKG_BUILD_DIR)/menuselect"
 	$(MAKE) -C "$(PKG_BUILD_DIR)" menuselect-tree
+	for cat in $(MENUSELECT_CATEGORIES); do \
+		cd "$(PKG_BUILD_DIR)" && \
+		./menuselect/menuselect \
+		--disable-category $$$$cat \
+		menuselect.makeopts; \
+	done
+	for item in $(AST_EMB_MODULES) $$(AST_ENABLE); do \
+		cd "$(PKG_BUILD_DIR)" && \
+		./menuselect/menuselect \
+		--enable $$$$item \
+		menuselect.makeopts; \
+	done
 	cd "$(PKG_BUILD_DIR)" && \
 		./menuselect/menuselect \
 			--disable BUILD_NATIVE \

--- a/net/asterisk-15.x/Makefile
+++ b/net/asterisk-15.x/Makefile
@@ -22,6 +22,23 @@ PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING LICENSE
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
+MENUSELECT_CATEGORIES:= \
+	MENUSELECT_ADDONS \
+	MENUSELECT_APPS \
+	MENUSELECT_BRIDGES \
+	MENUSELECT_CDR \
+	MENUSELECT_CEL \
+	MENUSELECT_CHANNELS \
+	MENUSELECT_CODECS \
+	MENUSELECT_FORMATS \
+	MENUSELECT_FUNCS \
+	MENUSELECT_PBX \
+	MENUSELECT_RES \
+	MENUSELECT_UTILS \
+	MENUSELECT_AGIS
+
+AST_ENABLE:=
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 
@@ -59,6 +76,9 @@ define BuildAsterisk15Module
   $$(call Package/asterisk15/Default)
     TITLE:=$(2) support
     DEPENDS:= asterisk15 $(patsubst +%,+PACKAGE_asterisk15-$(1):%,$(4))
+    ifneq ($$(CONFIG_PACKAGE_asterisk15-$(1)),)
+    AST_ENABLE+=$(6)
+    endif
   endef
 
   define Package/asterisk15-$(1)/conffiles
@@ -305,6 +325,18 @@ define Build/Compile
 	LDFLAGS="$(HOST_LDFLAGS) -Wl,-rpath,$(STAGING_DIR_HOSTPKG)/lib" \
 	$(MAKE) -C "$(PKG_BUILD_DIR)/menuselect"
 	$(MAKE) -C "$(PKG_BUILD_DIR)" menuselect-tree
+	for cat in $(MENUSELECT_CATEGORIES); do \
+		cd "$(PKG_BUILD_DIR)" && \
+		./menuselect/menuselect \
+		--disable-category $$$$cat \
+		menuselect.makeopts; \
+	done
+	for item in $(AST_EMB_MODULES) $$(AST_ENABLE); do \
+		cd "$(PKG_BUILD_DIR)" && \
+		./menuselect/menuselect \
+		--enable $$$$item \
+		menuselect.makeopts; \
+	done
 	cd "$(PKG_BUILD_DIR)" && \
 		./menuselect/menuselect \
 			--disable BUILD_NATIVE \


### PR DESCRIPTION
Hi Jiri.

I think this is a cool feature. First it disables all modules that get enabled by default, then it enables the modules required for the selected packages. Benefits are that stuff we don't need for the packages isn't built (so the build takes less time) and that there are modules that might be added in the future that are not enabled by default and this mechanism automatically takes care of enabling them.

This doesn't touch the compiler settings or sound files. Just the items that are actually compiled.

Kind regards,
Seb