### PR TITLE
siproxd: remove underscores from package names

### DIFF
--- a/net/siproxd/Makefile
+++ b/net/siproxd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=siproxd
 PKG_VERSION:=0.8.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/siproxd
@@ -64,18 +64,18 @@ define Package/siproxd/install
 endef
 
 define BuildPlugin
-  define Package/siproxd-mod-$(1)
+  define Package/siproxd-mod-$(subst _,-,$(1))
     $$(call Package/siproxd/Default)
     TITLE:= siproxd $(1) plugin
     DEPENDS:=siproxd
   endef
 
-  define Package/siproxd-mod-$(1)/install
+  define Package/siproxd-mod-$(subst _,-,$(1))/install
 	$(INSTALL_DIR) $$(1)/usr/lib/siproxd
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/siproxd/plugin_$(1).so $$(1)/usr/lib/siproxd
   endef
 
-  $$(eval $$(call BuildPackage,siproxd-mod-$(1)))
+  $$(eval $$(call BuildPackage,siproxd-mod-$(subst _,-,$(1))))
 endef
 
 $(eval $(call BuildPackage,siproxd))


### PR DESCRIPTION
Underscores should not be used in package base names as they're used as
semantic separators by opkg.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jsla
Compile tested: mips24kc
Run tested: N/A

Description:
Hi Jiri,

Fix package names, same as the others.

Kind regards,
Seb