### PR TITLE
libosip2: add fix for CVE-2017-7853

### DIFF
--- a/libs/libosip2/Makefile
+++ b/libs/libosip2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libosip2
 PKG_VERSION:=5.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/osip

--- a/libs/libosip2/patches/01-CVE-2017-7853.patch
+++ b/libs/libosip2/patches/01-CVE-2017-7853.patch
@@ -1,0 +1,31 @@
+From 1ae06daf3b2375c34af23083394a6f010be24a45 Mon Sep 17 00:00:00 2001
+From: Aymeric Moizard <amoizard@gmail.com>
+Date: Tue, 21 Feb 2017 17:16:26 +0100
+Subject:  * fix bug report: sr #109265: SIP message body length underflow in
+ libosip2-4.1.0    https://savannah.gnu.org/support/?109265    also applicable
+ to current latest version
+
+---
+ src/osipparser2/osip_message_parse.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/osipparser2/osip_message_parse.c b/src/osipparser2/osip_message_parse.c
+index 1628c60..aa35446 100644
+--- a/src/osipparser2/osip_message_parse.c
++++ b/src/osipparser2/osip_message_parse.c
+@@ -784,6 +784,12 @@ msg_osip_body_parse (osip_message_t * sip, const char *start_of_buf, const char
+     if ('\n' == start_of_body[0] || '\r' == start_of_body[0])
+       start_of_body++;
+ 
++    /* if message body is empty or contains a single CR/LF */
++    if (end_of_body <= start_of_body) {
++      osip_free (sep_boundary);
++      return OSIP_SYNTAXERROR;
++    }
++
+     body_len = end_of_body - start_of_body;
+ 
+     /* Skip CR before end boundary. */
+-- 
+cgit v1.0-41-gc330
+


### PR DESCRIPTION
Maintainer: @jslachta (actually package doesn't have a maintainer line currently)
Compile tested: mips_24kc
Run tested: -

Description: fix security bug.
