### PR TITLE
yate: Revert to internal regex implementation

### DIFF
--- a/net/yate/Makefile
+++ b/net/yate/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yate
 PKG_VERSION:=6.1.0-1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://yate.null.ro/tarballs/yate6/
@@ -124,6 +124,10 @@ CONFIGURE_ARGS+= \
 	--without-coredumper \
 	--without-doxygen \
 	--without-kdoc
+
+# The regexp implementation of musl 1.1.19 is not fully compatible with yate
+CONFIGURE_ARGS+= \
+	--enable-internalregex
 
 ifneq ($(CONFIG_PACKAGE_$(PKG_NAME)-mod-isaccodec),)
 CONFIGURE_ARGS+=$(if $(CONFIG_SOFT_FLOAT),--disable-isac-float --enable-isac-fixed,--disable-isac-fixed --enable-isac-float)


### PR DESCRIPTION
.. because the musl implementation doesn't seem to be fully compatible
with yate. We switched to the musl implementation in f6ad95d.

Yate has this regexp:
^([[:alpha:]][[:alnum:]]+:)?/?/?([^[:space:][:cntrl:]@]+@)?([[:alnum:]._+-]+|[[][[:xdigit:].:]+[]])(:[0-9]+)?

Given a string like

  sip:012345678@11.111.11.111:5060;user=phone

musl's regexec() returns these matches:
```
index start end
0     -1    0
1     0     32   sip:012345678@11.111.11.111:5060
2     -1    -1
3     0     14   sip:012345678@
4     14    27   11.111.11.111
5     27    32   :5060
```
.. but this is what yate expects:
```
index start end
0     -1    0
1     0     32   sip:012345678@11.111.11.111:5060
2     0     4    sip:
3     4     14   012345678@
4     14    27   11.111.11.111
5     27    32   :5060
```
Fixes #378

Signed-off-by: Robert Högberg <robert.hogberg@gmail.com>

-------------------------------

Maintainer: @jslachta 
Compile tested: ar71xx, dir-825 b1, OpenWrt 18.06.1
Run tested: ar71xx, dir-825 b1, OpenWrt 18.06.1 - call routing now works as documented