### PR TITLE
dahdi-tools: Fix dahdi dependency on lede-17.01

### DIFF
--- a/libs/dahdi-tools/Makefile
+++ b/libs/dahdi-tools/Makefile
@@ -44,6 +44,7 @@ define Package/dahdi-tools-libtonezone
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=DAHDI tonezone library
+  DEPENDS+=+libpthread
 endef
 
 TARGET_CFLAGS += $(FPIC)


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: arc700
Run tested: (don't have the hardware)

Description:
Hi Jiri,

This is one of the reasons asterisk fails to build on ARC (uclibc) in lede-17.01. For the other two reasons I sent PRs to the package maintainers (alsa + sqlite3).

Kind regards,
Sebastian