### PR TITLE
chan-lantiq: revert (non-working) hack, add Asterisk 15 variant

### DIFF
--- a/net/asterisk-chan-lantiq/Makefile
+++ b/net/asterisk-chan-lantiq/Makefile
@@ -20,38 +20,6 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSI
 
 include $(INCLUDE_DIR)/package.mk
 
-LTQ_DIR:=$(TOPDIR)/package/kernel/lantiq
-
-VMMC_PATH:=$(LTQ_DIR)/ltq-vmmc
-TAPI_PATH:=$(LTQ_DIR)/ltq-tapi
-IFXOS_PATH:=$(LTQ_DIR)/ltq-ifxos
-
-LTQ_MIRROR:=https://mirror2.openwrt.org/sources
-
-IFXOS_HASH:=$(shell cat $(IFXOS_PATH)/Makefile | sed -n '/^PKG_HASH:=/s///p')
-IFXOS_VERSION:=$(shell cat $(IFXOS_PATH)/Makefile | sed -n '/^PKG_VERSION:=/s///p')
-IFXOS:=lib_ifxos-$(IFXOS_VERSION)
-IFXOS_ARCHIVE:=$(IFXOS).tar.gz
-
-TAPI_HASH:=$(shell cat $(TAPI_PATH)/Makefile | sed -n '/^PKG_HASH:=/s///p')
-TAPI_VERSION:=$(shell cat $(TAPI_PATH)/Makefile | sed -n '/^PKG_VERSION:=/s///p')
-TAPI:=drv_tapi-$(TAPI_VERSION)
-TAPI_ARCHIVE:=$(TAPI).tar.bz2
-
-VMMC_HASH:=$(shell cat $(VMMC_PATH)/Makefile | sed -n '/^PKG_HASH:=/s///p')
-VMMC_VERSION:=$(shell cat $(VMMC_PATH)/Makefile | sed -n '/^PKG_VERSION:=/s///p')
-VMMC:=drv_vmmc-$(VMMC_VERSION)
-VMMC_ARCHIVE:=$(VMMC).tar.bz2
-
-define Download/files
-define Download/$(1)
-  FILE:=$(2)
-  HASH:=$(3)
-  URL:=$(4)
-endef
-$$(eval $$(call Download,$(1)))
-endef
-
 define Download/github
 define Download/$(PKG_NAME)
   VERSION:=$(1)
@@ -69,7 +37,7 @@ define Package/$(PKG_NAME)/Default
   CATEGORY:=Network
   TITLE:=Lantiq channel driver
   URL:=https://github.com/kochstefan/asterisk_channel_lantiq
-  DEPENDS:=@mips
+  DEPENDS:=kmod-ltq-vmmc
 endef
 
 define Package/asterisk13-$(PKG_NAME)
@@ -103,23 +71,6 @@ endef
 
 Package/asterisk13-$(PKG_NAME)/install = $(Package/Install/Default)
 
-define Package/postinst/Default
-#!/bin/sh
-if [ -z "$${IPKG_INSTROOT}" ]; then
-  echo
-  echo "o-------------------------------------------------------------------o"
-  echo "| chan-lantiq note                                                  |"
-  echo "o-------------------------------------------------------------------o"
-  echo "| Install kmod-ltq-vmmc if you want to use this Asterisk module.    |"
-  echo "| Unfortunately the dependency could not be added to the package.   |"
-  echo "o-------------------------------------------------------------=^_^=-o"
-  echo
-fi
-exit 0
-endef
-
-Package/asterisk13-$(PKG_NAME)/postinst = $(Package/postinst/Default)
-
 ifeq ($(BUILD_VARIANT),asterisk13)
 CHAN_LANTIQ_AST_INCLUDES:=-I$(STAGING_DIR)/usr/include/asterisk-13/include
 CHAN_LANTIQ_VERSION:=$(LANTIQ_AST13_VERSION)
@@ -130,26 +81,6 @@ define Build/Prepare
 	$(TAR) --extract --no-same-owner --no-same-permissions --xz \
 		--file=$(DL_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)-$(CHAN_LANTIQ_VERSION).tar.xz \
 		--directory=$(PKG_BUILD_DIR)
-	$(eval $(call Download/files,ltq-ifxos,$(IFXOS_ARCHIVE),$(IFXOS_HASH),$(LTQ_MIRROR)))
-	$(eval $(call Download/files,ltq-tapi,$(TAPI_ARCHIVE),$(TAPI_HASH),$(LTQ_MIRROR)))
-	$(eval $(call Download/files,ltq-vmmc,$(VMMC_ARCHIVE),$(VMMC_HASH),$(LTQ_MIRROR)))
-	$(TAR) --extract --no-same-owner --no-same-permissions --gzip \
-		--file=$(DL_DIR)/$(IFXOS_ARCHIVE) \
-		--directory=$(PKG_BUILD_DIR)
-	$(TAR) --extract --no-same-owner --no-same-permissions --bzip \
-		--file=$(DL_DIR)/$(TAPI_ARCHIVE) \
-		--directory=$(PKG_BUILD_DIR)
-	$(TAR) --extract --no-same-owner --no-same-permissions --bzip \
-		--file=$(DL_DIR)/$(VMMC_ARCHIVE) \
-		--directory=$(PKG_BUILD_DIR)
-	$(call PatchDir,$(PKG_BUILD_DIR)/$(IFXOS),$(IFXOS_PATH)/patches)
-	$(call PatchDir,$(PKG_BUILD_DIR)/$(TAPI),$(TAPI_PATH)/patches)
-	$(call PatchDir,$(PKG_BUILD_DIR)/$(VMMC),$(VMMC_PATH)/patches)
-	$(INSTALL_DIR) $(PKG_BUILD_DIR)/include
-	$(CP) $(PKG_BUILD_DIR)/$(IFXOS)/src/include $(PKG_BUILD_DIR)/include/ifxos
-	$(CP) $(PKG_BUILD_DIR)/$(TAPI)/include $(PKG_BUILD_DIR)/include/drv_tapi
-	$(CP) $(PKG_BUILD_DIR)/$(VMMC)/include $(PKG_BUILD_DIR)/include/drv_vmmc
-	cd $(PKG_BUILD_DIR)/include/drv_tapi && $(LN) ../ifxos/ifx_types.h .
 	$(CP) ./files/default.exports \
 		$(PKG_BUILD_DIR)/$(PKG_NAME)/src/channels/chan_lantiq.exports
 endef
@@ -157,8 +88,6 @@ endef
 define Build/Configure
 endef
 
-# Mark our includes as a system directory, because that's where they would
-# normally be. Not doing so results in redefinition warnings.
 define Build/Compile
 	cd $(PKG_BUILD_DIR)/$(PKG_NAME)/src/channels && \
 	$(TARGET_CC) -o chan_lantiq.o -c chan_lantiq.c -MD -MT chan_lantiq.o \
@@ -166,7 +95,6 @@ define Build/Compile
 		$(TARGET_CFLAGS) \
 		$(CHAN_LANTIQ_AST_INCLUDES) \
 		$(TARGET_CPPFLAGS) \
-		-isystem $(PKG_BUILD_DIR)/include \
 		-Wall -Wstrict-prototypes -Wmissing-prototypes \
 		-Wmissing-declarations $(FPIC) -DAST_MODULE=\"chan_lantiq\" && \
 	$(TARGET_CC) -o chan_lantiq.so -pthread $(TARGET_LDFLAGS) -shared \

--- a/net/asterisk-chan-lantiq/Makefile
+++ b/net/asterisk-chan-lantiq/Makefile
@@ -8,10 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chan-lantiq
-PKG_VERSION:=20171111
-PKG_RELEASE:=2
+PKG_VERSION:=20171128
+PKG_RELEASE:=1
 
 LANTIQ_AST13_VERSION:=5adf3d7774a75c88835f2f3daf824e2cda2c6e67
+LANTIQ_AST15_VERSION:=2eb991b66d135e6f22da30a2827918aed2d7b328
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
@@ -46,17 +47,25 @@ $(call Package/$(PKG_NAME)/Default)
   VARIANT:=asterisk13
 endef
 
+define Package/asterisk15-$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS+=asterisk15
+  VARIANT:=asterisk15
+endef
+
 define Package/description/Default
 An implementation of a Lantiq TAPI channel driver for Asterisk.
 endef
 
 Package/asterisk13-$(PKG_NAME)/description = $(Package/description/Default)
+Package/asterisk15-$(PKG_NAME)/description = $(Package/description/Default)
 
 define Package/conffiles/Default
 /etc/asterisk/lantiq.conf
 endef
 
 Package/asterisk13-$(PKG_NAME)/conffiles = $(Package/conffiles/Default)
+Package/asterisk15-$(PKG_NAME)/conffiles = $(Package/conffiles/Default)
 
 define Package/Install/Default
 	$(INSTALL_DIR) $(1)/etc/asterisk
@@ -70,10 +79,16 @@ define Package/Install/Default
 endef
 
 Package/asterisk13-$(PKG_NAME)/install = $(Package/Install/Default)
+Package/asterisk15-$(PKG_NAME)/install = $(Package/Install/Default)
 
 ifeq ($(BUILD_VARIANT),asterisk13)
 CHAN_LANTIQ_AST_INCLUDES:=-I$(STAGING_DIR)/usr/include/asterisk-13/include
 CHAN_LANTIQ_VERSION:=$(LANTIQ_AST13_VERSION)
+endif
+
+ifeq ($(BUILD_VARIANT),asterisk15)
+CHAN_LANTIQ_AST_INCLUDES:=-I$(STAGING_DIR)/usr/include/asterisk-15/include
+CHAN_LANTIQ_VERSION:=$(LANTIQ_AST15_VERSION)
 endif
 
 define Build/Prepare
@@ -92,7 +107,7 @@ define Build/Compile
 	cd $(PKG_BUILD_DIR)/$(PKG_NAME)/src/channels && \
 	$(TARGET_CC) -o chan_lantiq.o -c chan_lantiq.c -MD -MT chan_lantiq.o \
 		-MF .chan_lantiq.o.d -MP -pthread \
-		$(TARGET_CFLAGS) \
+		$(TARGET_CFLAGS) -DAST_MODULE_SELF_SYM=__internal_chan_lantiq_self \
 		$(CHAN_LANTIQ_AST_INCLUDES) \
 		$(TARGET_CPPFLAGS) \
 		-Wall -Wstrict-prototypes -Wmissing-prototypes \
@@ -103,3 +118,4 @@ define Build/Compile
 endef
 
 $(eval $(call BuildPackage,asterisk13-$(PKG_NAME)))
+$(eval $(call BuildPackage,asterisk15-$(PKG_NAME)))


### PR DESCRIPTION
Hi all,

Unfortunately the hack didn't work out. So this commit reverts it.

On another, more positive note, there's now also a variant for Asterisk 15.

Best regards,
Sebastian