### PR TITLE
freeswitch-stable: fix sed script

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -910,7 +910,7 @@ define Build/Prepare
 	echo '#codecs/mod_yuv' >> $(PKG_BUILD_DIR)/modules.conf
 	echo '#event_handlers/mod_event_test' >> $(PKG_BUILD_DIR)/modules.conf
 
-	$(SED) 's|$(FS_STABLE_ANCHOR)|APR_SETVAR(LDFLAGS,$(FS_STABLE_APR_LIBS) $(TARGET_LDFLAGS))|' \
+	$(SED) 's|$(FS_STABLE_ANCHOR)|APR_SETVAR(LDFLAGS,[$(FS_STABLE_APR_LIBS) $(TARGET_LDFLAGS)])|' \
 		$(PKG_BUILD_DIR)/libs/unimrcp/build/acmacros/apr.m4
 endef
 


### PR DESCRIPTION
The sed script used on libs/unimrcp is used to set LDFLAGS using
APR_SETVAR. Since nls.mk is included there are LDFLAGS with commas. But
the macro APR_SETVAR uses commas to separate arguments, so now the
LDFLAGS are only getting partially copied.

Solve this by surrounding LDFLAGS with brackets ([...]).

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: ar71xx, archs
Run tested: not yet

Description:
Fix compile failure caused by sed script.