### PR TITLE
freeswitch: fix a memory leak with openssl 1.1.0

### DIFF
--- a/net/freeswitch/Makefile
+++ b/net/freeswitch/Makefile
@@ -26,7 +26,7 @@ FS_WITH_DEFAULT_HEAD:=77d0cfbf9e9a546b4eee23d9668cf44022f5d454
 FS_WITH_DEFAULT_HEAD_SHORT:=$(shell echo $(FS_WITH_DEFAULT_HEAD)|cut -b -7)
 PKG_SOURCE_VERSION:=$(if $(CONFIG_FS_WITH_LATEST_HEAD),$(shell git ls-remote $(PKG_SOURCE_URL) HEAD | cut -f1),$(FS_WITH_DEFAULT_HEAD))
 PKG_SOURCE_VERSION_SHORT:=$(shell echo $(PKG_SOURCE_VERSION)|cut -b -7)
-PKG_RELEASE:=$(PKG_SOURCE_VERSION_SHORT)
+PKG_RELEASE:=$(PKG_SOURCE_VERSION_SHORT)-1
 PKG_SOURCE:=$(PKG_DISTNAME)-$(FS_WITH_DEFAULT_HEAD_SHORT).tar.xz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
@@ -619,6 +619,10 @@ ifeq ($(CONFIG_ARCH),"mips")
 endif
 #endif
 
+ifeq ($(CONFIG_USE_GLIBC),y)
+	CONFIGURE_VARS+= \
+		LIBS="-L$(STAGING_DIR)/lib -Wl,--push-state,--as-needed -lbsd -Wl,--pop-state"
+endif
 
 define Build/Prepare
 	$(call Build/Prepare/Default)

--- a/net/freeswitch/patches/glibc/src-mod_event_multicast-mod_event_multicast_c.patch
+++ b/net/freeswitch/patches/glibc/src-mod_event_multicast-mod_event_multicast_c.patch
@@ -1,0 +1,37 @@
+From ae56352cfff570f1b7ac0748aa339bd7bf373794 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cote2004-github@yahoo.com>
+Date: Sat, 9 Jun 2018 19:02:41 -0300
+Subject: [PATCH] mod_event_multicast.c: fix memory leak
+
+Fixed two memory leaks with openssl 1.1.
+
+Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
+---
+ src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+index f591855a3e..fb952ce740 100644
+--- a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
++++ b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+@@ -324,7 +324,7 @@ static void event_handler(switch_event_t *event)
+ 									  &tmplen, (unsigned char *) MAGIC, (int) strlen((char *) MAGIC));
+ 					outlen += tmplen;
+ 					EVP_EncryptFinal(ctx, (unsigned char *) buf + SWITCH_UUID_FORMATTED_LENGTH + outlen, &tmplen);
+-					EVP_CIPHER_CTX_cleanup(ctx);
++					EVP_CIPHER_CTX_free(ctx);
+ #else
+ 					EVP_CIPHER_CTX_init(&ctx);
+ 					EVP_EncryptInit(&ctx, EVP_bf_cbc(), NULL, NULL);
+@@ -570,7 +570,7 @@ SWITCH_MODULE_RUNTIME_FUNCTION(mod_event_multicast_runtime)
+ 			EVP_DecryptInit(ctx, NULL, (unsigned char *) globals.psk, (unsigned char *) uuid_str);
+ 			EVP_DecryptUpdate(ctx, (unsigned char *) tmp, &outl, (unsigned char *) packet, (int) len);
+ 			EVP_DecryptFinal(ctx, (unsigned char *) tmp + outl, &tmplen);
+-			EVP_CIPHER_CTX_cleanup(ctx);
++			EVP_CIPHER_CTX_free(ctx);
+ #else
+ 			EVP_CIPHER_CTX_init(&ctx);
+ 			EVP_DecryptInit(&ctx, EVP_bf_cbc(), NULL, NULL);
+-- 
+2.16.4
+

--- a/net/freeswitch/patches/musl/src-mod_event_multicast-mod_event_multicast_c.patch
+++ b/net/freeswitch/patches/musl/src-mod_event_multicast-mod_event_multicast_c.patch
@@ -1,0 +1,37 @@
+From ae56352cfff570f1b7ac0748aa339bd7bf373794 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cote2004-github@yahoo.com>
+Date: Sat, 9 Jun 2018 19:02:41 -0300
+Subject: [PATCH] mod_event_multicast.c: fix memory leak
+
+Fixed two memory leaks with openssl 1.1.
+
+Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
+---
+ src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+index f591855a3e..fb952ce740 100644
+--- a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
++++ b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+@@ -324,7 +324,7 @@ static void event_handler(switch_event_t *event)
+ 									  &tmplen, (unsigned char *) MAGIC, (int) strlen((char *) MAGIC));
+ 					outlen += tmplen;
+ 					EVP_EncryptFinal(ctx, (unsigned char *) buf + SWITCH_UUID_FORMATTED_LENGTH + outlen, &tmplen);
+-					EVP_CIPHER_CTX_cleanup(ctx);
++					EVP_CIPHER_CTX_free(ctx);
+ #else
+ 					EVP_CIPHER_CTX_init(&ctx);
+ 					EVP_EncryptInit(&ctx, EVP_bf_cbc(), NULL, NULL);
+@@ -570,7 +570,7 @@ SWITCH_MODULE_RUNTIME_FUNCTION(mod_event_multicast_runtime)
+ 			EVP_DecryptInit(ctx, NULL, (unsigned char *) globals.psk, (unsigned char *) uuid_str);
+ 			EVP_DecryptUpdate(ctx, (unsigned char *) tmp, &outl, (unsigned char *) packet, (int) len);
+ 			EVP_DecryptFinal(ctx, (unsigned char *) tmp + outl, &tmplen);
+-			EVP_CIPHER_CTX_cleanup(ctx);
++			EVP_CIPHER_CTX_free(ctx);
+ #else
+ 			EVP_CIPHER_CTX_init(&ctx);
+ 			EVP_DecryptInit(&ctx, EVP_bf_cbc(), NULL, NULL);
+-- 
+2.16.4
+

--- a/net/freeswitch/patches/uClibc/src-mod_event_multicast-mod_event_multicast_c.patch
+++ b/net/freeswitch/patches/uClibc/src-mod_event_multicast-mod_event_multicast_c.patch
@@ -1,0 +1,37 @@
+From ae56352cfff570f1b7ac0748aa339bd7bf373794 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cote2004-github@yahoo.com>
+Date: Sat, 9 Jun 2018 19:02:41 -0300
+Subject: [PATCH] mod_event_multicast.c: fix memory leak
+
+Fixed two memory leaks with openssl 1.1.
+
+Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
+---
+ src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+index f591855a3e..fb952ce740 100644
+--- a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
++++ b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+@@ -324,7 +324,7 @@ static void event_handler(switch_event_t *event)
+ 									  &tmplen, (unsigned char *) MAGIC, (int) strlen((char *) MAGIC));
+ 					outlen += tmplen;
+ 					EVP_EncryptFinal(ctx, (unsigned char *) buf + SWITCH_UUID_FORMATTED_LENGTH + outlen, &tmplen);
+-					EVP_CIPHER_CTX_cleanup(ctx);
++					EVP_CIPHER_CTX_free(ctx);
+ #else
+ 					EVP_CIPHER_CTX_init(&ctx);
+ 					EVP_EncryptInit(&ctx, EVP_bf_cbc(), NULL, NULL);
+@@ -570,7 +570,7 @@ SWITCH_MODULE_RUNTIME_FUNCTION(mod_event_multicast_runtime)
+ 			EVP_DecryptInit(ctx, NULL, (unsigned char *) globals.psk, (unsigned char *) uuid_str);
+ 			EVP_DecryptUpdate(ctx, (unsigned char *) tmp, &outl, (unsigned char *) packet, (int) len);
+ 			EVP_DecryptFinal(ctx, (unsigned char *) tmp + outl, &tmplen);
+-			EVP_CIPHER_CTX_cleanup(ctx);
++			EVP_CIPHER_CTX_free(ctx);
+ #else
+ 			EVP_CIPHER_CTX_init(&ctx);
+ 			EVP_DecryptInit(&ctx, EVP_bf_cbc(), NULL, NULL);
+-- 
+2.16.4
+


### PR DESCRIPTION
Maintainer: Mazi Lo (I couldn't find his username)
Compile tested: brcm47xx, openwrt master
Run tested: none

Description:
Fixed a memory leak when compiled with openssl 1.1.0.  It should be very simple to see this.  CTX is allocated, but it is not being freed, but only reset (cleanup is defined to reset in openssl 1.1.0).  I caught this while backporting openssl 1.1.0 support to v. 1.6.20, and submitted the patch upstream.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
