### PR TITLE
asterisk-opus: new package

### DIFF
--- a/net/asterisk-opus/Makefile
+++ b/net/asterisk-opus/Makefile
@@ -1,0 +1,94 @@
+#
+# Copyright (C) 2018 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=asterisk-opus
+PKG_VERSION:=20171009
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/traud/asterisk-opus.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=83e1b458c77e0e287adeca494eeb79edb077b0ff
+PKG_MIRROR_HASH:=89265ee63bc3cb02ef9e75087f782147db1dec53433f9d6cfc08c7229cd61881
+PKG_SOURCE_PROTO:=git
+
+PKG_BUILD_DIR=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+TARGET_CFLAGS += \
+	-DAST_MODULE_SELF_SYM=__internal_codec_opus_open_source_self \
+	$(FPIC)
+
+define Package/$(PKG_NAME)/Default
+  SUBMENU:=Telephony
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Opus codec support
+  URL:=https://github.com/traud/asterisk-opus
+  DEPENDS:=+libopus
+endef
+
+define Package/asterisk13-codec-opus
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS+=asterisk13
+  VARIANT:=asterisk13
+endef
+
+define Package/asterisk15-codec-opus
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS+=asterisk15
+  VARIANT:=asterisk15
+endef
+
+define Package/description/Default
+  Opus is the default audio codec in WebRTC. WebRTC is available in
+  Asterisk via SIP over WebSockets (WSS). Nevertheless, Opus can be used
+  for other transports (UDP, TCP, TLS) as well. Opus supersedes previous
+  codecs like CELT and SiLK. Furthermore, in favor of Opus, other
+  open-source audio codecs are no longer developed, like Speex, iSAC,
+  iLBC, and Siren. If you use your Asterisk as a back-to-back user agent
+  (B2BUA) and you transcode between various audio codecs, one should
+  enable Opus for future compatibility.
+
+  Opus is not only supported for pass-through but can be transcoded as
+  well.
+endef
+
+Package/asterisk13-codec-opus/description = $(Package/description/Default)
+Package/asterisk15-codec-opus/description = $(Package/description/Default)
+
+ifeq ($(BUILD_VARIANT),asterisk13)
+TARGET_CFLAGS+=-I$(STAGING_DIR)/usr/include/asterisk-13/include
+endif
+
+ifeq ($(BUILD_VARIANT),asterisk15)
+TARGET_CFLAGS+=-I$(STAGING_DIR)/usr/include/asterisk-15/include
+endif
+
+define Package/Install/Default
+	$(INSTALL_DIR) $(1)/usr/lib/asterisk/modules
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/codecs/codec_opus_open_source.so \
+		$(1)/usr/lib/asterisk/modules
+endef
+
+Package/asterisk13-codec-opus/install = $(Package/Install/Default)
+Package/asterisk15-codec-opus/install = $(Package/Install/Default)
+
+define Build/Configure
+endef
+
+$(eval $(call BuildPackage,asterisk13-codec-opus))
+$(eval $(call BuildPackage,asterisk15-codec-opus))

--- a/net/asterisk-opus/patches/01-Makefile.patch
+++ b/net/asterisk-opus/patches/01-Makefile.patch
@@ -1,0 +1,23 @@
+--- a/Makefile
++++ b/Makefile
+@@ -3,17 +3,17 @@ exec_prefix=$(prefix)
+ libdir=$(exec_prefix)/lib
+ 
+ CC=gcc
+-CFLAGS=-pthread -g3 -O3 -D_FORTIFY_SOURCE=2 -fPIC
++CFLAGS+=-pthread
+ CPPFLAGS=
+ DEFS=
+ INSTALL=/usr/bin/install -c
+-LDFLAGS=-shared -pthread -Wl,--warn-common
++LDFLAGS+=-shared -pthread -Wl,--warn-common
+ LIBS=
+ MKDIR_P=/bin/mkdir -p
+ SHELL=/bin/sh
+ 
+ ASTMODDIR=$(libdir)/asterisk/modules
+-MODULES=codec_opus_open_source format_ogg_opus_open_source format_vp8 res_format_attr_opus
++MODULES=codec_opus_open_source
+ 
+ .SUFFIXES: .c .so
+ 


### PR DESCRIPTION
Add package for Opus codec support plugin. Variants for both asterisk13
and asterisk15 included.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: nobody yet :)
Compile tested: mips24kc
Run tested: dir-825-c1, pass-through mode worked fine. Transcoding not completely sure because it maxed out my router. I called Ekiga echo test number and heard the announcement, so PCMA to Opus transcoding was fine. But during echo test I couldn't hear anything. Maybe because of my router being overloaded. Saw no errors in Asterisk debug.

Description:
Opus codec module for Asterisk. Variant build enabled.

Hello @dhewg can you check this out, please?

Regards,
Seb