### PR TITLE
asterisk: fix iconv related build issue

### DIFF
--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk13
 PKG_VERSION:=13.20.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases
@@ -316,6 +316,8 @@ PKG_CONFIG_DEPENDS:= \
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
+# Needed for res-config-mysql and func-iconv to find iconv
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/asterisk13/install/module
 	$(INSTALL_DIR) $(1)/usr/lib/asterisk/modules
@@ -355,7 +357,7 @@ define BuildAsterisk13Module
   define Package/asterisk13-$(1)
   $$(call Package/asterisk13/Default)
     TITLE:=$(2) support
-    DEPENDS:= asterisk13 $(patsubst +%,+PACKAGE_asterisk13-$(1):%,$(4))
+    DEPENDS:= asterisk13 $(patsubst +%,+PACKAGE_asterisk13-$(1):%,$(4)) $(9)
     ifneq ($$(CONFIG_PACKAGE_asterisk13-$(1)),)
     AST_ENABLE+=$(6)
     endif
@@ -710,7 +712,7 @@ endef
 $(eval $(call BuildPackage,asterisk13))
 $(eval $(call BuildPackage,asterisk13-sounds))
 
-################################
+#######################################
 # AST modules
 # Params:
 # 1 - Package subname
@@ -721,8 +723,9 @@ $(eval $(call BuildPackage,asterisk13-sounds))
 # 6 - module files
 # 7 - sound files
 # 8 - binary files
-################################
-#$(eval $(call BuildAsterisk13Module,subname,title,module description,module dependencies,conf files,module files,sound files,binary files))
+# 9 - complex depends (passed on as is)
+#######################################
+#$(eval $(call BuildAsterisk13Module,subname,title,module description,module dependencies,conf files,module files,sound files,binary files,complex depends))
 
 $(eval $(call BuildAsterisk13Module,app-adsiprog,ADSI programming,program Asterisk ADSI scripts into phone,+$(PKG_NAME)-res-adsi,adsi.conf asterisk.adsi telcordia-1.adsi,app_adsiprog,,))
 $(eval $(call BuildAsterisk13Module,app-agent-pool,Call center agent pool,call center agent pool,,agents.conf,app_agent_pool,,))
@@ -863,7 +866,7 @@ $(eval $(call BuildAsterisk13Module,func-global,Global variable,global variable 
 $(eval $(call BuildAsterisk13Module,func-groupcount,Group count,for counting number of channels in the specified group,,,func_groupcount,,))
 $(eval $(call BuildAsterisk13Module,func-hangupcause,HANGUPCAUSE related functions,functions related to retreiving per-channel hangupcause information,,,func_hangupcause,,))
 $(eval $(call BuildAsterisk13Module,func-holdintercept,Hold interception dialplan function,function that intercepts HOLD frames from channels and raises events,,,func_holdintercept,,))
-$(eval $(call BuildAsterisk13Module,func-iconv,Charset conversion,charset conversion,@!USE_UCLIBC,,func_iconv,,))
+$(eval $(call BuildAsterisk13Module,func-iconv,Charset conversion,charset conversion,,,func_iconv,,,$(ICONV_DEPENDS)))
 $(eval $(call BuildAsterisk13Module,func-jitterbuffer,Jitter buffer for read side of channel,put a jitterbuffer on the read side of a channel,,,func_jitterbuffer,,))
 $(eval $(call BuildAsterisk13Module,func-lock,Dialplan mutexes,dialplan mutexes,,,func_lock,,))
 $(eval $(call BuildAsterisk13Module,func-math,Math functions,Math functions,,,func_math,,))

--- a/net/asterisk-15.x/Makefile
+++ b/net/asterisk-15.x/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk15
 PKG_VERSION:=15.3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases
@@ -321,6 +321,8 @@ PKG_CONFIG_DEPENDS:= \
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
+# Needed for res-config-mysql and func-iconv to find iconv
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/asterisk15/install/module
 	$(INSTALL_DIR) $(1)/usr/lib/asterisk/modules
@@ -360,7 +362,7 @@ define BuildAsterisk15Module
   define Package/asterisk15-$(1)
   $$(call Package/asterisk15/Default)
     TITLE:=$(2) support
-    DEPENDS:= asterisk15 $(patsubst +%,+PACKAGE_asterisk15-$(1):%,$(4))
+    DEPENDS:= asterisk15 $(patsubst +%,+PACKAGE_asterisk15-$(1):%,$(4)) $(9)
     ifneq ($$(CONFIG_PACKAGE_asterisk15-$(1)),)
     AST_ENABLE+=$(6)
     endif
@@ -724,7 +726,7 @@ endef
 $(eval $(call BuildPackage,asterisk15))
 $(eval $(call BuildPackage,asterisk15-sounds))
 
-################################
+#######################################
 # AST modules
 # Params:
 # 1 - Package subname
@@ -735,8 +737,9 @@ $(eval $(call BuildPackage,asterisk15-sounds))
 # 6 - module files
 # 7 - sound files
 # 8 - binary files
-################################
-#$(eval $(call BuildAsterisk15Module,subname,title,module description,module dependencies,conf files,module files,sound files,binary files))
+# 9 - complex depends (passed on as is)
+#######################################
+#$(eval $(call BuildAsterisk15Module,subname,title,module description,module dependencies,conf files,module files,sound files,binary files,complex depends))
 
 $(eval $(call BuildAsterisk15Module,app-adsiprog,ADSI programming,program Asterisk ADSI scripts into phone,+$(PKG_NAME)-res-adsi,adsi.conf asterisk.adsi telcordia-1.adsi,app_adsiprog,,))
 $(eval $(call BuildAsterisk15Module,app-agent-pool,Call center agent pool,call center agent pool,,agents.conf,app_agent_pool,,))
@@ -881,7 +884,7 @@ $(eval $(call BuildAsterisk15Module,func-global,Global variable,global variable 
 $(eval $(call BuildAsterisk15Module,func-groupcount,Group count,for counting number of channels in the specified group,,,func_groupcount,,))
 $(eval $(call BuildAsterisk15Module,func-hangupcause,HANGUPCAUSE related functions,functions related to retreiving per-channel hangupcause information,,,func_hangupcause,,))
 $(eval $(call BuildAsterisk15Module,func-holdintercept,Hold interception dialplan function,function that intercepts HOLD frames from channels and raises events,,,func_holdintercept,,))
-$(eval $(call BuildAsterisk15Module,func-iconv,Charset conversion,charset conversion,@!USE_UCLIBC,,func_iconv,,))
+$(eval $(call BuildAsterisk15Module,func-iconv,Charset conversion,charset conversion,,,func_iconv,,,$(ICONV_DEPENDS)))
 $(eval $(call BuildAsterisk15Module,func-jitterbuffer,Jitter buffer for read side of channel,put a jitterbuffer on the read side of a channel,,,func_jitterbuffer,,))
 $(eval $(call BuildAsterisk15Module,func-lock,Dialplan mutexes,dialplan mutexes,,,func_lock,,))
 $(eval $(call BuildAsterisk15Module,func-math,Math functions,Math functions,,,func_math,,))


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: archs
Run tested: don't have archs hardware

Description:
Hello Jiri,

I'm cleaning up after the fallout from the libmariadb 10.2 upgrade. Asterisk is affected and needs a bit of tweaking for the uclibc compiles.

Kind regards,
Seb