### PR TITLE
restund: remove build timestamp

### DIFF
--- a/net/restund/Makefile
+++ b/net/restund/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=restund
 PKG_VERSION:=0.4.12
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.creytiv.com/pub

--- a/net/restund/patches/100-reproducible-builds.patch
+++ b/net/restund/patches/100-reproducible-builds.patch
@@ -1,0 +1,12 @@
+--- a/modules/status/status.c
++++ b/modules/status/status.c
+@@ -30,9 +30,6 @@ static void server_info(struct mbuf *mb)
+ 	mbuf_write_str(mb, "<table>\n");
+ 	mbuf_write_str(mb,
+ 		       " <tr><td>Version:</td><td>" VERSION "</td></tr>\n");
+-	mbuf_write_str(mb,
+-		       " <tr><td>Built:</td><td>" __DATE__ " " __TIME__
+-		       "</td></tr>\n");
+ 	mbuf_printf(mb, " <tr><td>Uptime:</td><td>%H</td></tr>\n",
+ 		    fmt_human_time, &uptime);
+ 	mbuf_write_str(mb, "</table>\n");


### PR DESCRIPTION
Build timestamps prevent reproducible builds [0].

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>