### PR TITLE
libosip2: fix build with ARC toolchain

### DIFF
--- a/libs/libosip2/Makefile
+++ b/libs/libosip2/Makefile
@@ -37,7 +37,8 @@ define Package/libosip2/description
  GNU oSIP library, a Session Initiation Protocol (SIP) implementation.
 endef
 
-TARGET_CFLAGS += $(FPIC)
+# toolchain __arc__ define conflicts with libosip2 source
+TARGET_CFLAGS += $(FPIC) $(if $(CONFIG_arc),-U__arc__)
 
 CONFIGURE_ARGS += \
 	--enable-shared \


### PR DESCRIPTION
ARC toolchain exports __arc__, which clashes with a symbol of the same
name in libosip2. This commit undefines the toolchain symbol when
building the library.

The fix was found in buildroot repo. Thanks to whoever spotted this!

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: (put here arch, model, OpenWRT/LEDE version)
Run tested: (put here arch, model, OpenWRT/LEDE version, tests done)

Description:
Hi Jiri,

Just a build fix.

Kind regards,
Seb