### PR TITLE
kamailio-4.x: add fix for CVE-2018-14767

### DIFF
--- a/net/kamailio-4.x/Makefile
+++ b/net/kamailio-4.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio4
 PKG_VERSION:=4.4.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://www.kamailio.org/pub/kamailio/$(PKG_VERSION)/src/
 PKG_SOURCE:=kamailio-$(PKG_VERSION)$(PKG_VARIANT)_src.tar.gz

--- a/net/kamailio-4.x/patches/130-CVE-2018-14767.patch
+++ b/net/kamailio-4.x/patches/130-CVE-2018-14767.patch
@@ -1,0 +1,28 @@
+commit 281a6c6b6eaaf30058b603325e8ded20b99e1456
+Author: Henning Westerholt <hw@kamailio.org>
+Date:   Mon May 7 09:36:53 2018 +0200
+
+    core: improve to header check guards, str consists of length and pointer
+
+diff --git a/src/core/msg_translator.c b/src/core/msg_translator.c
+index 22122768a..4dd648e87 100644
+--- a/msg_translator.c
++++ b/msg_translator.c
+@@ -2369,7 +2369,7 @@ char * build_res_buf_from_sip_req( unsigned int code, str *text ,str *new_tag,
+ 			case HDR_TO_T:
+ 				if (new_tag && new_tag->len) {
+ 					to_tag=get_to(msg)->tag_value;
+-					if ( to_tag.len || to_tag.s )
++					if ( to_tag.len && to_tag.s )
+ 						len+=new_tag->len-to_tag.len;
+ 					else
+ 						len+=new_tag->len+TOTAG_TOKEN_LEN/*";tag="*/;
+@@ -2497,7 +2497,7 @@ char * build_res_buf_from_sip_req( unsigned int code, str *text ,str *new_tag,
+ 				break;
+ 			case HDR_TO_T:
+ 				if (new_tag && new_tag->len){
+-					if (to_tag.s ) { /* replacement */
++					if (to_tag.len && to_tag.s) { /* replacement */
+ 						/* before to-tag */
+ 						append_str( p, hdr->name.s, to_tag.s-hdr->name.s);
+ 						/* to tag replacement */


### PR DESCRIPTION
CVE-2018-14767: "In Kamailio before 5.0.7 and 5.1.x before 5.1.4, a
crafted SIP message with a double "To" header and an empty "To" tag
causes a segmentation fault and crash. The reason is missing input
validation in the "build_res_buf_from_sip_req" core function. This could
result in denial of service and potentially the execution of arbitrary
code."

Patch from upstream. Path to msg_translator.c amended.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: ar71xx
Run tested: N/A

Description:
Same patch, only had to fix the path to the source file.

Kind regards,
Seb