### PR TITLE
bcg729: Remove BUILD_PATENTED.

### DIFF
--- a/libs/bcg729/Makefile
+++ b/libs/bcg729/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcg729
 PKG_VERSION:=1.0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.linphone.org/releases/sources/bcg729
@@ -31,7 +31,6 @@ define Package/bcg729
   CATEGORY:=Libraries
   TITLE:=Software G729A encoder and decoder library written in C
   URL:=http://www.linphone.org/technical-corner/bcg729.html
-  DEPENDS:=@BUILD_PATENTED
 endef
 
 define Package/bcg729/description


### PR DESCRIPTION
As of 2017, all patents have expired. Full announcement text below:

As of January 1, 2017 the patent terms of most Licensed Patents under the G.729 Consortium have expired.

With regard to the unexpired Licensed Copyrights and Licensed Patents of the G.729 Consortium Patent License Agreement, the Licensors of the G.729 Consortium, namely Orange SA, Nippon Telegraph and Telephone Corporation and Université de Sherbrooke (“Licensors”) have agreed to license the same under the existing terms on a royalty-free basis starting January 1, 2017.

For current Licensees of the G.729 Consortium Patent License Agreement, no reports and no payments will be due for Licensed Products Sold or otherwise distributed as of January 1, 2017.

Signed-off-by: Rosen Penev <rosenp@gmail.com>