### PR TITLE
freeswitch-stable: fix memory leak in mod_event_multicast

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PRG_NAME:=freeswitch
 PKG_NAME:=$(PRG_NAME)-stable
 PKG_VERSION:=1.8.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE_PROTO:=git

--- a/net/freeswitch-stable/patches/300-fix-memory-leak-in-mod_event_multicast.patch
+++ b/net/freeswitch-stable/patches/300-fix-memory-leak-in-mod_event_multicast.patch
@@ -1,0 +1,37 @@
+From ae56352cfff570f1b7ac0748aa339bd7bf373794 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cote2004-github@yahoo.com>
+Date: Sat, 9 Jun 2018 19:02:41 -0300
+Subject: [PATCH] mod_event_multicast.c: fix memory leak
+
+Fixed two memory leaks with openssl 1.1.
+
+Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
+---
+ src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+index f591855a3e..fb952ce740 100644
+--- a/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
++++ b/src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c
+@@ -324,7 +324,7 @@ static void event_handler(switch_event_t *event)
+ 									  &tmplen, (unsigned char *) MAGIC, (int) strlen((char *) MAGIC));
+ 					outlen += tmplen;
+ 					EVP_EncryptFinal(ctx, (unsigned char *) buf + SWITCH_UUID_FORMATTED_LENGTH + outlen, &tmplen);
+-					EVP_CIPHER_CTX_cleanup(ctx);
++					EVP_CIPHER_CTX_free(ctx);
+ #else
+ 					EVP_CIPHER_CTX_init(&ctx);
+ 					EVP_EncryptInit(&ctx, EVP_bf_cbc(), NULL, NULL);
+@@ -570,7 +570,7 @@ SWITCH_MODULE_RUNTIME_FUNCTION(mod_event_multicast_runtime)
+ 			EVP_DecryptInit(ctx, NULL, (unsigned char *) globals.psk, (unsigned char *) uuid_str);
+ 			EVP_DecryptUpdate(ctx, (unsigned char *) tmp, &outl, (unsigned char *) packet, (int) len);
+ 			EVP_DecryptFinal(ctx, (unsigned char *) tmp + outl, &tmplen);
+-			EVP_CIPHER_CTX_cleanup(ctx);
++			EVP_CIPHER_CTX_free(ctx);
+ #else
+ 			EVP_CIPHER_CTX_init(&ctx);
+ 			EVP_DecryptInit(&ctx, EVP_bf_cbc(), NULL, NULL);
+-- 
+2.16.4
+


### PR DESCRIPTION
Maintainer: @micmac1 
Compile tested: ramips/brcm47xx, openwrt master
Run tested: none

Description:
Applied a patch, submitted upstream at https://freeswitch.org/jira/browse/FS-11193
that fixes two memory leaks in `mod_event_multicast.c`.

In `src/mod/event_handlers/mod_event_multicast/mod_event_multicast.c`, `event_handler()` function, when encrypting data using openssl 1.1.0, the context ctx is allocated by `EVP_CIPHER_CTX_new()`, then data is encrypted, and at the end, EVP_CIPHER_CTX_cleanup is called. This function resets the context so that it can be used again, but ctx is not freed. The correct call would be to `EVP_CIPHER_CTX_free()`, which frees the memory.
The same thing happens in the decryption function: `ctx` is allocated, but never freed. 

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>