### PR TITLE
baresip: add missing dependency

### DIFF
--- a/net/baresip/Makefile
+++ b/net/baresip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=baresip
 PKG_VERSION:=0.5.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.creytiv.com/pub
@@ -150,7 +150,7 @@ $(eval $(call BuildPackage,baresip))
 $(eval $(call BuildPlugin,alsa,ALSA audio driver,alsa,+alsa-lib))
 $(eval $(call BuildPlugin,aubridge,Audio bridge module,aubridge,))
 $(eval $(call BuildPlugin,aufile,Audio module for using a WAV-file as audio input,aufile,))
-$(eval $(call BuildPlugin,avcodec,Video codec using FFmpeg,avcodec,+libffmpeg-full))
+$(eval $(call BuildPlugin,avcodec,Video codec using FFmpeg,avcodec,+libffmpeg-full +libx264))
 $(eval $(call BuildPlugin,avformat,Video source using FFmpeg,avformat,+libffmpeg-full))
 $(eval $(call BuildPlugin,cons,UDP/TCP console UI driver,cons,))
 $(eval $(call BuildPlugin,debug_cmd,Debug commands,debug_cmd,))


### PR DESCRIPTION
The avcodec module needs a depend on libx264.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>