### PR TITLE
Rtpproxy bump

### DIFF
--- a/net/rtpproxy/Makefile
+++ b/net/rtpproxy/Makefile
@@ -45,6 +45,11 @@ $(call Package/rtpproxy/Default)
   MENU:=1
 endef
 
+define Package/rtpproxy/conffiles
+/etc/init.d/rtpproxy
+/etc/config/rtpproxy
+endef
+
 define Package/rtpproxy-mod-acct_csv
 $(call Package/rtpproxy/Default)
   DEPENDS:=rtpproxy
@@ -65,7 +70,7 @@ define Package/rtpproxy/install
 	$(INSTALL_BIN) ./files/rtpproxy.init $(1)/etc/init.d/rtpproxy
 
 	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_BIN) ./files/rtpproxy.config $(1)/etc/config/rtpproxy
+	$(INSTALL_CONF) ./files/rtpproxy.config $(1)/etc/config/rtpproxy
 endef
 
 define Package/rtpproxy-mod-acct_csv/install

--- a/net/rtpproxy/Makefile
+++ b/net/rtpproxy/Makefile
@@ -29,13 +29,24 @@ PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/rtpproxy
+define Package/rtpproxy/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Telephony
+  URL:=http://www.rtpproxy.org/
+endef
+
+define Package/rtpproxy
+$(call Package/rtpproxy/Default)
   DEPENDS:=+libpthread +librt
   TITLE:=RTP (Realtime Transport Protocol) proxy
-  URL:=http://www.rtpproxy.org/
+  MENU:=1
+endef
+
+define Package/rtpproxy-mod-acct_csv
+$(call Package/rtpproxy/Default)
+  DEPENDS:=rtpproxy
+  TITLE:=RTPproxy accounting module
 endef
 
 CONFIGURE_VARS += \
@@ -52,4 +63,11 @@ define Package/rtpproxy/install
 	$(INSTALL_BIN) ./files/rtpproxy.config $(1)/etc/config/rtpproxy
 endef
 
+define Package/rtpproxy-mod-acct_csv/install
+	$(INSTALL_DIR) $(1)/usr/lib/rtpproxy
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/rtpproxy/rtpp_acct_csv.so \
+							$(1)/usr/lib/rtpproxy
+endef
+
 $(eval $(call BuildPackage,rtpproxy))
+$(eval $(call BuildPackage,rtpproxy-mod-acct_csv))

--- a/net/rtpproxy/Makefile
+++ b/net/rtpproxy/Makefile
@@ -23,6 +23,8 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_CHECK_FORMAT_SECURITY:=0
 PKG_INSTALL:=1
 
+PKG_FIXUP:=autoreconf
+
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
@@ -51,6 +53,9 @@ endef
 
 CONFIGURE_VARS += \
         ac_cv_lib_bcg729_initBcg729EncoderChannel=no
+
+# Otherwise OpenWrt's CPPFLAGS are ignored
+TARGET_CFLAGS+=$(TARGET_CPPFLAGS)
 
 define Package/rtpproxy/install
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/net/rtpproxy/Makefile
+++ b/net/rtpproxy/Makefile
@@ -1,6 +1,6 @@
 #
-# Copyright (C) 2014 OpenWrt.org
-# Copyright (C) 2017 Jiri Slachta <jiri@slachta.eu>
+# Copyright (C) 2014 - 2018 OpenWrt.org
+# Copyright (C) 2017 - 2018 Jiri Slachta <jiri@slachta.eu>
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,15 +9,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtpproxy
-PKG_VERSION:=2.0.0
-PKG_RELEASE:=2
+PKG_VERSION:=2.1.0-20170914
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/sippy/rtpproxy.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=d5926892630139bcbe55d1f3fa36764c881648bc
-PKG_MIRROR_HASH:=7da4a9b83f01b4169cf3f087c76e73fd9b4f5afb8d543c4663e874d8d9b1b26a
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_SOURCE_VERSION:=589cc78cb8698b49aa408c6411c8720a2a0efe3c
+PKG_MIRROR_HASH:=087b363a7e5f112fe0c601e147ac087f528a500a25340cbccc12d90935876137
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.xz
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_CHECK_FORMAT_SECURITY:=0

--- a/net/rtpproxy/patches/102-don-t-build-rtpproxy_debug.patch
+++ b/net/rtpproxy/patches/102-don-t-build-rtpproxy_debug.patch
@@ -1,23 +1,16 @@
-Index: rtpproxy-2.0.0/src/Makefile.am
-===================================================================
---- rtpproxy-2.0.0.orig/src/Makefile.am
-+++ rtpproxy-2.0.0/src/Makefile.am
+--- a/src/Makefile.am
++++ b/src/Makefile.am
 @@ -1,4 +1,4 @@
 -bin_PROGRAMS=rtpproxy rtpproxy_debug
 +bin_PROGRAMS=rtpproxy
- rtpproxy_SOURCES=main.c rtp.h rtp_server.c rtp_server.h \
+ BASE_SOURCES=main.c rtp.h rtpp_server.c rtpp_server.h \
    rtpp_defines.h rtpp_log.h rtpp_record.c rtpp_record.h rtpp_session.h \
    rtpp_util.c rtpp_util.h rtp.c rtp_resizer.c rtp_resizer.h rtpp_session.c \
-Index: rtpproxy-2.0.0/src/Makefile.in
-===================================================================
---- rtpproxy-2.0.0.orig/src/Makefile.in
-+++ rtpproxy-2.0.0/src/Makefile.in
-@@ -78,7 +78,7 @@ PRE_UNINSTALL = :
- POST_UNINSTALL = :
- build_triplet = @build@
- host_triplet = @host@
--bin_PROGRAMS = rtpproxy$(EXEEXT) rtpproxy_debug$(EXEEXT)
-+bin_PROGRAMS = rtpproxy$(EXEEXT)
- subdir = src
- DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
- 	$(srcdir)/config.h.in $(top_srcdir)/depcomp
+--- a/modules/acct_csv/Makefile.am
++++ b/modules/acct_csv/Makefile.am
+@@ -1,4 +1,4 @@
+-pkglib_LTLIBRARIES = rtpp_acct_csv.la rtpp_acct_csv_debug.la
++pkglib_LTLIBRARIES = rtpp_acct_csv.la
+ 
+ rtpp_acct_csv_la_SOURCES = rtpp_acct_csv.c
+ rtpp_acct_csv_la_LDFLAGS = -avoid-version -module -shared -export-dynamic

--- a/net/rtpproxy/patches/103-add-missing-includes.patch
+++ b/net/rtpproxy/patches/103-add-missing-includes.patch
@@ -1,0 +1,36 @@
+--- a/src/rtpp_record.c
++++ b/src/rtpp_record.c
+@@ -48,6 +48,7 @@
+ #include <string.h>
+ #include <unistd.h>
+ 
++#include "config.h"
+ #include "rtp.h"
+ #include "rtp_packet.h"
+ #include "rtpp_log.h"
+@@ -67,6 +68,7 @@
+ #include "rtpp_session.h"
+ #include "rtpp_stream.h"
+ #include "rtpp_time.h"
++#include "rtpp_util.h"
+ #include "rtpp_pipe.h"
+ #include "rtpp_netaddr.h"
+ 
+--- a/modules/acct_csv/rtpp_acct_csv.c
++++ b/modules/acct_csv/rtpp_acct_csv.c
+@@ -38,6 +38,7 @@
+ #include <string.h>
+ #include <unistd.h>
+ 
++#include "config.h"
+ #include "rtpp_ssrc.h"
+ #include "rtpa_stats.h"
+ #include "rtpp_monotime.h"
+@@ -50,6 +51,7 @@
+ #include "rtpp_module.h"
+ #include "rtpp_netaddr.h"
+ #include "rtpp_network.h"
++#include "rtpp_util.h"
+ #include "rtpp_cfg_stable.h"
+ 
+ #define SSRC_STRLEN 11


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: x86_64, mips24kc
Run tested: mips_24kc

Description:

Hello Jiri,

rtpproxy 2.0.0 branch hasn't been updated in a while upstream. Update to 2.1.0 which received last fixes end of last year.

Kind regards,
Seb