### PR TITLE
freeswitch: adjust python mk files

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -277,7 +277,7 @@ include $(INCLUDE_DIR)/package.mk
 
 FS_STABLE_PERL_FEED:=$(TOPDIR)/feeds/packages/lang/perl
 
-$(call include_mk, python-host.mk)
+include $(TOPDIR)/feeds/packages/lang/python/python-host.mk
 include $(FS_STABLE_PERL_FEED)/perlmod.mk
 
 FS_STABLE_PERL_LIBS:=$(shell grep "^libs=" \

--- a/net/freeswitch/Makefile
+++ b/net/freeswitch/Makefile
@@ -245,7 +245,7 @@ PKG_CONFIG_DEPENDS:= \
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 ifneq ($(CONFIG_FS_WITH_PYTHON),)
-$(call include_mk, python3-package.mk)
+include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
 endif
 
 


### PR DESCRIPTION
Maintainer: @micmac1, @2Habibie
Compile tested: N/A
Run tested: N/A

-------------------

Since commit:
  https://github.com/openwrt/packages/commit/ccdc6bc530444283a510ceb6a50878493fe356f2
the python package.mk files have moved.

The intent is to also get rid of the include_mk
construct, because that one relies for python
to be built, before having access to those mk files.

There might be another change to the approach
of using python package mk files, but until
then, they need to be included directly.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>