### PR TITLE
(for lede-17.01) asterisk-13.x: patch AST-2018-008

### DIFF
--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk13
 PKG_VERSION:=13.19.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases/

--- a/net/asterisk-13.x/patches/060-AST-2018-008-13.diff
+++ b/net/asterisk-13.x/patches/060-AST-2018-008-13.diff
@@ -1,0 +1,101 @@
+From 4eeb16d1a316aa3d6f5710a2f6beffb0fecb6121 Mon Sep 17 00:00:00 2001
+From: Richard Mudgett <rmudgett@digium.com>
+Date: Mon, 30 Apr 2018 17:38:58 -0500
+Subject: [PATCH] AST-2018-008: Fix enumeration of endpoints from ACL rejected addresses.
+
+When endpoint specific ACL rules block a SIP request they respond with a
+403 forbidden.  However, if an endpoint is not identified then a 401
+unauthorized response is sent.  This vulnerability just discloses which
+requests hit a defined endpoint.  The ACL rules cannot be bypassed to gain
+access to the disclosed endpoints.
+
+* Made endpoint specific ACL rules now respond with a 401 unauthorized
+which is the same as if an endpoint were not identified.  The fix is
+accomplished by replacing the found endpoint with the artificial endpoint
+which always fails authentication.
+
+ASTERISK-27818
+
+Change-Id: Icb275a54ff8e2df6c671a6d9bda37b5d732b3b32
+---
+
+diff --git a/res/res_pjsip/pjsip_distributor.c b/res/res_pjsip/pjsip_distributor.c
+index e056b60..19266df 100644
+--- a/res/res_pjsip/pjsip_distributor.c
++++ b/res/res_pjsip/pjsip_distributor.c
+@@ -666,6 +666,26 @@
+ 	ao2_unlock(unid);
+ }
+ 
++static int apply_endpoint_acl(pjsip_rx_data *rdata, struct ast_sip_endpoint *endpoint);
++static int apply_endpoint_contact_acl(pjsip_rx_data *rdata, struct ast_sip_endpoint *endpoint);
++
++static void apply_acls(pjsip_rx_data *rdata)
++{
++	struct ast_sip_endpoint *endpoint;
++
++	/* Is the endpoint allowed with the source or contact address? */
++	endpoint = rdata->endpt_info.mod_data[endpoint_mod.id];
++	if (endpoint != artificial_endpoint
++		&& (apply_endpoint_acl(rdata, endpoint)
++			|| apply_endpoint_contact_acl(rdata, endpoint))) {
++		ast_debug(1, "Endpoint '%s' not allowed by ACL\n",
++			ast_sorcery_object_get_id(endpoint));
++
++		/* Replace the rdata endpoint with the artificial endpoint. */
++		ao2_replace(rdata->endpt_info.mod_data[endpoint_mod.id], artificial_endpoint);
++	}
++}
++
+ static pj_bool_t endpoint_lookup(pjsip_rx_data *rdata)
+ {
+ 	struct ast_sip_endpoint *endpoint;
+@@ -684,6 +704,7 @@
+ 			ao2_unlink(unidentified_requests, unid);
+ 			ao2_ref(unid, -1);
+ 		}
++		apply_acls(rdata);
+ 		return PJ_FALSE;
+ 	}
+ 
+@@ -743,6 +764,8 @@
+ 			ast_sip_report_invalid_endpoint(name, rdata);
+ 		}
+ 	}
++
++	apply_acls(rdata);
+ 	return PJ_FALSE;
+ }
+ 
+@@ -826,16 +849,11 @@
+ 
+ 	ast_assert(endpoint != NULL);
+ 
+-	if (endpoint!=artificial_endpoint) {
+-		if (apply_endpoint_acl(rdata, endpoint) || apply_endpoint_contact_acl(rdata, endpoint)) {
+-			if (!is_ack) {
+-				pjsip_endpt_respond_stateless(ast_sip_get_pjsip_endpoint(), rdata, 403, NULL, NULL, NULL);
+-			}
+-			return PJ_TRUE;
+-		}
++	if (is_ack) {
++		return PJ_FALSE;
+ 	}
+ 
+-	if (!is_ack && ast_sip_requires_authentication(endpoint, rdata)) {
++	if (ast_sip_requires_authentication(endpoint, rdata)) {
+ 		pjsip_tx_data *tdata;
+ 		struct unidentified_request *unid;
+ 
+@@ -871,6 +889,10 @@
+ 			return PJ_TRUE;
+ 		}
+ 		pjsip_tx_data_dec_ref(tdata);
++	} else if (endpoint == artificial_endpoint) {
++		/* Uh. Oh.  The artificial endpoint couldn't challenge so block the request. */
++		pjsip_endpt_respond_stateless(ast_sip_get_pjsip_endpoint(), rdata, 500, NULL, NULL, NULL);
++		return PJ_TRUE;
+ 	}
+ 
+ 	return PJ_FALSE;
+


### PR DESCRIPTION
Patch from upstream for AST-2018-008.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: ar71xx
Run tested: N/A

