### PR TITLE
kamailio-5.x: make jsonrpc filter portable

### DIFF
--- a/net/kamailio-5.x/Makefile
+++ b/net/kamailio-5.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio5
 PKG_VERSION:=5.1.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://www.kamailio.org/pub/kamailio/$(PKG_VERSION)/src
 PKG_SOURCE:=kamailio-$(PKG_VERSION)$(PKG_VARIANT)_src.tar.gz

--- a/net/kamailio-5.x/patches/150-posix-awk-filter.patch
+++ b/net/kamailio-5.x/patches/150-posix-awk-filter.patch
@@ -1,0 +1,32 @@
+commit 59d287586f502a8df71c2e91899fde49594e072e
+Author: Sebastian Kemper <sebastian_ml@gmx.net>
+Date:   Sun Oct 7 18:54:39 2018 +0200
+
+    kamctl: make jsonrpc filter portable
+    
+    The filter has a regex looking for a literal '{' in the beginning of a
+    line. Some awk implementations interpret this as a meta character, so
+    the regex is deemed broken. Example with busybox awk (POSIX):
+    
+    root@hank2:~# kamctl ps
+    awk: bad regex '^{.+"id"[       ]*:[    ]*[0-9]+[       ]*}$': Invalid contents of {}
+    root@hank2:~#
+    
+    To fix this enclose the character in square brackets. This always
+    matches for a literal '{' and is portable.
+    
+    Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
+
+diff --git a/utils/kamctl/kamctl.base b/utils/kamctl/kamctl.base
+index adeceb77f..a776e10d8 100644
+--- a/utils/kamctl/kamctl.base
++++ b/utils/kamctl/kamctl.base
+@@ -715,7 +715,7 @@ filter_json()
+ 	$AWK 'function ltrim(s) { sub(/^[ \t\r\n]+/, "", s); return s }
+ 		BEGIN { line=0; IGNORECASE=1; }
+ 		{ line++; }
+-		NR == 1 && /^{.+"id"[ \t]*:[ \t]*[0-9]+[ \t]*}$/ { print; next; }
++		NR == 1 && /^[{].+"id"[ \t]*:[ \t]*[0-9]+[ \t]*}$/ { print; next; }
+ 		NR == 1 && /^200 OK/ { next; }
+ 		/^[ \t]*"jsonrpc":[ \t]*"2.0"/ { print; next; }
+ 		/^[ \t]*"result":[ \t]*\[.+/ {


### PR DESCRIPTION
With OpenWrt default awk - so awk from busybox - the filter is broken,
causing jsonrpc calls to fail, i.e. when running "kamctl ps". Below
patch makes the filter portable. Patch was already accepted upstream.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: mips24kc DIR-825 C1
Run tested: mips24kc DIR-825 C1

Description:

Hello Jiri,

This fixes kamctl runtime failures due to non-portable awk script.

Kind regards,
Seb
