### PR TITLE
baresip: update baresip-mod-pulse depend

### DIFF
--- a/net/baresip/Makefile
+++ b/net/baresip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=baresip
 PKG_VERSION:=0.5.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.creytiv.com/pub
@@ -207,7 +207,7 @@ $(eval $(call BuildPlugin,oss,OSS audio driver,oss,))
 $(eval $(call BuildPlugin,plc,Packet Loss Concealment,plc,+libspandsp))
 $(eval $(call BuildPlugin,portaudio,Portaudio audio driver,portaudio,+portaudio))
 $(eval $(call BuildPlugin,presence,Presence module,presence,))
-$(eval $(call BuildPlugin,pulse,Pulseaudio audio driver,pulse,+pulseaudio-daemon))
+$(eval $(call BuildPlugin,pulse,Pulseaudio audio driver,pulse,+pulseaudio))
 $(eval $(call BuildPlugin,selfview,Video selfview module,selfview,))
 $(eval $(call BuildPlugin,sndfile,Audio dumper using libsndfile,sndfile,+libsndfile))
 $(eval $(call BuildPlugin,speex,Speex audio codec,speex,+libspeex))


### PR DESCRIPTION
There are two pulseaudio packages, pulseaudio-daemon and
pulseaudio-daemon-avahi. Both provide pulseaudio. Depend on pulseaudio
so the user may choose which one to install.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: x86_64
Run tested: N/A

Description:
Hi Jiri,

This cleans up the depend of mod-pulse.

Kind regards,
Seb