### PR TITLE
asterisk-chan-dongle: simplify and update snapshot

### DIFF
--- a/net/asterisk-chan-dongle/Makefile
+++ b/net/asterisk-chan-dongle/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk-chan-dongle
-PKG_VERSION:=1.1-20170913
-PKG_RELEASE:=2
+PKG_VERSION:=1.1-20180305
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/wdoekes/asterisk-chan-dongle.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=4ef5ad7eea7245a031101875be08b924aa1e151b
-PKG_MIRROR_HASH:=cbff4a4d9e78cc5ef91bd00d8e68cbe5f6e131dc568395085780c87d05a6cb1c
+PKG_SOURCE_VERSION:=fe2861efde02d0c53dafbf29f9fc71e214d6f605
+PKG_MIRROR_HASH:=5278572c398b8f5b1101a37fcfdb5621f7e81bd1858be462ce71685728b33001
 PKG_SOURCE_PROTO:=git
 
 PKG_FIXUP:=autoreconf
@@ -25,6 +25,8 @@ PKG_LICENSE_FILES:=COPYRIGHT.txt LICENSE.txt
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
+
+MODULES_DIR:=/usr/lib/asterisk/modules
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -83,6 +85,7 @@ TARGET_LDFLAGS+=$(if $(CONFIG_USE_UCLIBC),-L$(STAGING_DIR)/usr/lib/libiconv-full
 # $CHAN_DONGLE_ICONV_INC used by 200-fix-iconv-detection.patch
 CONFIGURE_VARS += \
 	CHAN_DONGLE_ICONV_INC="$(TOOLCHAIN_DIR)/include $(STAGING_DIR)/usr/lib/libiconv-full/include" \
+	DESTDIR="$(MODULES_DIR)" \
 	ac_cv_type_size_t=yes \
 	ac_cv_type_ssize_t=yes
 
@@ -96,8 +99,8 @@ Package/asterisk15-chan-dongle/conffiles = $(Package/conffiles/Default)
 define Package/Install/Default
 	$(INSTALL_DIR) $(1)/etc/asterisk
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/etc/dongle.conf $(1)/etc/asterisk
-	$(INSTALL_DIR) $(1)/usr/lib/asterisk/modules
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/chan_dongle.so $(1)/usr/lib/asterisk/modules
+	$(INSTALL_DIR) $(1)$(MODULES_DIR)
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/chan_dongle.so $(1)$(MODULES_DIR)
 endef
 
 Package/asterisk13-chan-dongle/install = $(Package/Install/Default)

--- a/net/asterisk-chan-dongle/Makefile
+++ b/net/asterisk-chan-dongle/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017 OpenWrt.org
+# Copyright (C) 2017 - 2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -74,38 +74,17 @@ CONFIGURE_ARGS+= \
 TARGET_CFLAGS+= \
 	-I$(CHAN_DONGLE_AST_HEADERS)
 
+MAKE_FLAGS+=LD="$(TARGET_CC)"
+
 # musl and glibc include their own iconv, but uclibc does not
-ifneq ($(CONFIG_USE_UCLIBC),)
-TARGET_CPPFLAGS+= \
-	-I$(STAGING_DIR)/usr/lib/libiconv-full/include
-endif
-
-# -DAST_MODULE_SELF_SYM=__internal_chan_dongle_self to fix Asterisk 14
-# compile issues
-CHAN_DONGLE_EXTRA_CFLAGS:= \
-	-Wno-old-style-declaration \
-	-I$(PKG_BUILD_DIR) \
-	-DAST_MODULE_SELF_SYM=__internal_chan_dongle_self \
-	$(TARGET_CPPFLAGS) \
-	-D_GNU_SOURCE \
-	-DHAVE_CONFIG_H \
-	$(FPIC)
-
-MAKE_ARGS:= \
-	CC="$(TARGET_CC)" \
-	LD="$(TARGET_CC)" \
-	CFLAGS="$(TARGET_CFLAGS) $(CHAN_DONGLE_EXTRA_CFLAGS)" \
-	LDFLAGS="$(TARGET_LDFLAGS) $(if $(CONFIG_USE_UCLIBC),-L$(STAGING_DIR)/usr/lib/libiconv-full/lib -liconv)"
+TARGET_CPPFLAGS+=$(if $(CONFIG_USE_UCLIBC),-I$(STAGING_DIR)/usr/lib/libiconv-full/include)
+TARGET_LDFLAGS+=$(if $(CONFIG_USE_UCLIBC),-L$(STAGING_DIR)/usr/lib/libiconv-full/lib -liconv)
 
 # $CHAN_DONGLE_ICONV_INC used by 200-fix-iconv-detection.patch
 CONFIGURE_VARS += \
 	CHAN_DONGLE_ICONV_INC="$(TOOLCHAIN_DIR)/include $(STAGING_DIR)/usr/lib/libiconv-full/include" \
 	ac_cv_type_size_t=yes \
 	ac_cv_type_ssize_t=yes
-
-define Build/Compile
-	$(MAKE) $(PKG_JOBS) -C "$(PKG_BUILD_DIR)" $(MAKE_ARGS)
-endef
 
 define Package/conffiles/Default
 /etc/asterisk/dongle.conf

--- a/net/asterisk-chan-dongle/patches/300-use-openwrt-flags.patch
+++ b/net/asterisk-chan-dongle/patches/300-use-openwrt-flags.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -216,8 +216,6 @@ dnl Apply options to defines
+ if test "x$enable_debug" = "xyes" ; then
+   CFLAGS="$CFLAGS -O0 -g"
+   AC_DEFINE([__DEBUG__], [1], [Build with debugging])
+-else
+-  CFLAGS="$CFLAGS -O6"
+ fi
+ 
+ dnl Asterisk header files use lots of old style declarations, ignore those.


### PR DESCRIPTION
Maintainer: @jsla
Compile tested: x86_64 and arch_archs
Run tested: N/A

Description:
Hello Jiri,

Simplifies the Makefile. Also updates to a current snapshot.

Regards,
Seb