### PR TITLE
sipp: remove build timestamp

### DIFF
--- a/net/sipp/Makefile
+++ b/net/sipp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sipp
 PKG_VERSION:=3.5.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/SIPp/sipp/releases/download/v$(PKG_VERSION)

--- a/net/sipp/patches/110-reproducible-builds.patch
+++ b/net/sipp/patches/110-reproducible-builds.patch
@@ -1,0 +1,11 @@
+--- a/src/sipp.cpp
++++ b/src/sipp.cpp
+@@ -1396,7 +1396,7 @@ int main(int argc, char *argv[])
+ #ifdef RTP_STREAM
+                        "-RTPSTREAM"
+ #endif
+-                       " built " __DATE__ ", " __TIME__);
++                       );
+ 
+                 printf
+                 (" This program is free software; you can redistribute it and/or\n"


### PR DESCRIPTION
Build timestamps prevent reproducible builds [0].

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>