### PR TITLE
freeswitch-stable: change how python-host.mk is included

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -277,7 +277,7 @@ include $(INCLUDE_DIR)/package.mk
 
 FS_STABLE_PERL_FEED:=$(TOPDIR)/feeds/packages/lang/perl
 
-$(call include_mk, python-host.mk)
+include $(TOPDIR)/feeds/packages/lang/python/python-host.mk
 include $(FS_STABLE_PERL_FEED)/perlmod.mk
 
 FS_STABLE_PERL_LIBS:=$(shell grep "^libs=" \


### PR DESCRIPTION
This was suggested in PR #241 by @commodo. Python maintainers moved the
.mk files and also want to get rid of the include_mk construct.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: mips_24kc
Run tested: N/A

Description: see commit
