### PR TITLE
baresip/re: build fix and a workaround

### DIFF
--- a/libs/re/patches/005-fix-builds-for-mipsel-targets.patch
+++ b/libs/re/patches/005-fix-builds-for-mipsel-targets.patch
@@ -1,0 +1,14 @@
+--- a/mk/re.mk
++++ b/mk/re.mk
+@@ -448,11 +448,6 @@ endif
+ 
+ CFLAGS	+= -DARCH=\"$(ARCH)\"
+ 
+-ifeq ($(ARCH),mipsel)
+-CFLAGS += -march=mips32
+-endif
+-
+-
+ ##############################################################################
+ #
+ # External libraries section

--- a/net/baresip/Config.in
+++ b/net/baresip/Config.in
@@ -1,0 +1,16 @@
+menu "bareSIP configuration"
+	depends on PACKAGE_baresip
+
+config BARESIP_WITH_FFMPEG
+	bool "Compile with FFmpeg support"
+	default y if (i386||x86_64)
+	help
+	  The sole purpose of this symbol is to prevent that the bareSIP
+	  video modules, the ones which depend on FFmpeg, are built by
+	  default. The reason is that FFmpeg often fails to compile for
+	  some targets, causing the bareSIP compile to fail as well.
+
+	  If you want the modules which depend on FFmpeg to become
+	  available, select 'y'.
+
+endmenu

--- a/net/baresip/Makefile
+++ b/net/baresip/Makefile
@@ -50,6 +50,10 @@ PKG_CONFIG_DEPENDS:= \
 
 include $(INCLUDE_DIR)/package.mk
 
+define Package/$(PKG_NAME)/config
+	source "$(SOURCE)/Config.in"
+endef
+
 define Package/baresip/Default
   SECTION:=net
   CATEGORY:=Network
@@ -151,8 +155,8 @@ $(eval $(call BuildPackage,baresip))
 $(eval $(call BuildPlugin,alsa,ALSA audio driver,alsa,+alsa-lib))
 $(eval $(call BuildPlugin,aubridge,Audio bridge module,aubridge,))
 $(eval $(call BuildPlugin,aufile,Audio module for using a WAV-file as audio input,aufile,))
-$(eval $(call BuildPlugin,avcodec,Video codec using FFmpeg,avcodec,+libffmpeg-full +libx264))
-$(eval $(call BuildPlugin,avformat,Video source using FFmpeg,avformat,+libffmpeg-full))
+$(eval $(call BuildPlugin,avcodec,Video codec using FFmpeg,avcodec,@BARESIP_WITH_FFMPEG +libffmpeg-full +libx264))
+$(eval $(call BuildPlugin,avformat,Video source using FFmpeg,avformat,@BARESIP_WITH_FFMPEG +libffmpeg-full))
 $(eval $(call BuildPlugin,cons,UDP/TCP console UI driver,cons,))
 $(eval $(call BuildPlugin,debug_cmd,Debug commands,debug_cmd,))
 $(eval $(call BuildPlugin,dtls_srtp,DTLS-SRTP end-to-end encryption,dtls_srtp,))


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: mipsel, i386
Run tested: -
Description: fixes re build failures on mipsel targets and prevents baresip build failures on arm, mips etc.

Kind regards,
Seb
