### PR TITLE
New PR: add gsmlib, libctb and mod_gsmopen

### DIFF
--- a/libs/gsmlib/Makefile
+++ b/libs/gsmlib/Makefile
@@ -1,0 +1,88 @@
+#
+# Copyright (C) 2018 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gsmlib
+PKG_VERSION:=1.10-20140304
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/vbouchaud/gsmlib.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=cd5442de07cfe052316ede58640ef81b20627276
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_FIXUP:=autoreconf
+
+PKG_INSTALL:=1
+
+PKG_LICENSE:=LGPL-2.1+
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)/Default
+  SUBMENU:=Telephony
+  URL:=https://github.com/vbouchaud/gsmlib
+endef
+
+define Package/$(PKG_NAME)
+$(call Package/$(PKG_NAME)/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=GSM mobile phone access lib
+  DEPENDS:=+libstdcpp
+endef
+
+define Package/gsm-utils
+$(call Package/$(PKG_NAME)/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=GSM mobile phone access apps
+  DEPENDS:=+$(PKG_NAME)
+endef
+
+define Package/$(PKG_NAME)/description
+A library to access GSM mobile phones via GSM modems.
+endef
+
+define Package/gsm-utils/description
+Some simple command line programs to access GSM mobile phones via GSM modems.
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/$(PKG_NAME)
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)/usr/include/$(PKG_NAME)/*.h \
+		$(1)/usr/include/$(PKG_NAME)
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgsmme.so* $(1)/usr/lib
+endef
+
+define Build/Prepare
+$(call Build/Prepare/Default)
+	$(INSTALL_DATA) \
+		$(STAGING_DIR_HOSTPKG)/share/gettext/po/Makefile.in.in \
+		$(PKG_BUILD_DIR)/po
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libgsmme.so* $(1)/usr/lib
+endef
+
+define Package/gsm-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/* $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,gsm-utils))

--- a/libs/gsmlib/patches/01-update-autotools.patch
+++ b/libs/gsmlib/patches/01-update-autotools.patch
@@ -1,0 +1,40 @@
+Description: Update autotools-related stuff.
+
+--- a/configure.in
++++ b/configure.in
+@@ -15,6 +15,7 @@ AC_INIT(gsmlib/gsm_error.h)
+ 
+ dnl Other
+ AC_CONFIG_AUX_DIR(scripts)
++AC_CONFIG_MACRO_DIR([m4])
+ AC_PROG_INSTALL
+ 
+ dnl check for libintl
+@@ -34,6 +35,8 @@ if test "$CXXFLAGS" = ""; then
+    CXXFLAGS="-O2"
+ fi
+ 
++AC_USE_SYSTEM_EXTENSIONS
++
+ dnl comment out this line to get extensive debugging output and asserts
+ dnl CXXFLAGS="-DNDEBUG $CXXFLAGS"
+ 
+--- /dev/null
++++ b/po/Makevars
+@@ -0,0 +1,5 @@
++DOMAIN = $(PACKAGE)
++
++subdir = po
++top_builddir = ..
++
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -11,6 +11,8 @@
+ # * Created: 21.5.1999
+ # *************************************************************************
+ 
++ACLOCAL_AMFLAGS = -I m4
++
+ SUBDIRS_ =	po gsmlib apps tests doc scripts win32 ext
+ 
+ EXTRA_DIST =	gsmlib.spec

--- a/libs/gsmlib/patches/02-fix-cross-compile.patch
+++ b/libs/gsmlib/patches/02-fix-cross-compile.patch
@@ -1,0 +1,21 @@
+--- a/configure.in
++++ b/configure.in
+@@ -60,7 +60,7 @@ AC_PROG_CPP
+ AC_PROG_CXX
+ 
+ dnl check for gcc 2.95.x
+-AC_TRY_RUN([
++AC_RUN_IFELSE([
+ #include <unistd.h>
+ main()
+ {
+@@ -72,7 +72,8 @@ main()
+ }
+ ],,
+ [echo "need at least gcc 2.95 to compile correctly"
+-exit 1])
++exit 1],
++[echo "checking if at least gcc 2.95 is available... cross-compiling (assuming yes)"])
+ 
+ dnl check for alloca
+ AC_FUNC_ALLOCA

--- a/libs/gsmlib/patches/03-disable-Siemens-specific-code.patch
+++ b/libs/gsmlib/patches/03-disable-Siemens-specific-code.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -13,7 +13,7 @@
+ 
+ ACLOCAL_AMFLAGS = -I m4
+ 
+-SUBDIRS_ =	po gsmlib apps tests doc scripts win32 ext
++SUBDIRS_ =	po gsmlib apps tests doc scripts win32
+ 
+ EXTRA_DIST =	gsmlib.spec
+ 

--- a/libs/libctb/Makefile
+++ b/libs/libctb/Makefile
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2018 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libctb
+PKG_VERSION:=0.16
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://iftools.com/download/ctb/$(PKG_VERSION)
+PKG_HASH:=1cb0026a66cfbf8e26988f76cb861f1fbfd04f272f9b9adaf0d463d01282fc08
+
+MAKE_PATH:=build
+
+PKG_INSTALL:=1
+
+PKG_LICENSE:=LGPL
+PKG_LICENSE_FILES:=build/COPYING
+PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  SUBMENU:=Telephony
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Communications toolbox - ctb
+  URL:=https://iftools.com/opensource/ctb.en.php
+  DEPENDS:=+libstdcpp
+endef
+
+define Package/$(PKG_NAME)/description
+Multiplatform library for different interfaces.
+endef
+
+MAKE_FLAGS += \
+	DEBUG=0 \
+	GPIB=0 \
+	prefix=/usr
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/ctb-$(PKG_VERSION)/linux
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)/usr/include/ctb-$(PKG_VERSION)/*.h \
+		$(PKG_BUILD_DIR)/include/ctb-$(PKG_VERSION)/kbhit.h \
+		$(1)/usr/include/ctb-$(PKG_VERSION)
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)/usr/include/ctb-$(PKG_VERSION)/linux/*.h \
+		$(1)/usr/include/ctb-$(PKG_VERSION)/linux
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/lib/$(PKG_NAME)-$(PKG_VERSION).so \
+		$(1)/usr/lib
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) \
+		$(PKG_INSTALL_DIR)/usr/lib/$(PKG_NAME)-$(PKG_VERSION).so \
+		$(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 OpenWrt.org
+# Copyright (C) 2017 - 2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PRG_NAME:=freeswitch
 PKG_NAME:=$(PRG_NAME)-stable
 PKG_VERSION:=1.6.19
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=$(PRG_NAME)-$(PKG_VERSION).tar.xz
@@ -272,6 +272,14 @@ FS_STABLE_PERL_LIBS:=$(shell grep "^libs=" \
 
 FS_STABLE_PYTHON_SITE_DIR:=$(FS_STABLE_LIB_DIR)/python$(PYTHON_VERSION)/site-packages
 
+# musl and glibc include their own iconv, but uclibc does not
+ifneq ($(CONFIG_USE_UCLIBC),)
+TARGET_CPPFLAGS+= \
+	-I$(STAGING_DIR)/usr/lib/libiconv-full/include
+TARGET_LDFLAGS += \
+	-L$(STAGING_DIR)/usr/lib/libiconv-full/lib
+endif
+
 define Download/files
 define Download/$(1)
   FILE:=$(2)
@@ -332,6 +340,7 @@ $(call Package/$(PKG_NAME)/Default)
 	  +FS_STABLE_WITH_ODBC:unixodbc \
 	  +FS_STABLE_WITH_PGSQL:libpq \
 	  +FS_STABLE_WITH_PNG:libpng \
+	  +USE_UCLIBC:libiconv-full \
 	  +libcurl \
 	  +libedit \
 	  +libopenssl \

--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -154,6 +154,7 @@ FS_STABLE_MOD_AVAILABLE:= \
 	g723_1 \
 	g729 \
 	graylog2 \
+	gsmopen \
 	h26x \
 	hash \
 	hiredis \
@@ -915,6 +916,13 @@ ifeq ($(CONFIG_PACKAGE_$(PKG_NAME)-mod-pocketsphinx),)
 endif
 endif
 
+# Hack for mod_gsmopen - it has a build-time dep on mod_spandsp
+ifneq ($(CONFIG_PACKAGE_$(PKG_NAME)-mod-gsmopen),)
+ifeq ($(CONFIG_PACKAGE_$(PKG_NAME)-mod-spandsp),)
+	$(SED) '/mod_spandsp$$$$/s/^#//' $(PKG_BUILD_DIR)/modules.conf
+endif
+endif
+
 # Hack for mod_unimrcp - it has a build-time dep on mod_sofia
 ifneq ($(CONFIG_PACKAGE_$(PKG_NAME)-mod-unimrcp),)
 ifeq ($(CONFIG_PACKAGE_$(PKG_NAME)-mod-sofia),)
@@ -1070,6 +1078,7 @@ $(eval $(call Package/$(PKG_NAME)/Module,fsv,FSV,This module provides dialplan a
 $(eval $(call Package/$(PKG_NAME)/Module,g723_1,G.723.1 passthrough,G.723.1 codec passthrough.,))
 $(eval $(call Package/$(PKG_NAME)/Module,g729,G.729 passthrough,G.729 codec passthrough.,))
 $(eval $(call Package/$(PKG_NAME)/Module,graylog2,Graylog2 logger,GELF logger for Graylog2 and Logstash.,))
+$(eval $(call Package/$(PKG_NAME)/Module,gsmopen,GSM endpoint,GSMopen is a channel driver that allows an SMS to be sent to and from\nFreeSWITCH as well as incoming and outgoing GSM voice calls.,+gsmlib +libctb +libjpeg +liblzma))
 $(eval $(call Package/$(PKG_NAME)/Module,h26x,H.26x passthrough,H.26x video codec passthrough.,))
 $(eval $(call Package/$(PKG_NAME)/Module,hash,Hash,This module provides a key-value in-memory datastore. Usable as a\nlimit backend.,))
 $(eval $(call Package/$(PKG_NAME)/Module,hiredis,Redis client,This module provides a mechanism to use Redis as a datastore.,+libhiredis))

--- a/net/freeswitch-stable/patches/270-fix-uclibc-iconv-in-gsmopen.patch
+++ b/net/freeswitch-stable/patches/270-fix-uclibc-iconv-in-gsmopen.patch
@@ -1,0 +1,62 @@
+--- a/src/mod/endpoints/mod_gsmopen/gsmopen_protocol.cpp
++++ b/src/mod/endpoints/mod_gsmopen/gsmopen_protocol.cpp
+@@ -2521,11 +2521,11 @@ int ucs2_to_utf8(private_t *tech_pvt, ch
+ 	DEBUGA_GSMOPEN("1 ciao in=%s, inleft=%d, out=%s, outleft=%d, converted=%s, utf8_out=%s\n",
+ 				   GSMOPEN_P_LOG, inbuf, (int) inbytesleft, outbuf, (int) outbytesleft, converted, utf8_out);
+ 
+-#ifdef WIN32
++#ifdef __UCLIBC__ // libiconv-full needs this conversion
+ 	iconv_res = iconv(iconv_format, (const char **) &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-#else // WIN32
++#else
+ 	iconv_res = iconv(iconv_format, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-#endif // WIN32
++#endif
+ 	if (iconv_res == (size_t) -1) {
+ 		DEBUGA_GSMOPEN("2 ciao in=%s, inleft=%d, out=%s, outleft=%d, converted=%s, utf8_out=%s\n",
+ 					   GSMOPEN_P_LOG, inbuf, (int) inbytesleft, outbuf, (int) outbytesleft, converted, utf8_out);
+@@ -2560,11 +2560,11 @@ int utf8_to_iso_8859_1(private_t *tech_p
+ 
+ 	DEBUGA_GSMOPEN("in=%s, inleft=%d, out=%s, outleft=%d, utf8_in=%s, iso_8859_1_out=%s\n",
+ 				   GSMOPEN_P_LOG, inbuf, (int) inbytesleft, outbuf, (int) outbytesleft, utf8_in, iso_8859_1_out);
+-#ifdef WIN32
++#ifdef __UCLIBC__
+ 	iconv_res = iconv(iconv_format, (const char **) &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-#else // WIN32
++#else
+ 	iconv_res = iconv(iconv_format, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-#endif // WIN32
++#endif
+ 	if (iconv_res == (size_t) -1) {
+ 		DEBUGA_GSMOPEN("cannot translate in iso_8859_1 error: %s (errno: %d)\n", GSMOPEN_P_LOG, strerror(errno), errno);
+ 		return -1;
+@@ -2597,11 +2597,11 @@ int iso_8859_1_to_utf8(private_t *tech_p
+ 	}
+ 
+ 	inbytesleft = strlen(iso_8859_1_in) * 2;
+-#ifdef WIN32
++#ifdef __UCLIBC__
+ 	iconv_res = iconv(iconv_format, (const char **) &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-#else // WIN32
++#else
+ 	iconv_res = iconv(iconv_format, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-#endif // WIN32
++#endif
+ 	if (iconv_res == (size_t) -1) {
+ 		DEBUGA_GSMOPEN("ciao in=%s, inleft=%d, out=%s, outleft=%d, utf8_out=%s\n",
+ 					   GSMOPEN_P_LOG, inbuf, (int) inbytesleft, outbuf, (int) outbytesleft, utf8_out);
+@@ -2642,11 +2642,11 @@ int utf8_to_ucs2(private_t *tech_pvt, ch
+ 
+ 	DEBUGA_GSMOPEN("in=%s, inleft=%d, out=%s, outleft=%d, utf8_in=%s, converted=%s\n",
+ 				   GSMOPEN_P_LOG, inbuf, (int) inbytesleft, outbuf, (int) outbytesleft, utf8_in, converted);
+-#ifdef WIN32
++#ifdef __UCLIBC__
+ 	iconv_res = iconv(iconv_format, (const char **) &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-#else // WIN32
++#else
+ 	iconv_res = iconv(iconv_format, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-#endif // WIN32
++#endif
+ 	if (iconv_res == (size_t) -1) {
+ 		ERRORA("error: %s %d\n", GSMOPEN_P_LOG, strerror(errno), errno);
+ 		return -1;


### PR DESCRIPTION
Maintainer: me
Compile tested: arc, mips_24kc and x86_64
Run tested: don't have the hardware

Description:

Hi all,

I'd like to add gsmlib and libctb. Both are needed for mod_gsmopen in FreeSWITCH. The packages aren't available for OpenWrt yet.

mod_gsmopen is for FreeSWITCH what chan-dongle is for Asterisk. Having the option to use your PBX as a GSM gateway is nice, e.g. for making test calls etc. (or just making normal phones calls via GSM and sending/receiving SMS).

gsmlib: A library to access GSM mobile phones via GSM modems
libctb: Communications toolbox - ctb

Both libs are admittedly a bit dated already. But they are hard dependencies of mod_gsmopen.

Please let me know if you have any concerns or doubts. Otherwise I'd like to merge these commits the coming weekend.

Best regards.
Seb