### PR TITLE
asterisk-13.x: remove sounds cache

### DIFF
--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -226,8 +226,7 @@ CONFIGURE_ARGS+= \
 	--without-tinfo \
 	--without-vorbis \
 	--without-vpb \
-	--with-z="$(STAGING_DIR)/usr" \
-	--with-sounds-cache="$(DL_DIR)"
+	--with-z="$(STAGING_DIR)/usr"
 
 ifeq ($(CONFIG_PACKAGE_$(PKG_NAME)-res-pjproject)$(CONFIG_PACKAGE_$(PKG_NAME)-res-srtp),)
 CONFIGURE_ARGS+= \


### PR DESCRIPTION
When there is no sounds cache declared the build system will not attempt to
download any sound packs or their SHA1 checksums.

This is to be preferred because:

  a) the build may occur offline, causing it to fail
  b) plain http is used by the build system for downloading

There is no drawback here because the standard sound packs are included in
the Asterisk source tarball already.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: lantiq
Run tested: N/A

Description:
Hello Jiri,

As there will be another 17.01 release I suggest to port this back to 17.01 as well, to make sure that there will be chan-lantiq available from the build bots. If the build bot doesn't allow fetches during the building itself, then this could end up missing otherwise.

Kind regards,
Seb
