### PR TITLE
(master) kamailio-5.x: add fix for CVE-2018-16657

### DIFF
--- a/net/kamailio-5.x/Makefile
+++ b/net/kamailio-5.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio5
 PKG_VERSION:=5.1.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://www.kamailio.org/pub/kamailio/$(PKG_VERSION)/src
 PKG_SOURCE:=kamailio-$(PKG_VERSION)$(PKG_VARIANT)_src.tar.gz

--- a/net/kamailio-5.x/patches/141-CVE-2018-16657.patch
+++ b/net/kamailio-5.x/patches/141-CVE-2018-16657.patch
@@ -1,0 +1,46 @@
+commit d67b2f9874ca23bd69f18df71b8f53b1b6151f6d
+Author: Henning Westerholt <hw@kamailio.org>
+Date:   Sun Jun 3 20:59:32 2018 +0200
+
+    core: improve header safe guards for Via handling
+    
+    (cherry picked from commit ad68e402ece8089f133c10de6ce319f9e28c0692)
+
+diff --git a/src/core/crc.c b/src/core/crc.c
+index 462846324..23b2876ec 100644
+--- a/src/core/crc.c
++++ b/src/core/crc.c
+@@ -231,6 +231,8 @@ void crcitt_string_array( char *dst, str src[], int size )
+ 	ccitt = 0xFFFF;
+ 	str_len=CRC16_LEN;
+ 	for (i=0; i<size; i++ ) {
++		/* invalid str with positive length and null char pointer */
++		if( unlikely(src[i].s==NULL)) break;
+ 		c=src[i].s;
+ 		len=src[i].len;
+ 		while(len) {
+diff --git a/src/core/msg_translator.c b/src/core/msg_translator.c
+index 201e3a5e1..58978f958 100644
+--- a/src/core/msg_translator.c
++++ b/src/core/msg_translator.c
+@@ -168,12 +168,17 @@ static int check_via_address(struct ip_addr* ip, str *name,
+ 						(name->s[name->len-1]==']')&&
+ 						(strncasecmp(name->s+1, s, len)==0))
+ 				)
+-		   )
++		   ) {
+ 			return 0;
+-		else
+-
++		}
++		else {
++			if (unlikely(name->s==NULL)) {
++				LM_CRIT("invalid Via host name\n");
++				return -1;
++			}
+ 			if (strncmp(name->s, s, name->len)==0)
+ 				return 0;
++		}
+ 	}else{
+ 		LM_CRIT("could not convert ip address\n");
+ 		return -1;


### PR DESCRIPTION
In Kamailio before 5.0.7 and 5.1.x before 5.1.4, a crafted SIP message with
an invalid Via header causes a segmentation fault and crashes Kamailio. The
reason is missing input validation in the crcitt_string_array core function
for calculating a CRC hash for To tags. (An additional error is present in
the check_via_address core function: this function also misses input
validation.) This could result in denial of service and potentially the
execution of arbitrary code.

Patch from upstream.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: mips24kc
Run tested: mips24kc

Description:
Hello Jiri,

Fix for a CVE that was recently announced.

Kind regards,
Seb