### PR TITLE
freeswitch-stable: use system libtiff

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PRG_NAME:=freeswitch
 PKG_NAME:=$(PRG_NAME)-stable
 PKG_VERSION:=1.6.20
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=$(PRG_NAME)-$(PKG_VERSION).tar.xz
@@ -940,6 +940,8 @@ FS_STABLE_APR_LIBS:=-L$(PKG_BUILD_DIR)/libs/apr -L$(PKG_BUILD_DIR)/libs/apr-util
 define Build/Prepare
 	$(call Build/Prepare/Default)
 
+	$(RM) -r $(PKG_BUILD_DIR)/libs/tiff-*
+
 	echo '#applications/mod_random' >> $(PKG_BUILD_DIR)/modules.conf
 	echo '#codecs/mod_yuv' >> $(PKG_BUILD_DIR)/modules.conf
 	echo '#event_handlers/mod_event_test' >> $(PKG_BUILD_DIR)/modules.conf
@@ -1167,7 +1169,7 @@ $(eval $(call Package/$(PKG_NAME)/Module,fsv,FSV,This module provides dialplan a
 $(eval $(call Package/$(PKG_NAME)/Module,g723_1,G.723.1 passthrough,G.723.1 codec passthrough.,))
 $(eval $(call Package/$(PKG_NAME)/Module,g729,G.729 passthrough,G.729 codec passthrough.,))
 $(eval $(call Package/$(PKG_NAME)/Module,graylog2,Graylog2 logger,GELF logger for Graylog2 and Logstash.,))
-$(eval $(call Package/$(PKG_NAME)/Module,gsmopen,GSM endpoint,GSMopen is a channel driver that allows an SMS to be sent to and from\nFreeSWITCH as well as incoming and outgoing GSM voice calls.,+gsmlib +libctb +libjpeg +liblzma))
+$(eval $(call Package/$(PKG_NAME)/Module,gsmopen,GSM endpoint,GSMopen is a channel driver that allows an SMS to be sent to and from\nFreeSWITCH as well as incoming and outgoing GSM voice calls.,+gsmlib +libctb +libjpeg +liblzma +libtiff))
 $(eval $(call Package/$(PKG_NAME)/Module,h26x,H.26x passthrough,H.26x video codec passthrough.,))
 $(eval $(call Package/$(PKG_NAME)/Module,hash,Hash,This module provides a key-value in-memory datastore. Usable as a\nlimit backend.,))
 $(eval $(call Package/$(PKG_NAME)/Module,hiredis,Redis client,This module provides a mechanism to use Redis as a datastore.,+libhiredis))
@@ -1231,7 +1233,7 @@ $(eval $(call Package/$(PKG_NAME)/Module,snmp,SNMP,An SNMP stats reporter.,+libn
 $(eval $(call Package/$(PKG_NAME)/Module,snom,SNOM,This module implements features specific to SNOM phones.,))
 $(eval $(call Package/$(PKG_NAME)/Module,sofia,Sofia SIP,SIP module.,))
 $(eval $(call Package/$(PKG_NAME)/Module,sonar,Sonar,This module measures the latency on an audio link by sending audible\naudio sonar pings.,))
-$(eval $(call Package/$(PKG_NAME)/Module,spandsp,SpanDSP,This module implements SpanDSP fax. It includes DSP and codec\nfunctionality.,+libjpeg +liblzma))
+$(eval $(call Package/$(PKG_NAME)/Module,spandsp,SpanDSP,This module implements SpanDSP fax. It includes DSP and codec\nfunctionality.,+libjpeg +liblzma +libtiff))
 $(eval $(call Package/$(PKG_NAME)/Module,spy,User Spy,This module adds the ability to monitor the audio of a channel.,))
 $(eval $(call Package/$(PKG_NAME)/Module,ssml,SSML,mod_ssml is a FreeSWITCH module that renders SSML into audio. This\nmodule requires a text-to-speech module for speech synthesis.,))
 $(eval $(call Package/$(PKG_NAME)/Module,stress,Stress,This module attempts to detect voice stress on an audio channel.,))

--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -675,6 +675,7 @@ endef
 CONFIGURE_ARGS+= \
 	--srcdir=$(PKG_BUILD_DIR) \
 	--disable-dependency-tracking \
+	--disable-silent-rules \
 	--disable-static \
 	--disable-system-xmlrpc-c \
 	--enable-core-libedit-support \

--- a/net/freeswitch-stable/patches/120-fix-copts.diff
+++ b/net/freeswitch-stable/patches/120-fix-copts.diff
@@ -136,22 +136,3 @@
  
  #Set default language
  AC_LANG_C
---- a/libs/tiff-4.0.2/configure.ac
-+++ b/libs/tiff-4.0.2/configure.ac
-@@ -30,11 +30,13 @@ AC_CONFIG_AUX_DIR(config)
- AC_CONFIG_MACRO_DIR(m4)
- AC_LANG(C)
- AC_PROG_LIBTOOL
-+m4_include(../apr/build/apr_common.m4)
- m4_include(m4/acinclude.m4)
- 
--CFLAGS="$CFLAGS $CONFIGURE_CFLAGS"
--CXXFLAGS="$CXXFLAGS $CONFIGURE_CXXFLAGS"
--LDFLAGS="$LDFLAGS $CONFIGURE_LDFLAGS"
-+APR_ADDTO(CFLAGS, [$CONFIGURE_CFLAGS])
-+APR_ADDTO(CPPFLAGS, [$CONFIGURE_CPPFLAGS])
-+APR_ADDTO(CXXFLAGS, [$CONFIGURE_CXXFLAGS])
-+APR_ADDTO(LDFLAGS, [$CONFIGURE_LDFLAGS])
- 
- dnl Compute the canonical host (run-time) system type variable
- AC_CANONICAL_HOST

--- a/net/freeswitch-stable/patches/310-use-system-tiff.patch
+++ b/net/freeswitch-stable/patches/310-use-system-tiff.patch
@@ -1,0 +1,87 @@
+commit 34c48368dcfef09ba4a694256aa9615d91252461
+Author: Mike Jerris <mike@jerris.com>
+Date:   Tue Mar 14 17:39:05 2017 -0500
+
+    FS-10074: [libtiff] stop using embedded libtiff.  Build now requires system libtiff
+
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -125,7 +125,6 @@ CORE_CFLAGS += -DSWITCH_HAVE_YUV
+ endif
+ CORE_CFLAGS += -I$(switch_srcdir)/libs/srtp/crypto/include -Ilibs/srtp/crypto/include
+ CORE_CFLAGS += -I$(switch_builddir)/libs/spandsp/src -I$(switch_srcdir)/libs/spandsp/src 
+-CORE_CFLAGS += -I$(switch_builddir)/libs/tiff-4.0.2/libtiff -I$(switch_srcdir)/libs/tiff-4.0.2/libtiff
+ if ENABLE_LIBVPX
+ CORE_CFLAGS += -DSWITCH_HAVE_VPX
+ endif
+@@ -731,11 +730,6 @@ sndfile-reconf:
+ 	cd libs/libsndfile && ./config.status --recheck
+ 	cd libs/libsndfile && ./config.status
+ 
+-tiff-reconf:
+-	cd libs/tiff-4.0.2 && autoreconf -fi
+-	cd libs/tiff-4.0.2 && sh ./configure.gnu $(MY_DEFAULT_ARGS)
+-	cd libs/tiff-4.0.2 && make
+-
+ python-reconf:
+ 	rm -f src/mod/languages/mod_python/Makefile
+ 	./config.status
+@@ -757,7 +751,7 @@ iks-reconf:
+ 	cd libs/iksemel && sh ./configure.gnu $(MY_DEFAULT_ARGS)
+ 	$(MAKE) mod_dingaling-clean
+ 
+-spandsp-reconf: tiff-reconf
++spandsp-reconf:
+ 	cd libs/spandsp && $(MAKE) clean || echo
+ 	cd libs/spandsp && autoreconf -fi
+ 	cd libs/spandsp && sh ./configure.gnu $(MY_DEFAULT_ARGS)
+--- a/configure.ac
++++ b/configure.ac
+@@ -1984,7 +1984,6 @@ AC_CONFIG_SUBDIRS([libs/libdingaling])
+ AC_CONFIG_SUBDIRS([libs/sofia-sip])
+ AC_CONFIG_SUBDIRS([libs/freetdm])
+ AC_CONFIG_SUBDIRS([libs/unimrcp])
+-AC_CONFIG_SUBDIRS([libs/tiff-4.0.2])
+ AC_CONFIG_SUBDIRS([libs/spandsp])
+ if test "x${enable_zrtp}" = "xyes"; then
+    AC_CONFIG_SUBDIRS([libs/libzrtp])
+--- a/libs/spandsp/configure.gnu
++++ b/libs/spandsp/configure.gnu
+@@ -1,4 +1,4 @@
+ #! /bin/sh
+ srcpath=$(dirname $0 2>/dev/null )  || srcpath="." 
+-$srcpath/configure "$@" --disable-shared --with-pic --enable-builtin-tiff
++$srcpath/configure "$@" --disable-shared --with-pic
+ 
+--- a/src/mod/applications/mod_spandsp/Makefile.am
++++ b/src/mod/applications/mod_spandsp/Makefile.am
+@@ -1,24 +1,17 @@
+ include $(top_srcdir)/build/modmake.rulesam
+ MODNAME=mod_spandsp
+ 
+-TIFF_DIR=$(switch_srcdir)/libs/tiff-4.0.2
+-TIFF_BUILDDIR=$(switch_builddir)/libs/tiff-4.0.2
+-TIFF_LA=$(TIFF_BUILDDIR)/libtiff/libtiff.la
+ SPANDSP_DIR=$(switch_srcdir)/libs/spandsp
+ SPANDSP_BUILDDIR=$(switch_builddir)/libs/spandsp
+ SPANDSP_LA=$(SPANDSP_BUILDDIR)/src/libspandsp.la
+ 
+ mod_LTLIBRARIES = mod_spandsp.la
+ mod_spandsp_la_SOURCES  = mod_spandsp.c udptl.c mod_spandsp_fax.c mod_spandsp_dsp.c mod_spandsp_codecs.c mod_spandsp_modem.c
+-mod_spandsp_la_CFLAGS   = $(AM_CFLAGS)
+-mod_spandsp_la_CPPFLAGS = -I$(SPANDSP_DIR)/src -I$(TIFF_DIR)/libtiff -I$(TIFF_BUILDDIR)/libtiff -I$(SPANDSP_BUILDDIR)/src -I$(TIFF_BUILDDIR)/libtiff -I.
+-mod_spandsp_la_LIBADD   = $(switch_builddir)/libfreeswitch.la $(SPANDSP_LA) $(TIFF_LA) $(SPANDSP_LA_JBIG) $(SPANDSP_LA_LZMA) -ljpeg -lz
++mod_spandsp_la_CFLAGS   = $(AM_CFLAGS) 
++mod_spandsp_la_CPPFLAGS = -I$(SPANDSP_DIR)/src -I$(SPANDSP_BUILDDIR)/src -I.
++mod_spandsp_la_LIBADD   = $(switch_builddir)/libfreeswitch.la $(SPANDSP_LA) $(SPANDSP_LA_JBIG) $(SPANDSP_LA_LZMA) -ljpeg -lz -ltiff
+ mod_spandsp_la_LDFLAGS  = -avoid-version -module -no-undefined -shared
+ 
+-$(SPANDSP_LA): $(TIFF_LA) $(SPANDSP_DIR) $(SPANDSP_DIR)/.update
+-	cd $(SPANDSP_BUILDDIR) && $(MAKE) CPPFLAGS="$(CPPFLAGS) -I$(TIFF_BUILDDIR)/libtiff -I$(TIFF_DIR)/libtiff" CFLAGS="$(CFLAGS)"
+-	$(TOUCH_TARGET)
+-
+-$(TIFF_LA): $(TIFF_DIR) $(TIFF_DIR)/.update
+-	cd $(TIFF_BUILDDIR) && $(MAKE)
++$(SPANDSP_LA): $(SPANDSP_DIR) $(SPANDSP_DIR)/.update
++	cd $(SPANDSP_BUILDDIR) && $(MAKE) CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)"
+ 	$(TOUCH_TARGET)

--- a/net/freeswitch-stable/patches/311-use-system-tiff.patch
+++ b/net/freeswitch-stable/patches/311-use-system-tiff.patch
@@ -1,0 +1,34 @@
+commit f51ab63c2628e3ff21bd8a301dbacbc23766554a
+Author: Mike Jerris <mike@jerris.com>
+Date:   Wed Mar 15 09:57:03 2017 -0500
+
+    FS-10074: [libtiff] stop using embedded libtiff.  Build now requires system libtiff
+
+--- a/debian/bootstrap.sh
++++ b/debian/bootstrap.sh
+@@ -310,6 +310,7 @@ Build-Depends:
+  libpcre3-dev,
+  libedit-dev (>= 2.11),
+  libsqlite3-dev,
++ libtiff5-dev,
+  wget, pkg-config,
+  yasm,
+ # core codecs
+--- a/freeswitch.spec
++++ b/freeswitch.spec
+@@ -150,6 +150,7 @@ BuildRequires: openssl-devel >= 1.0.1e
+ BuildRequires: pcre-devel 
+ BuildRequires: speex-devel 
+ BuildRequires: sqlite-devel
++BuildRequires: libtiff-devel
+ BuildRequires: ldns-devel
+ BuildRequires: libedit-devel
+ BuildRequires: perl
+@@ -208,6 +209,7 @@ Requires: ncurses
+ Requires: pcre
+ Requires: speex
+ Requires: sqlite
++Requires: libtiff
+ Requires: libedit
+ Requires: openssl >= 1.0.1e
+ Requires: unixODBC

--- a/net/freeswitch-stable/patches/312-use-system-tiff.patch
+++ b/net/freeswitch-stable/patches/312-use-system-tiff.patch
@@ -1,0 +1,41 @@
+commit 920d10afe725566a33c1c570d99ad2dc99625712
+Author: Mike Jerris <mike@jerris.com>
+Date:   Wed Mar 15 15:00:15 2017 -0500
+
+    FS-10074: [libtiff] stop using embedded libtiff.  Build now requires system libtiff
+
+--- a/src/mod/endpoints/mod_skypopen/Makefile.am
++++ b/src/mod/endpoints/mod_skypopen/Makefile.am
+@@ -1,10 +1,6 @@
+ include $(top_srcdir)/build/modmake.rulesam
+ MODNAME=mod_skypopen
+ 
+-TIFF_DIR=$(switch_srcdir)/libs/tiff-4.0.2
+-TIFF_BUILDDIR=$(switch_builddir)/libs/tiff-4.0.2
+-TIFF_LA=$(TIFF_BUILDDIR)/libtiff/libtiff.la
+-
+ SPANDSP_DIR=$(switch_srcdir)/libs/spandsp
+ SPANDSP_BUILDDIR=$(switch_builddir)/libs/spandsp
+ SPANDSP_LA=$(SPANDSP_BUILDDIR)/src/libspandsp.la
+@@ -12,16 +8,12 @@ SPANDSP_LA=$(SPANDSP_BUILDDIR)/src/libsp
+ mod_LTLIBRARIES = mod_skypopen.la
+ mod_skypopen_la_SOURCES  = mod_skypopen.c skypopen_protocol.c
+ mod_skypopen_la_CFLAGS   = $(AM_CFLAGS)
+-mod_skypopen_la_CPPFLAGS = -I$(SPANDSP_DIR)/src -I$(TIFF_DIR)/libtiff -I$(SPANDSP_BUILDDIR)/src -I$(TIFF_BUILDDIR)/libtiff -I.
+-mod_skypopen_la_LIBADD   = $(switch_builddir)/libfreeswitch.la $(SPANDSP_LA) $(TIFF_LA)
++mod_skypopen_la_CPPFLAGS = -I$(SPANDSP_DIR)/src -I$(SPANDSP_BUILDDIR)/src -I.
++mod_skypopen_la_LIBADD   = $(switch_builddir)/libfreeswitch.la $(SPANDSP_LA)
+ mod_skypopen_la_LDFLAGS  = -avoid-version -module -no-undefined -shared -lX11
+ 
+-BUILT_SOURCES = $(TIFF_LA) $(SPANDSP_LA)
+-
+-$(SPANDSP_LA): $(TIFF_LA) $(SPANDSP_DIR) $(SPANDSP_DIR)/.update
+-	cd $(SPANDSP_BUILDDIR) && $(MAKE) CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS) -I$(TIFF_BUILDDIR)/libtiff -I$(TIFF_DIR)/libtiff"
+-	$(TOUCH_TARGET)
++BUILT_SOURCES = $(SPANDSP_LA)
+ 
+-$(TIFF_LA): $(TIFF_DIR) $(TIFF_DIR)/.update
+-	cd $(TIFF_BUILDDIR) && $(MAKE)
++$(SPANDSP_LA): $(SPANDSP_DIR) $(SPANDSP_DIR)/.update
++	cd $(SPANDSP_BUILDDIR) && $(MAKE) CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)"
+ 	$(TOUCH_TARGET)

--- a/net/freeswitch-stable/patches/313-use-system-tiff.patch
+++ b/net/freeswitch-stable/patches/313-use-system-tiff.patch
@@ -1,0 +1,41 @@
+commit 4a7c459e37d77b05f258001ccae99935fb660caf
+Author: Mike Jerris <mike@jerris.com>
+Date:   Wed Mar 15 15:02:04 2017 -0500
+
+    FS-10074: [libtiff] stop using embedded libtiff.  Build now requires system libtiff
+
+--- a/src/mod/endpoints/mod_gsmopen/Makefile.am
++++ b/src/mod/endpoints/mod_gsmopen/Makefile.am
+@@ -1,10 +1,6 @@
+ include $(top_srcdir)/build/modmake.rulesam
+ MODNAME=mod_gsmopen
+ 
+-TIFF_DIR=$(switch_srcdir)/libs/tiff-4.0.2
+-TIFF_BUILDDIR=$(switch_builddir)/libs/tiff-4.0.2
+-TIFF_LA=$(TIFF_BUILDDIR)/libtiff/libtiff.la
+-
+ SPANDSP_DIR=$(switch_srcdir)/libs/spandsp
+ SPANDSP_BUILDDIR=$(switch_builddir)/libs/spandsp
+ SPANDSP_LA=$(SPANDSP_BUILDDIR)/src/libspandsp.la
+@@ -12,16 +8,12 @@ SPANDSP_LA=$(SPANDSP_BUILDDIR)/src/libsp
+ mod_LTLIBRARIES = mod_gsmopen.la
+ mod_gsmopen_la_SOURCES  = mod_gsmopen.cpp gsmopen_protocol.cpp 
+ mod_gsmopen_la_CXXFLAGS = $(SWITCH_AM_CXXFLAGS)
+-mod_gsmopen_la_CPPFLAGS = -I$(SPANDSP_DIR)/src -I$(TIFF_DIR)/libtiff -I$(SPANDSP_BUILDDIR)/src -I$(TIFF_BUILDDIR)/libtiff -I.
+-mod_gsmopen_la_LIBADD   = $(switch_builddir)/libfreeswitch.la $(SPANDSP_LA) $(TIFF_LA)
++mod_gsmopen_la_CPPFLAGS = -I$(SPANDSP_DIR)/src -I$(SPANDSP_BUILDDIR)/src -I.
++mod_gsmopen_la_LIBADD   = $(switch_builddir)/libfreeswitch.la $(SPANDSP_LA)
+ mod_gsmopen_la_LDFLAGS  = -avoid-version -module -no-undefined -lctb-0.16 -lgsmme
+ 
+-BUILT_SOURCES = $(TIFF_LA) $(SPANDSP_LA)
+-
+-$(SPANDSP_LA): $(TIFF_LA) $(SPANDSP_DIR) $(SPANDSP_DIR)/.update
+-	cd $(SPANDSP_BUILDDIR) && $(MAKE) CPPFLAGS="$(CPPFLAGS) -I$(TIFF_BUILDDIR)/libtiff -I$(TIFF_DIR)/libtiff" CFLAGS="$(CFLAGS)"
+-	$(TOUCH_TARGET)
++BUILT_SOURCES = $(SPANDSP_LA)
+ 
+-$(TIFF_LA): $(TIFF_DIR) $(TIFF_DIR)/.update
+-	cd $(TIFF_BUILDDIR) && $(MAKE)
++$(SPANDSP_LA): $(SPANDSP_DIR) $(SPANDSP_DIR)/.update
++	cd $(SPANDSP_BUILDDIR) && $(MAKE) CPPFLAGS="$(CPPFLAGS)" CFLAGS="$(CFLAGS)"
+ 	$(TOUCH_TARGET)

--- a/net/freeswitch-stable/patches/314-use-system-tiff.patch
+++ b/net/freeswitch-stable/patches/314-use-system-tiff.patch
@@ -1,0 +1,92 @@
+commit 7a4c76119114b82d26dab5d5adfe5a2429e32434
+Author: Mike Jerris <mike@jerris.com>
+Date:   Thu Mar 16 11:29:08 2017 -0500
+
+    FS-10074: [libtiff] remove more libtiff references
+
+--- a/debian/copyright
++++ b/debian/copyright
+@@ -1700,27 +1700,6 @@ Copyright: 2007 <robs@users.sourceforge.
+  2007-2009 Erik de Castro Lopo <erikd@mega-nerd.com>
+ License: LGPL-2+
+ 
+-Files: libs/tiff-4.0.2/*
+-Copyright: 1988-1997 Sam Leffler
+- 1991-1997 Silicon Graphics, Inc.
+- 2006-2010 Richard Nolde
+- 1999-2000 Frank Warmerdam
+- 1990 by Digital Equipment Corporation, Maynard, Massachusetts.
+- 1990 by Sun Microsystems, Inc.
+- Joris Van Damme <info@awaresystems.be>
+- AWare Systems <http://www.awaresystems.be/>
+-License: MIT/X11 (BSD like)
+-
+-Files: libs/tiff-4.0.2/port/getopt.c
+- libs/tiff-4.0.2/port/strcasecmp.c
+- libs/tiff-4.0.2/port/lfind.c
+-Copyright: 1987, 1993, 1994, The Regents of the University of California.
+-License: BSD-3-clause
+-
+-Files: libs/tiff-4.0.2/port/strtoull.c
+-Copyright: 1992, 1993, The Regents of the University of California.
+-License: BSD-4-clause
+-
+ Files: src/switch_dso.c
+ Copyright: 2008 Michael Jerris
+ License: BSD-like
+--- a/debian/license-reconcile.yml
++++ b/debian/license-reconcile.yml
+@@ -186,21 +186,6 @@ Rules:
+    Copyright: 1999-2009 Erik de Castro Lopo <erikd@mega-nerd.com>
+    Justification: prevent false-psitive copyright detection
+   -
+-   Glob: libs/tiff-4.0.2/libtiff/tif_tile.c
+-   Matches: Copyright\s(c)\s1991-1997\sSam\sLeffler
+-   Matches: copyright\snotices\sand\sthis\spermission\snotice\sappear\sin
+-   Copyright: 1991-1997 Sam Leffler
+-  -
+-   Glob: libs/tiff-4.0.2/*
+-   Matches: Additions\s\(c\)\sRichard\sNolde\s2006-2010
+-   Matches: copyright\snotices\sand\sthis\spermission\snotice\sappear\sin
+-   Copyright: 2006-2010 Richard Nolde
+-  -
+-   Glob: libs/tiff-4.0.2/libtiff/tiffvers.h
+-   Matches: 1988-1996\sSam\sLeffler..Copyright\s\(c\)\s1991-1996\sSilicon\sGraphics,\sInc.
+-   Copyright: 1991-1996 Sam Leffler
+-   Copyright: 1991-1996 Silicon Graphics, Inc
+-  -
+    Glob: src/mod/endpoints/mod_khomp/*
+    Matches: The\scontents\sof\sthis\sfile\sare\ssubject\sto\sthe\sMozilla\sPublic\sLicense\sVersion\s1.1
+    Matches: Alternatively,\sthe\scontents\sof\sthis\sfile\smay\sbe\sused\sunder\sthe\sterms\sof\sthe
+--- a/docs/Doxygen.conf
++++ b/docs/Doxygen.conf
+@@ -1240,15 +1240,9 @@ SEARCH_INCLUDES        = YES
+ # contain include files that are not input files but should be processed by
+ # the preprocessor.
+ 
+-INCLUDE_PATH           =../libs/apr ../libs/apr-util \
+-			../libs/iksemel ../libs/ilbc ../libs/js \
+-			../libs/libg722_1 ../libs/libnatpmp \
+-			../libs/libsndfile ../libs/miniupnpc  \
+-			../libs/portaudio ../libs/sofia-sip ../libs/spandsp \
+-			../libs/srtp \
+-			../libs/tiff-4.0.2 ../libs/udns \
+-			../libs/unimrcp ../libs/voipcodecs ../libs/win32 \
+-			../libs/xmlrpc-c
++INCLUDE_PATH           =../libs/apr ../libs/apr-util ../libs/iksemel ../libs/libnatpmp \
++			../libs/miniupnpc ../libs/sofia-sip ../libs/spandsp \
++			../libs/srtp ../libs/unimrcp ../libs/win32 ../libs/xmlrpc-c
+ 
+ # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
+ # patterns (like *.h and *.hpp) to filter out the header-files in the
+--- a/rebootstrap.sh
++++ b/rebootstrap.sh
+@@ -8,7 +8,7 @@ BGJOB=false
+ VERBOSE=false
+ BASEDIR=`pwd`;
+ LIBDIR=${BASEDIR}/libs;
+-SUBDIRS="apr libzrtp iksemel libdingaling sofia-sip srtp freetdm spandsp unimrcp tiff-4.0.2 fs";
++SUBDIRS="apr libzrtp iksemel libdingaling sofia-sip srtp freetdm spandsp unimrcp fs";
+ 
+ while getopts 'jhd:v' o; do 
+   case "$o" in


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64
Run tested: N/A
Description: Use system libtiff instead of bundled copy
