### PR TITLE
yate: fix mysql detection

### DIFF
--- a/net/yate/Makefile
+++ b/net/yate/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yate
 PKG_VERSION:=6.0.0-1
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://yate.null.ro/tarballs/yate6/
@@ -108,7 +108,7 @@ CONFIGURE_ARGS+= \
 	--enable-ilbc \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-mod-ilbcwebrtc),--enable-ilbc-webrtc,--disable-ilbc-webrtc) \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-mod-pgsqldb),--with-libpq="$(STAGING_DIR)/usr",--without-libpq) \
-	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-mod-mysqldb),--with-mysql="$(STAGING_DIR)/usr",--without-mysql) \
+	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-mod-mysqldb),--with-mysql=yes,--with-mysql=no) \
 	--without-wphwec \
 	--without-libgsm \
 	--without-amrnb \


### PR DESCRIPTION
When configure is called with '--with-mysql="$(STAGING_DIR)/usr"' it tries
to detect mysql manually instead of using mysql_config. This doesn't always
work:

```
<snip>
checking for MySQL in /var/lib/buildbot/slaves/slave-lede-builds4/i386_pentium4/build/sdk/staging_dir/target-i386_pentium4_musl/usr... no
<snip>
```

This commit changes the configure argument to '--with-mysql=yes/no'. When
'yes' is selected configure uses mysql_config and then the detection works
reliably.

```
<snip>
checking for MySQL using mysql_config... yes 10.1.32
checking whether MYSQL_OPT_RECONNECT is declared... yes
checking whether MYSQL_OPT_READ_TIMEOUT is declared... yes
checking whether MYSQL_OPT_WRITE_TIMEOUT is declared... yes
checking whether mysql_set_character_set is declared... yes
<snip>
```

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: mips24_kcc, pentium4
Run tested: N/A

Description:
Fix sporadic yate build failures.