### PR TITLE
pjproject: add PKG_CONFIG_DEPENDS

### DIFF
--- a/libs/pjproject/Makefile
+++ b/libs/pjproject/Makefile
@@ -25,6 +25,8 @@ PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
+PKG_CONFIG_DEPENDS:=CONFIG_SOFT_FLOAT
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/pjproject/Default


### PR DESCRIPTION
It is unlikely that SOFT_FLOAT is toggled, but add it to
PKG_CONFIG_DEPENDS for completeness' sake anyway.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: x86_64
Run tested: N/A
