### PR TITLE
freeswitch-stable: fix iconv related issues

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PRG_NAME:=freeswitch
 PKG_NAME:=$(PRG_NAME)-stable
 PKG_VERSION:=1.6.20
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=$(PRG_NAME)-$(PKG_VERSION).tar.xz
@@ -239,6 +239,13 @@ PKG_CONFIG_DEPENDS:= \
 
 include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
+# iconv support
+include $(INCLUDE_DIR)/nls.mk
+
+# mod_gsmopen can't detect if iconv's inbuf is const
+ifeq ($(ICONV_FULL),1)
+TARGET_CFLAGS+=-DFS_STABLE_ICONV_INBUF_CONST
+endif
 
 FS_STABLE_PERL_FEED:=$(TOPDIR)/feeds/packages/lang/perl
 
@@ -250,14 +257,6 @@ FS_STABLE_PERL_LIBS:=$(shell grep "^libs=" \
 			sed "s/^libs=//;s/'//g")
 
 FS_STABLE_PYTHON_SITE_DIR:=$(FS_STABLE_LIB_DIR)/python$(PYTHON_VERSION)/site-packages
-
-# musl and glibc include their own iconv, but uclibc does not
-ifneq ($(CONFIG_USE_UCLIBC),)
-TARGET_CPPFLAGS+= \
-	-I$(STAGING_DIR)/usr/lib/libiconv-full/include
-TARGET_LDFLAGS += \
-	-L$(STAGING_DIR)/usr/lib/libiconv-full/lib
-endif
 
 define Download/files
 define Download/$(1)
@@ -361,11 +360,11 @@ $(call Package/$(PKG_NAME)/Default)
   USERID:=$(PRG_NAME)=372:$(PRG_NAME)=372
   DEPENDS:= \
 	  $(CXX_DEPENDS) \
+	  $(ICONV_DEPENDS) \
 	  +FS_STABLE_WITH_FREETYPE:libfreetype \
 	  +FS_STABLE_WITH_ODBC:unixodbc \
 	  +FS_STABLE_WITH_PGSQL:libpq \
 	  +FS_STABLE_WITH_PNG:libpng \
-	  +USE_UCLIBC:libiconv-full \
 	  +libcurl \
 	  +libedit \
 	  +libopenssl \

--- a/net/freeswitch-stable/patches/270-fix-uclibc-iconv-in-gsmopen.patch
+++ b/net/freeswitch-stable/patches/270-fix-uclibc-iconv-in-gsmopen.patch
@@ -1,62 +1,67 @@
 --- a/src/mod/endpoints/mod_gsmopen/gsmopen_protocol.cpp
 +++ b/src/mod/endpoints/mod_gsmopen/gsmopen_protocol.cpp
-@@ -2521,11 +2521,11 @@ int ucs2_to_utf8(private_t *tech_pvt, ch
+@@ -104,6 +104,12 @@ int gettimeofday(struct timeval *tv, str
+ /***************/
+ #endif /* WIN32 */
+ 
++#if defined(FS_STABLE_ICONV_INBUF_CONST)
++#define ICONV_INBUF_TYPE const char **
++#else
++#define ICONV_INBUF_TYPE char **
++#endif
++
+ int gsmopen_serial_init(private_t *tech_pvt, int controldevice_speed)
+ {
+ 	if (!tech_pvt)
+@@ -2521,11 +2527,7 @@ int ucs2_to_utf8(private_t *tech_pvt, ch
  	DEBUGA_GSMOPEN("1 ciao in=%s, inleft=%d, out=%s, outleft=%d, converted=%s, utf8_out=%s\n",
  				   GSMOPEN_P_LOG, inbuf, (int) inbytesleft, outbuf, (int) outbytesleft, converted, utf8_out);
  
 -#ifdef WIN32
-+#ifdef __UCLIBC__ // libiconv-full needs this conversion
- 	iconv_res = iconv(iconv_format, (const char **) &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-	iconv_res = iconv(iconv_format, (const char **) &inbuf, &inbytesleft, &outbuf, &outbytesleft);
 -#else // WIN32
-+#else
- 	iconv_res = iconv(iconv_format, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-	iconv_res = iconv(iconv_format, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
 -#endif // WIN32
-+#endif
++	iconv_res = iconv(iconv_format, (ICONV_INBUF_TYPE)&inbuf, &inbytesleft, &outbuf, &outbytesleft);
  	if (iconv_res == (size_t) -1) {
  		DEBUGA_GSMOPEN("2 ciao in=%s, inleft=%d, out=%s, outleft=%d, converted=%s, utf8_out=%s\n",
  					   GSMOPEN_P_LOG, inbuf, (int) inbytesleft, outbuf, (int) outbytesleft, converted, utf8_out);
-@@ -2560,11 +2560,11 @@ int utf8_to_iso_8859_1(private_t *tech_p
+@@ -2560,11 +2562,7 @@ int utf8_to_iso_8859_1(private_t *tech_p
  
  	DEBUGA_GSMOPEN("in=%s, inleft=%d, out=%s, outleft=%d, utf8_in=%s, iso_8859_1_out=%s\n",
  				   GSMOPEN_P_LOG, inbuf, (int) inbytesleft, outbuf, (int) outbytesleft, utf8_in, iso_8859_1_out);
 -#ifdef WIN32
-+#ifdef __UCLIBC__
- 	iconv_res = iconv(iconv_format, (const char **) &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-	iconv_res = iconv(iconv_format, (const char **) &inbuf, &inbytesleft, &outbuf, &outbytesleft);
 -#else // WIN32
-+#else
- 	iconv_res = iconv(iconv_format, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-	iconv_res = iconv(iconv_format, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
 -#endif // WIN32
-+#endif
++	iconv_res = iconv(iconv_format, (ICONV_INBUF_TYPE)&inbuf, &inbytesleft, &outbuf, &outbytesleft);
  	if (iconv_res == (size_t) -1) {
  		DEBUGA_GSMOPEN("cannot translate in iso_8859_1 error: %s (errno: %d)\n", GSMOPEN_P_LOG, strerror(errno), errno);
  		return -1;
-@@ -2597,11 +2597,11 @@ int iso_8859_1_to_utf8(private_t *tech_p
+@@ -2597,11 +2595,7 @@ int iso_8859_1_to_utf8(private_t *tech_p
  	}
  
  	inbytesleft = strlen(iso_8859_1_in) * 2;
 -#ifdef WIN32
-+#ifdef __UCLIBC__
- 	iconv_res = iconv(iconv_format, (const char **) &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-	iconv_res = iconv(iconv_format, (const char **) &inbuf, &inbytesleft, &outbuf, &outbytesleft);
 -#else // WIN32
-+#else
- 	iconv_res = iconv(iconv_format, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-	iconv_res = iconv(iconv_format, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
 -#endif // WIN32
-+#endif
++	iconv_res = iconv(iconv_format, (ICONV_INBUF_TYPE)&inbuf, &inbytesleft, &outbuf, &outbytesleft);
  	if (iconv_res == (size_t) -1) {
  		DEBUGA_GSMOPEN("ciao in=%s, inleft=%d, out=%s, outleft=%d, utf8_out=%s\n",
  					   GSMOPEN_P_LOG, inbuf, (int) inbytesleft, outbuf, (int) outbytesleft, utf8_out);
-@@ -2642,11 +2642,11 @@ int utf8_to_ucs2(private_t *tech_pvt, ch
+@@ -2642,11 +2636,7 @@ int utf8_to_ucs2(private_t *tech_pvt, ch
  
  	DEBUGA_GSMOPEN("in=%s, inleft=%d, out=%s, outleft=%d, utf8_in=%s, converted=%s\n",
  				   GSMOPEN_P_LOG, inbuf, (int) inbytesleft, outbuf, (int) outbytesleft, utf8_in, converted);
 -#ifdef WIN32
-+#ifdef __UCLIBC__
- 	iconv_res = iconv(iconv_format, (const char **) &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-	iconv_res = iconv(iconv_format, (const char **) &inbuf, &inbytesleft, &outbuf, &outbytesleft);
 -#else // WIN32
-+#else
- 	iconv_res = iconv(iconv_format, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+-	iconv_res = iconv(iconv_format, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
 -#endif // WIN32
-+#endif
++	iconv_res = iconv(iconv_format, (ICONV_INBUF_TYPE)&inbuf, &inbytesleft, &outbuf, &outbytesleft);
  	if (iconv_res == (size_t) -1) {
  		ERRORA("error: %s %d\n", GSMOPEN_P_LOG, strerror(errno), errno);
  		return -1;

--- a/net/freeswitch-stable/patches/360-fix-APR_TRY_COMPILE_NO_WARNING.patch
+++ b/net/freeswitch-stable/patches/360-fix-APR_TRY_COMPILE_NO_WARNING.patch
@@ -1,0 +1,50 @@
+--- a/libs/apr-util/build/apr_common.m4
++++ b/libs/apr-util/build/apr_common.m4
+@@ -493,13 +493,15 @@ AC_DEFUN([APR_TRY_COMPILE_NO_WARNING],
+  if test "$ac_cv_prog_gcc" = "yes"; then 
+    CFLAGS="$CFLAGS -Werror"
+  fi
+- AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+-  [#include "confdefs.h"
+-  ]
+-  [[$1]]
+-  [int main(int argc, const char *const *argv) {]
+-  [[$2]]
+-  [   return 0; }]])],
++ AC_COMPILE_IFELSE(
++  [AC_LANG_SOURCE(
++   [#include "confdefs.h"
++   ]
++   [[$1]]
++   [int main(int argc, const char *const *argv) {]
++   [[$2]]
++   [   return 0; }]
++  )],
+   [$3], [$4])
+  CFLAGS=$apr_save_CFLAGS
+ ])
+--- a/libs/apr/build/apr_common.m4
++++ b/libs/apr/build/apr_common.m4
+@@ -493,13 +493,15 @@ AC_DEFUN([APR_TRY_COMPILE_NO_WARNING],
+  if test "$ac_cv_prog_gcc" = "yes"; then 
+    CFLAGS="$CFLAGS -Werror"
+  fi
+- AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+-  [#include "confdefs.h"
+-  ]
+-  [[$1]]
+-  [int main(int argc, const char *const *argv) {]
+-  [[$2]]
+-  [   return 0; }]])],
++ AC_COMPILE_IFELSE(
++  [AC_LANG_SOURCE(
++   [#include "confdefs.h"
++   ]
++   [[$1]]
++   [int main(int argc, const char *const *argv) {]
++   [[$2]]
++   [   return 0; }]
++  )],
+   [$3], [$4])
+  CFLAGS=$apr_save_CFLAGS
+ ])


### PR DESCRIPTION
Maintainer: me
Compile tested: ar71xx + archs
Run tested: not yet

Description:
Fix apr m4 macro plus replace iconv hack in FS with nls.mk. 