### PR TITLE
pcapsipdump: compile fixes

### DIFF
--- a/net/pcapsipdump/Makefile
+++ b/net/pcapsipdump/Makefile
@@ -36,9 +36,10 @@ define Package/pcapsipdump/description
  (even if there is thousands of concurrect SIP sessions).
 endef
 
-MAKE_VARS += \
+MAKE_FLAGS += \
 	CC="$(TARGET_CXX)" \
-	CPPFLAGS="$(TARGET_CXXFLAGS) -fno-rtti $(TARGET_CPPFLAGS)"
+	CPPFLAGS="$(TARGET_CXXFLAGS) -fno-rtti $(TARGET_CPPFLAGS)" \
+	LIBS="-lpcap"
 
 define Package/pcapsipdump/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
Previous revert only works when libstdcpp is the default C++ lib. To
make the compile work in all scenarios LIBS needs to be defined and
MAKE_FLAGS are required instead of MAKE_VARS, otherwise the included
variables are overridden.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: x86_64
Run tested:

Description:
Meh, looks like my testing of the previous commit was only half-baked.

Kind regards,
Seb