### PR TITLE
freeswitch-stable: Add FreeTDM support

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -241,6 +241,8 @@ FS_STABLE_MOD_AVAILABLE:= \
 	yaml \
 	yuv
 
+LIBFTDM:=libfreetdm
+
 PKG_CONFIG_DEPENDS:= \
 	$(patsubst %,CONFIG_PACKAGE_$(PKG_NAME)-%,$(FS_STABLE_MISC_AVAILABLE)) \
 	$(patsubst %,CONFIG_PACKAGE_$(PKG_NAME)-mod-%,$(FS_STABLE_MOD_AVAILABLE)) \
@@ -257,6 +259,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_FS_STABLE_WITH_VPX \
 	CONFIG_FS_STABLE_WITH_ZRTP \
 	CONFIG_LIBC \
+	CONFIG_PACKAGE_$(LIBFTDM) \
 	CONFIG_SOFT_FLOAT
 
 include $(INCLUDE_DIR)/package.mk
@@ -309,6 +312,24 @@ define Package/$(PKG_NAME)/install/mod
 	$(INSTALL_DIR) $(1)$(FS_STABLE_MOD_DIR)
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(FS_STABLE_MOD_DIR)/mod_$(2).so \
 						$(1)$(FS_STABLE_MOD_DIR)
+endef
+
+define Package/$(LIBFTDM)
+  CATEGORY:=Libraries
+  DEPENDS:=$(PKG_NAME)
+  SECTION:=libs
+  SUBMENU:=Telephony
+  TITLE:=TDM signaling and media API
+  URL:=https://www.$(PRG_NAME).org
+endef
+
+define Package/$(LIBFTDM)/description
+Provides a unified interface to hardware TDM cards and ss7 stacks for
+FreeSWITCH.
+endef
+
+define Package/$(LIBFTDM)/install
+$(call Package/$(PKG_NAME)/install/lib,$(1),$(LIBFTDM))
 endef
 
 define Package/$(PKG_NAME)/config
@@ -922,6 +943,12 @@ endef
 
 define Build/Compile
 	$(call Build/Compile/Default)
+# FreeTDM is only compiled/installed automatically if mod_freetdm is selected
+ifneq ($(CONFIG_PACKAGE_$(LIBFTDM)),)
+ifeq ($(CONFIG_PACKAGE_$(PKG_NAME)-mod-freetdm),)
+	$(call Build/Compile/Default,-C $(PKG_BUILD_DIR)/libs/freetdm)
+endif
+endif
 ifneq ($(CONFIG_PACKAGE_$(PKG_NAME)-misc-perl-esl),)
 	$(call Build/Compile/Default,-C $(PKG_BUILD_DIR)/libs/esl perlmod)
 endif
@@ -932,6 +959,11 @@ endef
 
 define Build/Install
 	$(call Build/Install/Default)
+ifneq ($(CONFIG_PACKAGE_$(LIBFTDM)),)
+ifeq ($(CONFIG_PACKAGE_$(PKG_NAME)-mod-freetdm),)
+	$(call Build/Install/Default,-C $(PKG_BUILD_DIR)/libs/freetdm install)
+endif
+endif
 ifneq ($(CONFIG_PACKAGE_$(PKG_NAME)-misc-perl-esl),)
 	$(call Build/Compile/Default,-C $(PKG_BUILD_DIR)/libs/esl DESTDIR=$(PKG_INSTALL_DIR) perlmod-install)
 endif
@@ -948,8 +980,15 @@ define Build/InstallDev
 	$(INSTALL_DATA) \
 		$(PKG_INSTALL_DIR)$(FS_STABLE_PKGCONFIG_DIR)/$(PRG_NAME).pc \
 						$(1)$(FS_STABLE_PKGCONFIG_DIR)
+ifneq ($(CONFIG_PACKAGE_$(LIBFTDM)),)
+	$(INSTALL_DATA) \
+		$(PKG_INSTALL_DIR)$(FS_STABLE_PKGCONFIG_DIR)/freetdm.pc \
+						$(1)$(FS_STABLE_PKGCONFIG_DIR)
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include
+endif
 endef
 
+$(eval $(call BuildPackage,$(LIBFTDM)))
 $(eval $(call BuildPackage,$(PKG_NAME)))
 $(eval $(call BuildPackage,$(PKG_NAME)-misc-hotplug))
 $(eval $(call BuildPackage,$(PKG_NAME)-misc-perl-esl))

--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -72,6 +72,14 @@ FS_STABLE_SYSCONF_DIR:=/etc
 FS_STABLE_TLS_DIR:=$(FS_STABLE_SYSCONF_DIR)/$(PRG_NAME)/tls
 FS_STABLE_TZ_DIR:=$(FS_STABLE_DATA_DIR)/tz
 
+FS_STABLE_FTMOD_AVAILABLE:= \
+	analog \
+	analog_em \
+	libpri \
+	pritap \
+	skel \
+	zt
+
 # Maintain a list of all non-module packages so they can be added to
 # PKG_CONFIG_DEPENDS.
 FS_STABLE_MISC_AVAILABLE:= \
@@ -149,6 +157,7 @@ FS_STABLE_MOD_AVAILABLE:= \
 	expr \
 	fifo \
 	format_cdr \
+	freetdm \
 	fsk \
 	fsv \
 	g723_1 \
@@ -245,6 +254,7 @@ LIBFTDM:=libfreetdm
 
 PKG_CONFIG_DEPENDS:= \
 	$(patsubst %,CONFIG_PACKAGE_$(PKG_NAME)-%,$(FS_STABLE_MISC_AVAILABLE)) \
+	$(patsubst %,CONFIG_PACKAGE_$(PKG_NAME)-ftmod-%,$(FS_STABLE_FTMOD_AVAILABLE)) \
 	$(patsubst %,CONFIG_PACKAGE_$(PKG_NAME)-mod-%,$(FS_STABLE_MOD_AVAILABLE)) \
 	CONFIG_FS_STABLE_WITH_DEBUG \
 	CONFIG_FS_STABLE_WITH_FREETYPE \
@@ -300,6 +310,12 @@ define Package/$(PKG_NAME)/install/dir
 	do \
 		$(INSTALL_DATA) $(2)/$$$$$$$$file $(1)/$$$$$$$$file; \
 	done
+endef
+
+define Package/$(PKG_NAME)/install/ftmod
+	$(INSTALL_DIR) $(1)$(FS_STABLE_MOD_DIR)
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)$(FS_STABLE_MOD_DIR)/ftmod_$(2).so \
+						$(1)$(FS_STABLE_MOD_DIR)
 endef
 
 define Package/$(PKG_NAME)/install/lib
@@ -539,6 +555,24 @@ endef
 $$(eval $$(call BuildPackage,$(PKG_NAME)-example-$(1)))
 endef
 
+define Package/$(PKG_NAME)/FTModule
+define Package/$(PKG_NAME)-ftmod-$(1)
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS := \
+	  $(PKG_NAME) \
+	  $(patsubst +%,+PACKAGE_$(PKG_NAME)-ftmod-$(1):%,$(4)) \
+	  +PACKAGE_$(PKG_NAME)-ftmod-$(1):$(LIBFTDM)
+  TITLE:=$(2) FreeTDM module
+endef
+define Package/$(PKG_NAME)-ftmod-$(1)/description
+$(subst \n,$(newline),$(3))
+endef
+define Package/$(PKG_NAME)-ftmod-$(1)/install
+$(call Package/$(PKG_NAME)/install/ftmod,$$(1),$(1))
+endef
+$$(eval $$(call BuildPackage,$(PKG_NAME)-ftmod-$(1)))
+endef
+
 define Package/$(PKG_NAME)/Language
 define Package/$(PKG_NAME)-lang-$(1)
 $(call Package/$(PKG_NAME)/Default)
@@ -650,7 +684,9 @@ CONFIGURE_ARGS+= \
 	$(if $(CONFIG_FS_STABLE_WITH_ODBC),--with-odbc-lib="$(STAGING_DIR)$(FS_STABLE_LIB_DIR)") \
 	$(if $(CONFIG_FS_STABLE_WITH_ODBC),--with-odbc="$(STAGING_DIR)/usr") \
 	$(if $(CONFIG_FS_STABLE_WITH_PGSQL),,--without-pgsql) \
-	$(if $(CONFIG_FS_STABLE_WITH_PNG),,--without-png)
+	$(if $(CONFIG_FS_STABLE_WITH_PNG),,--without-png) \
+	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-ftmod-libpri),--with-libpri="$(STAGING_DIR)/usr",--without-libpri) \
+	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-ftmod-pritap),--with-pritap,--without-pritap)
 
 ifneq ($(CONFIG_PACKAGE_$(PKG_NAME)-misc-python-esl)$(CONFIG_PACKAGE_$(PKG_NAME)-mod-python),)
 CONFIGURE_ARGS+= \
@@ -1011,6 +1047,22 @@ $(eval $(call Package/$(PKG_NAME)/Example,testing))
 $(eval $(call Package/$(PKG_NAME)/Example,vanilla))
 
 ################################
+# FreeTDM modules
+# Params:
+# 1 - Package subname
+# 2 - Package title
+# 3 - Module description
+# 4 - Module dependencies
+################################
+
+$(eval $(call Package/$(PKG_NAME)/FTModule,analog,Analog,Offers generic FXO/FXS support for any type of card supported by FreeTDM.,))
+$(eval $(call Package/$(PKG_NAME)/FTModule,analog_em,Analog EM,Offers generic E&M signaling for any type of card supported by FreeTDM.,))
+$(eval $(call Package/$(PKG_NAME)/FTModule,libpri,LibPRI,Offers support for PRI lines using the open source libpri stack for any\ntype of card supported by FreeTDM. Supports both PRI and BRI signalling.,+libpri @!aarch64))
+$(eval $(call Package/$(PKG_NAME)/FTModule,pritap,PRI tapping,This module is used to tap PRI lines.,+$(PKG_NAME)-ftmod-libpri))
+$(eval $(call Package/$(PKG_NAME)/FTModule,skel,Skeleton,ftmod_skel is an example module.,))
+$(eval $(call Package/$(PKG_NAME)/FTModule,zt,DAHDI I/O,This module supports the DAHDI interface. The DAHDI interface is used by\nseveral hardware vendors.,))
+
+################################
 # FreeSWITCH language files
 # Params:
 # 1 - Language code
@@ -1095,6 +1147,7 @@ $(eval $(call Package/$(PKG_NAME)/Module,event_zmq,ZMQ event,ZMQ event module.,)
 $(eval $(call Package/$(PKG_NAME)/Module,expr,Expr,This module adds expr support for expression evaluation.,))
 $(eval $(call Package/$(PKG_NAME)/Module,fifo,FIFO,This module adds a first-in first-out queue system.,))
 $(eval $(call Package/$(PKG_NAME)/Module,format_cdr,Multiformat CDR,A superset of mod_json_cdr and mod_xml_cdr.,))
+$(eval $(call Package/$(PKG_NAME)/Module,freetdm,FreeTDM endpoint,This module is the glue between FreeSWITCH and FreeTDM.,+$(LIBFTDM)))
 $(eval $(call Package/$(PKG_NAME)/Module,fsk,FSK,This module adds frequency-shift keying support which can be used to\nsend and receive caller ID.,))
 $(eval $(call Package/$(PKG_NAME)/Module,fsv,FSV,This module provides dialplan applications for recording and playing\nvideos.,))
 $(eval $(call Package/$(PKG_NAME)/Module,g723_1,G.723.1 passthrough,G.723.1 codec passthrough.,))

--- a/net/freeswitch-stable/patches/280-tone-down-freetdm-COMP_VENDOR_CFLAGS.patch
+++ b/net/freeswitch-stable/patches/280-tone-down-freetdm-COMP_VENDOR_CFLAGS.patch
@@ -1,0 +1,11 @@
+--- a/libs/freetdm/configure.ac
++++ b/libs/freetdm/configure.ac
+@@ -88,7 +88,7 @@ AC_ARG_ENABLE([enable_64],
+ 
+ case "${ax_cv_c_compiler_vendor}" in
+ gnu)
+-	COMP_VENDOR_CFLAGS="-ffast-math -Wall -Werror -Wunused-variable -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -O0"
++	COMP_VENDOR_CFLAGS="-ffast-math -Wall -Wunused-variable -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes"
+ 	;;
+ sun)
+ 	COMP_VENDOR_CFLAGS="-xc99=all -mt -xCC -xvpara"

--- a/net/freeswitch-stable/patches/290-fix-mod_freetdm-copts.patch
+++ b/net/freeswitch-stable/patches/290-fix-mod_freetdm-copts.patch
@@ -1,0 +1,8 @@
+--- a/libs/freetdm/mod_freetdm/Makefile.in
++++ b/libs/freetdm/mod_freetdm/Makefile.in
+@@ -1,4 +1,4 @@
+-FT_CFLAGS=@CFLAGS@ @COMP_VENDOR_CFLAGS@ @DEFS@
++FT_CFLAGS=@COMP_VENDOR_CFLAGS@ @DEFS@
+ 
+ BASE=../../..
+ FT_DIR=..


### PR DESCRIPTION
Maintainer: me
Compile tested: arc, mips_24kc, x86_64
Run tested: none (don't have the TDM hardware)

Description:
This pull request adds FreeTDM support to the FreeSWITCH packages. OpenWrt has already proper DAHDI support and FreeTDM is the bridge to that for FreeSWITCH.