### PR TITLE
sipp: use preferred standard C++ lib

### DIFF
--- a/net/sipp/Makefile
+++ b/net/sipp/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2017 OpenWrt.org
+# Copyright (C) 2013-2018 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sipp
 PKG_VERSION:=3.5.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/SIPp/sipp/releases/download/v$(PKG_VERSION)
@@ -20,13 +20,14 @@ PKG_LICENSE_FILES:=LICENSE.txt
 
 PKG_FIXUP:=autoreconf
 
+include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/sipp
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Telephony
-  DEPENDS:=+libncurses +libpthread +libstdcpp
+  DEPENDS:=$(CXX_DEPENDS) +libncurses +libpthread
   TITLE:=test tool / traffic generator for the SIP protocol
   URL:=http://sipp.sourceforge.net/
 endef


### PR DESCRIPTION
Currently libstdc++ is hardcoded. Change that and use whatever standard
C++ lib has preference.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: x86_64 + mips_24kc
Run tested: mips_24kc

Description:
Same as in the other PR for asterisk, removes the hardcoded dep on libstdcpp.