### PR TITLE
Bcg729 flags

### DIFF
--- a/libs/bcg729/Makefile
+++ b/libs/bcg729/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcg729
 PKG_VERSION:=1.0.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.linphone.org/releases/sources/bcg729
@@ -41,7 +41,7 @@ define Package/bcg729/description
 endef
 
 # Otherwise spandsp ignores OpenWrt's CPPFLAGS
-TARGET_CFLAGS += $(FPIC) $(TARGET_CPPFLAGS)
+TARGET_CFLAGS += $(TARGET_CPPFLAGS)
 
 CMAKE_OPTIONS += \
 	-DCMAKE_VERBOSE_MAKEFILE=TRUE \

--- a/libs/bcg729/Makefile
+++ b/libs/bcg729/Makefile
@@ -1,5 +1,5 @@
 # 
-# Copyright (C) 2006-2017 OpenWrt.org
+# Copyright (C) 2006-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -40,9 +40,11 @@ define Package/bcg729/description
  source code in any kind.
 endef
 
-TARGET_CFLAGS += $(FPIC)
+# Otherwise spandsp ignores OpenWrt's CPPFLAGS
+TARGET_CFLAGS += $(FPIC) $(TARGET_CPPFLAGS)
 
 CMAKE_OPTIONS += \
+	-DCMAKE_VERBOSE_MAKEFILE=TRUE \
 	-DENABLE_SHARED=YES \
 	-DENABLE_STATIC=NO \
 	-DENABLE_TESTS=NO


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: x86_64
Run tested:  N/A

Description:
Hello Jiri,

This is the first of a number of pull requests which are mostly meant to clean up the build flags.

- $(FPIC): gets removed from TARGET_CFLAGS

    Reasoning:

      - The build systems (i.e. configure scripts and Makefiles) of the packages make sure that the compiler emits position-independent code for shared libs anyway.
      - Forcing $(FPIC) to be always used results in applications (e.g. xsltproc from libxslt) being built with PIC as well, which is not desirable at all (PIC should be used for libs only, applications will be slowed down).

- CPPFLAGS get added where needed, so that fortify-source headers are picked up.

Kind regards,
Seb