### PR TITLE
siproxd: fix init code when multiple sections are defined

### DIFF
--- a/net/siproxd/files/siproxd.init
+++ b/net/siproxd/files/siproxd.init
@@ -95,6 +95,7 @@ siproxd_cb() {
 			# Initialize section processing and save section name.
 			"siproxd")
 				sec="$2"
+				secs="$secs $sec"
 				if [ -f "$siproxd_conf_prefix$sec.conf" ]; then
 					rm "$siproxd_conf_prefix$sec.conf"
 				fi
@@ -102,25 +103,27 @@ siproxd_cb() {
 					"$siproxd_conf_prefix$sec.conf"
 			;;
 			# Parse OpenWRT interface names (e.g. "wan") and apply defaults,
-			# using saved section name.
+			# using saved section names.
 			"")
-				local chrootjail
-				local pid_file
+				for sec in $secs; do
+					local chrootjail
+					local pid_file
 
-				setup_networks "$sec"
-				apply_defaults "$sec"
+					setup_networks "$sec"
+					apply_defaults "$sec"
 
-				config_get chrootjail "$sec" chrootjail
-				if [ -n "$chrootjail" ]; then
-					if [ ! -d "$chrootjail" ]; then
-						mkdir -p "$chrootjail"
-						chmod 0755 "$chrootjail"
+					config_get chrootjail "$sec" chrootjail
+					if [ -n "$chrootjail" ]; then
+						if [ ! -d "$chrootjail" ]; then
+							mkdir -p "$chrootjail"
+							chmod 0755 "$chrootjail"
+						fi
 					fi
-				fi
 
-				config_get pid_file "$sec" pid_file
-				SERVICE_PID_FILE="$pid_file" service_start \
-				$siproxd_bin --config "$siproxd_conf_prefix$sec.conf"
+					config_get pid_file "$sec" pid_file
+					SERVICE_PID_FILE="$pid_file" service_start \
+					$siproxd_bin --config "$siproxd_conf_prefix$sec.conf"
+				done
 			;;
 		esac
 		return 0


### PR DESCRIPTION
Maintainer: @jslachta
Compile tested: LEDE 17.01.4 x86-generic
Run tested: LEDE 17.01.4 x86-generic

Description:

When multiple sections were defined in uci for siproxd, all but the last one didn't result in a running siproxd process. The configuration file was written incompletely for all but the last section defined. The service was only started for that configuration file. It seems like that issue was introduced by @guidosarducci in https://github.com/openwrt/telephony/pull/304. Since that patch went into the lede-17.01 and openwrt-18.06 branches, this one should be cherry-picked too.