### PR TITLE
freeswitch-stable: add SIGKILL to init script

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PRG_NAME:=freeswitch
 PKG_NAME:=$(PRG_NAME)-stable
 PKG_VERSION:=1.8.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE_PROTO:=git

--- a/net/freeswitch-stable/files/freeswitch.init
+++ b/net/freeswitch-stable/files/freeswitch.init
@@ -1,5 +1,5 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2017 OpenWrt.org
+# Copyright (C) 2017 - 2018 OpenWrt.org
 
 START=90
 
@@ -122,6 +122,15 @@ stop_service() {
     [ $retval -eq 0 ] && kill $mypid 2>/dev/null
     timeout=$(($timeout-10))
   done
+
+  [ $retval -ne 1 ] && {
+    $LOGGER Application seems to hang
+    $LOGGER Sending SIGKILL
+    kill -SIGKILL $mypid 2>/dev/null
+    sleep 3
+    pgrep $FS | grep -w $mypid &>/dev/null
+    retval=$?
+  }
 
   [ $retval -ne 1 ] && {
     $LOGGER Failed to stop $FS


### PR DESCRIPTION
Sometimes freeswitch doesn't exit after receiving the SIGTERM signal.
This can be reproduced by sending SIGTERM to a freeswitch instance which
is initializing (which can take quite some time).

Instead of just giving up and exiting - leaving a hung freeswitch
process on the system - this commit adds some lines to the init script
that send SIGKILL to freeswitch in case the attempt to terminate it with
SIGTERM fails.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: ar71xx
Run tested: ar71xx

Description:
Improve stop procedure in init script.