### PR TITLE
Asterisk standard c++ lib

### DIFF
--- a/libs/pjproject/Makefile
+++ b/libs/pjproject/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pjproject
 PKG_VERSION:=2.7.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=pjproject-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.pjsip.org/release/$(PKG_VERSION)
@@ -27,6 +27,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_CONFIG_DEPENDS:=CONFIG_SOFT_FLOAT
 
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/pjproject/Default
@@ -34,7 +35,7 @@ define Package/pjproject/Default
   CATEGORY:=Libraries
   SUBMENU:=Telephony
   URL:=http://www.pjsip.org
-  DEPENDS:=+libopenssl +libuuid +libstdcpp +libpthread
+  DEPENDS:=$(CXX_DEPENDS) +libopenssl +libuuid +libpthread
 endef
 
 define Package/pjproject/install/lib

--- a/libs/pjproject/patches/160-remove-hardcoded-lstdc++.patch
+++ b/libs/pjproject/patches/160-remove-hardcoded-lstdc++.patch
@@ -1,0 +1,22 @@
+--- a/build.mak.in
++++ b/build.mak.in
+@@ -293,7 +293,6 @@ export APP_LDLIBS := $(PJSUA_LIB_LDLIB)
+ 	$(PJLIB_LDLIB) \
+ 	@LIBS@
+ export APP_LDXXLIBS := $(PJSUA2_LIB_LDLIB) \
+-	-lstdc++ \
+ 	$(APP_LDLIBS)
+ 
+ # Here are the variabels to use if application is using the library
+--- a/pjsip/build/Makefile
++++ b/pjsip/build/Makefile
+@@ -152,8 +152,7 @@ export PJSUA2_LIB_LDFLAGS += $(PJSUA_LIB
+ 			     $(PJNATH_LDLIB) \
+ 			     $(PJLIB_UTIL_LDLIB) \
+ 			     $(PJLIB_LDLIB) \
+-			     $(_LDFLAGS) \
+-			     -lstdc++
++			     $(_LDFLAGS)
+ 
+ 
+ ###############################################################################

--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -422,7 +422,7 @@ define Package/asterisk13
 $(call Package/asterisk13/Default)
   TITLE:=Complete open source PBX, v$(PKG_VERSION)
   MENU:=1
-  DEPENDS:=+jansson +libcap +libedit +libncurses +libopenssl +libpopt +libsqlite3 +libstdcpp +libuuid +libxml2 +libxslt +zlib
+  DEPENDS:=+jansson +libcap +libedit +libncurses +libopenssl +libsqlite3 +libstdcpp +libuuid +libxml2 +zlib
 endef
 
 define Package/asterisk13/description
@@ -536,7 +536,7 @@ CONFIGURE_ARGS+= \
 	--without-osptk \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-pbx-lua),--with-lua="$(STAGING_DIR)/usr",--without-lua) \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-pgsql),--with-postgres="$(STAGING_DIR)/usr",--without-postgres) \
-	--with-popt="$(STAGING_DIR)/usr" \
+	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-util-smsq),--with-popt="$(STAGING_DIR)/usr",--without-popt) \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-chan-console),--with-portaudio="$(STAGING_DIR)/usr",--without-portaudio) \
 	--without-pwlib \
 	--without-radius \
@@ -770,7 +770,7 @@ $(eval $(call BuildAsterisk13Module,app-sayunixtime,Say Unix time,an application
 $(eval $(call BuildAsterisk13Module,app-senddtmf,Send DTMF digits,Sends arbitrary DTMF digits,,,app_senddtmf,,))
 $(eval $(call BuildAsterisk13Module,app-sendtext,Send text,transmit a text message,,,app_sendtext,,))
 $(eval $(call BuildAsterisk13Module,app-skel,Skeleton [sample],skeleton for development of an Asterisk application,,app_skel.conf,app_skel,,))
-$(eval $(call BuildAsterisk13Module,app-sms,SMS,SMS support (ETSI ES 201 912 protocol 1),+libpopt +libstdcpp,,app_sms,,))
+$(eval $(call BuildAsterisk13Module,app-sms,SMS,SMS support (ETSI ES 201 912 protocol 1),,,app_sms,,))
 $(eval $(call BuildAsterisk13Module,app-softhangup,Hang up requested channel,SoftHangup application,,,app_softhangup,,))
 $(eval $(call BuildAsterisk13Module,app-speech,Dialplan Speech,Dialplan Speech Applications,+asterisk13-res-speech,,app_speech_utils,,))
 $(eval $(call BuildAsterisk13Module,app-stack,Stack applications,Stack applications Gosub Return etc.,+asterisk13-res-agi,,app_stack,,))
@@ -996,6 +996,6 @@ $(eval $(call BuildAsterisk13Util,check_expr,Expression checker [older version].
 $(eval $(call BuildAsterisk13Util,check_expr2,Expression checker [newer version].,,))
 $(eval $(call BuildAsterisk13Util,conf2ael,Convert .conf to .ael.,+$(PKG_NAME)-pbx-ael,))
 $(eval $(call BuildAsterisk13Util,muted,Listens for AMI events. Mutes soundcard during call.,,muted.conf))
-$(eval $(call BuildAsterisk13Util,smsq,Send messages from command line.,,))
+$(eval $(call BuildAsterisk13Util,smsq,Send messages from command line.,+libpopt,))
 $(eval $(call BuildAsterisk13Util,stereorize,Merge two mono WAV-files to one stereo WAV-file.,,))
 $(eval $(call BuildAsterisk13Util,streamplayer,A utility for reading from a raw TCP stream [MOH source].,,))

--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk13
 PKG_VERSION:=13.19.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases
@@ -313,6 +313,7 @@ PKG_CONFIG_DEPENDS:= \
 	$(patsubst %,CONFIG_PACKAGE_$(PKG_NAME)-util-%,$(UTILS_AVAILABLE)) \
 	CONFIG_ASTERISK13_LOW_MEMORY
 
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 
@@ -422,7 +423,7 @@ define Package/asterisk13
 $(call Package/asterisk13/Default)
   TITLE:=Complete open source PBX, v$(PKG_VERSION)
   MENU:=1
-  DEPENDS:=+jansson +libcap +libedit +libncurses +libopenssl +libsqlite3 +libstdcpp +libuuid +libxml2 +zlib
+  DEPENDS:=$(CXX_DEPENDS) +jansson +libcap +libedit +libncurses +libopenssl +libsqlite3 +libuuid +libxml2 +zlib
 endef
 
 define Package/asterisk13/description

--- a/net/asterisk-15.x/Makefile
+++ b/net/asterisk-15.x/Makefile
@@ -428,7 +428,7 @@ define Package/asterisk15
 $(call Package/asterisk15/Default)
   TITLE:=Complete open source PBX, v$(PKG_VERSION)
   MENU:=1
-  DEPENDS:=+jansson +libcap +libedit +libncurses +libopenssl +libpopt +libsqlite3 +libstdcpp +libuuid +libxml2 +libxslt +zlib
+  DEPENDS:=+jansson +libcap +libedit +libncurses +libopenssl +libsqlite3 +libstdcpp +libuuid +libxml2 +zlib
 endef
 
 define Package/asterisk15/description
@@ -542,7 +542,7 @@ CONFIGURE_ARGS+= \
 	--without-osptk \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-pbx-lua),--with-lua="$(STAGING_DIR)/usr",--without-lua) \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-pgsql),--with-postgres="$(STAGING_DIR)/usr",--without-postgres) \
-	--with-popt="$(STAGING_DIR)/usr" \
+	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-util-smsq),--with-popt="$(STAGING_DIR)/usr",--without-popt) \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-chan-console),--with-portaudio="$(STAGING_DIR)/usr",--without-portaudio) \
 	--without-pwlib \
 	--without-radius \
@@ -786,7 +786,7 @@ $(eval $(call BuildAsterisk15Module,app-sayunixtime,Say Unix time,an application
 $(eval $(call BuildAsterisk15Module,app-senddtmf,Send DTMF digits,Sends arbitrary DTMF digits,,,app_senddtmf,,))
 $(eval $(call BuildAsterisk15Module,app-sendtext,Send text,transmit a text message,,,app_sendtext,,))
 $(eval $(call BuildAsterisk15Module,app-skel,Skeleton [sample],skeleton for development of an Asterisk application,,app_skel.conf,app_skel,,))
-$(eval $(call BuildAsterisk15Module,app-sms,SMS,SMS support (ETSI ES 201 912 protocol 1),+libpopt +libstdcpp,,app_sms,,))
+$(eval $(call BuildAsterisk15Module,app-sms,SMS,SMS support (ETSI ES 201 912 protocol 1),,,app_sms,,))
 $(eval $(call BuildAsterisk15Module,app-softhangup,Hang up requested channel,SoftHangup application,,,app_softhangup,,))
 $(eval $(call BuildAsterisk15Module,app-speech,Dialplan Speech,Dialplan Speech Applications,+asterisk15-res-speech,,app_speech_utils,,))
 $(eval $(call BuildAsterisk15Module,app-stack,Stack applications,Stack applications Gosub Return etc.,+asterisk15-res-agi,,app_stack,,))
@@ -1019,6 +1019,6 @@ $(eval $(call BuildAsterisk15Util,check_expr,Expression checker [older version].
 $(eval $(call BuildAsterisk15Util,check_expr2,Expression checker [newer version].,,))
 $(eval $(call BuildAsterisk15Util,conf2ael,Convert .conf to .ael.,+$(PKG_NAME)-pbx-ael,))
 $(eval $(call BuildAsterisk15Util,muted,Listens for AMI events. Mutes soundcard during call.,,muted.conf))
-$(eval $(call BuildAsterisk15Util,smsq,Send messages from command line.,,))
+$(eval $(call BuildAsterisk15Util,smsq,Send messages from command line.,+libpopt,))
 $(eval $(call BuildAsterisk15Util,stereorize,Merge two mono WAV-files to one stereo WAV-file.,,))
 $(eval $(call BuildAsterisk15Util,streamplayer,A utility for reading from a raw TCP stream [MOH source].,,))

--- a/net/asterisk-15.x/Makefile
+++ b/net/asterisk-15.x/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk15
 PKG_VERSION:=15.2.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases
@@ -319,6 +319,7 @@ PKG_CONFIG_DEPENDS:= \
 	$(patsubst %,CONFIG_PACKAGE_$(PKG_NAME)-util-%,$(UTILS_AVAILABLE)) \
 	CONFIG_ASTERISK15_LOW_MEMORY
 
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 
@@ -428,7 +429,7 @@ define Package/asterisk15
 $(call Package/asterisk15/Default)
   TITLE:=Complete open source PBX, v$(PKG_VERSION)
   MENU:=1
-  DEPENDS:=+jansson +libcap +libedit +libncurses +libopenssl +libsqlite3 +libstdcpp +libuuid +libxml2 +zlib
+  DEPENDS:=$(CXX_DEPENDS) +jansson +libcap +libedit +libncurses +libopenssl +libsqlite3 +libuuid +libxml2 +zlib
 endef
 
 define Package/asterisk15/description


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: x86_64, mips_24kc
Run tested: mips_24kc

Description:
Hi Jiri,

This removes the hardcoding of libstdcpp in the Asterisk and pjproject packages. If the preference is libuClibc++ it uses that instead. On OpenWrt libuClibc++ is default. It's about 1 MByte smaller on the router than libstdc++ and uses less RAM.

I've tested both 13 and 15, making phone calls both via chan_sip and pjsip. All OK.

The pull request also fixes some depends.

Kind regards,
Seb