### PR TITLE
PR: yate follow-up and a bit of kamailio

### DIFF
--- a/net/kamailio-5.x/Makefile
+++ b/net/kamailio-5.x/Makefile
@@ -57,7 +57,7 @@ define Package/kamailio5/install
 		$(PKG_INSTALL_DIR)/usr/sbin/kam{ailio,cmd,ctl,dbctl} \
 		$(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/usr/lib/kamailio/modules
-	$(INSTALL_BIN) \
+	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/kamailio/lib*.so* \
 		$(1)/usr/lib/kamailio/
 	$(INSTALL_DIR) $(1)/etc/kamailio

--- a/net/yate/Makefile
+++ b/net/yate/Makefile
@@ -83,9 +83,6 @@ define Package/$(PKG_NAME)-collection-basic
    TITLE := Basic Yate Server
 endef
 
-# Otherwise yate ignores CPPFLAGS
-TARGET_CFLAGS += $(TARGET_CPPFLAGS)
-
 CONFIGURE_ARGS+= \
 	$(if $(CONFIG_x86_64),--enable-sse2) \
 	--disable-sctp \


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: x86_64
Run tested: N/A

Description:

Hi Jiri,

There is a bit of fallout after the yate series. Basically I had tested the commits on arc_archs and there they worked. But apparently there the fortify-source headers are actually not available or just different (uClibc related maybe).

Anyway, on other targets there is build failures when compiling against fortify-headers. The yate commit addresses that.

And the 2nd commit is just something I found a bit later. Saves some space in the package.

;-)

Kind regards,
Seb