### PR TITLE
freeswitch-stable: fix garbled output in fs_cli

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PRG_NAME:=freeswitch
 PKG_NAME:=$(PRG_NAME)-stable
 PKG_VERSION:=1.8.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE_PROTO:=git

--- a/net/freeswitch-stable/patches/020-fix-fs_cli-typo.patch
+++ b/net/freeswitch-stable/patches/020-fix-fs_cli-typo.patch
@@ -1,0 +1,27 @@
+commit f76230b16ed6e28847a00e1fa4edd46d19a52251
+Author: Sebastian Kemper <sebastian_ml@gmx.net>
+Date:   Thu Aug 2 23:38:43 2018 +0200
+
+    FS-11309: [fs_cli] fix typo
+    
+    Commit bc3e1c9e7de1855eec454bba467fd2586e5e251b introduced a typo that
+    results in EL_REFRESH never being used, even if available. This can
+    cause the screen to garble.
+    
+    This fixes the typo.
+    
+    Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
+
+diff --git a/libs/esl/fs_cli.c b/libs/esl/fs_cli.c
+index b4a5838175..d52422dd4c 100644
+--- a/libs/esl/fs_cli.c
++++ b/libs/esl/fs_cli.c
+@@ -674,7 +674,7 @@ static void redisplay(void)
+ 	esl_mutex_lock(MUTEX);
+ 	{
+ #ifdef HAVE_LIBEDIT
+-#ifdef XHAVE_DECL_EL_REFRESH
++#ifdef HAVE_DECL_EL_REFRESH
+ #ifdef HAVE_EL_WSET
+ 		/* Current libedit versions don't implement EL_REFRESH in eln.c so
+ 		 * use the wide version instead. */


### PR DESCRIPTION
Fix a typo. Sent to upstream via Jira FS-11309.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: ar71xx
Run tested: ar71xx

Description:
Fix fs_cli issue.