### PR TITLE
asterisk: remove sounds cache

### DIFF
--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -551,8 +551,7 @@ CONFIGURE_ARGS+= \
 	--without-tinfo \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-format-ogg-vorbis),--with-vorbis="$(STAGING_DIR)/usr",--without-vorbis) \
 	--without-vpb \
-	--with-z="$(STAGING_DIR)/usr" \
-	--with-sounds-cache="$(DL_DIR)"
+	--with-z="$(STAGING_DIR)/usr"
 
 ifeq ($(CONFIG_PACKAGE_$(PKG_NAME)-codec-speex)$(CONFIG_PACKAGE_$(PKG_NAME)-func-speex),)
 CONFIGURE_ARGS+= \

--- a/net/asterisk-15.x/Makefile
+++ b/net/asterisk-15.x/Makefile
@@ -557,8 +557,7 @@ CONFIGURE_ARGS+= \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-res-resolver-unbound),--with-unbound="$(STAGING_DIR)/usr",--without-unbound) \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-format-ogg-vorbis),--with-vorbis="$(STAGING_DIR)/usr",--without-vorbis) \
 	--without-vpb \
-	--with-z="$(STAGING_DIR)/usr" \
-	--with-sounds-cache="$(DL_DIR)"
+	--with-z="$(STAGING_DIR)/usr"
 
 ifeq ($(CONFIG_PACKAGE_$(PKG_NAME)-codec-speex)$(CONFIG_PACKAGE_$(PKG_NAME)-format-ogg-speex)$(CONFIG_PACKAGE_$(PKG_NAME)-func-speex),)
 CONFIGURE_ARGS+= \


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: ar71xx
Run tested: N/A

Description:
Hello Jiri,

Turns out the sound pack download issue is easy to fix after all. Just a one-liner :)

Kind regards,
Seb