### PR TITLE
freeswitch-stable: fix incompatible pointer type

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PRG_NAME:=freeswitch
 PKG_NAME:=$(PRG_NAME)-stable
 PKG_VERSION:=1.6.20
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=$(PRG_NAME)-$(PKG_VERSION).tar.xz

--- a/net/freeswitch-stable/patches/350-fix-pcre-pointer-type.patch
+++ b/net/freeswitch-stable/patches/350-fix-pcre-pointer-type.patch
@@ -1,0 +1,11 @@
+--- a/src/switch_regex.c
++++ b/src/switch_regex.c
+@@ -37,7 +37,7 @@ SWITCH_DECLARE(switch_regex_t *) switch_
+ 													  int options, const char **errorptr, int *erroroffset, const unsigned char *tables)
+ {
+ 
+-	return pcre_compile(pattern, options, errorptr, erroroffset, tables);
++	return (switch_regex_t *)pcre_compile(pattern, options, errorptr, erroroffset, tables);
+ 
+ }
+ 


### PR DESCRIPTION
Currently compiles fail with:

  CC       libfreeswitch_la-switch_regex.lo
src/switch_regex.c: In function 'switch_regex_compile':
src/switch_regex.c:40:9: error: return from incompatible pointer type [-Werror=incompatible-pointer-types]
  return pcre_compile(pattern, options, errorptr, erroroffset, tables);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
Makefile:2100: recipe for target 'libfreeswitch_la-switch_regex.lo' failed
make[5]: *** [libfreeswitch_la-switch_regex.lo] Error 1

Fix cherry-picked from upstream.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
