### PR TITLE
asterisk-chan-lantiq: fix dep for nonshared builds

### DIFF
--- a/net/asterisk-13.x-chan-lantiq/Makefile
+++ b/net/asterisk-13.x-chan-lantiq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk13-chan-lantiq
 PKG_VERSION:=20180215
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/kochstefan/asterisk_channel_lantiq.git
@@ -27,12 +27,12 @@ PKG_FLAGS:=nonshared
 include $(INCLUDE_DIR)/package.mk
 
 define Package/$(PKG_NAME)
-  SUBMENU:=Telephony
+  SUBMENU:=Telephony Lantiq
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Lantiq channel driver
   URL:=https://github.com/kochstefan/asterisk_channel_lantiq
-  DEPENDS:=asterisk13 +kmod-ltq-vmmc
+  DEPENDS:=+asterisk13 +kmod-ltq-vmmc
 endef
 
 define Package/$(PKG_NAME)/description

--- a/net/asterisk-15.x-chan-lantiq/Makefile
+++ b/net/asterisk-15.x-chan-lantiq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk15-chan-lantiq
 PKG_VERSION:=20180215
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/kochstefan/asterisk_channel_lantiq.git
@@ -27,12 +27,12 @@ PKG_FLAGS:=nonshared
 include $(INCLUDE_DIR)/package.mk
 
 define Package/$(PKG_NAME)
-  SUBMENU:=Telephony
+  SUBMENU:=Telephony Lantiq
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Lantiq channel driver
   URL:=https://github.com/kochstefan/asterisk_channel_lantiq
-  DEPENDS:=asterisk15 +kmod-ltq-vmmc
+  DEPENDS:=+asterisk15 +kmod-ltq-vmmc
 endef
 
 define Package/$(PKG_NAME)/description


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: lantiq xway
Run tested: N/A

Description:
Hi Jiri,

I'm 99% sure now that I found the reason for the buildbots not building chan-lantiq. This commit should fix this.

I thought about reverting the previous commit, but the VARIANT version didn't look too nice due to the different git branches used upstream. I think the non-VARIANT Makefiles for chan-lantiq are easier on the eyes and should be kept.

The commit messages mentions the reason for the new sub menu. I didn't find a better way. Without it it would look really broken:

```
{M} asterisk13............................ Complete open source PBX, v13.19.2  --->                      │ │  
  │ │                                  <M> asterisk13-chan-lantiq............................. Lantiq channel driver (NEW)                      │ │  
  │ │                                  < > asterisk13-chan-mgcp........................................ MGCP support (NEW)                      │ │  
  │ │                                  < > asterisk13-chan-mobile......................... Bluetooth channel support (NEW)                      │ │  
  │ │                                  < > asterisk13-chan-motif............................. Jingle channel support (NEW)                      │ │  
  │ │                                  < > asterisk13-chan-ooh323............................. H.323 channel support (NEW)
```

Kind regards,
Seb