### PR TITLE
kamailio-5.x: fix awk issue and some tweaks

### DIFF
--- a/net/kamailio-5.x/Makefile
+++ b/net/kamailio-5.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio5
 PKG_VERSION:=5.1.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://www.kamailio.org/pub/kamailio/$(PKG_VERSION)/src
 PKG_SOURCE:=kamailio-$(PKG_VERSION)$(PKG_VARIANT)_src.tar.gz
@@ -369,6 +369,16 @@ EXTRA_MODULES:= \
 	$(if $(CONFIG_PACKAGE_kamailio5-mod-ims-diameter-server),,ims_diameter_server) \
 	$(if $(CONFIG_PACKAGE_kamailio5-mod-uid-gflags),,uid_gflags)
 
+# MIPS tweak:
+#
+# Kamailio enables use of fast inline assembly locks when ARCH is set to
+# "mips2". When ARCH is set to "mips" instead, Kamailio assumes it is dealing
+# with an old 32-bit MIPS CPU without hardware locking support (like R3000).
+#
+# When CONFIG_CPU_TYPE matches one of the identifiers in the list below, set
+# ARCH to "mips2" to get FAST_LOCK support.
+CPU_MIPS2:=mips32 24kc 34kc 74kc
+
 PKG_MAKE_ARGS:= \
 	prefix=/ \
 	cfg_dir=/etc/kamailio/ \
@@ -387,7 +397,7 @@ PKG_MAKE_ARGS:= \
 	SYSBASE="$(STAGING_DIR)/usr" \
 	CROSS_COMPILE=$(TARGET_CROSS) \
 	CC="$(TARGET_CC)" \
-	ARCH="$(ARCH)"  \
+	$(if $(findstring $(call qstrip,$(CONFIG_CPU_TYPE)),$(CPU_MIPS2)),ARCH="mips2",ARCH="$(ARCH)") \
 	DESTDIR=$(PKG_INSTALL_DIR) \
 	quiet=verbose
 

--- a/net/kamailio-5.x/Makefile
+++ b/net/kamailio-5.x/Makefile
@@ -21,6 +21,8 @@ PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
+PKG_BUILD_PARALLEL:=1
+
 MODULES_AVAILABLE:= \
 	acc \
 	acc_diameter \

--- a/net/kamailio-5.x/patches/150-posix-awk-filter.patch
+++ b/net/kamailio-5.x/patches/150-posix-awk-filter.patch
@@ -1,0 +1,32 @@
+commit 59d287586f502a8df71c2e91899fde49594e072e
+Author: Sebastian Kemper <sebastian_ml@gmx.net>
+Date:   Sun Oct 7 18:54:39 2018 +0200
+
+    kamctl: make jsonrpc filter portable
+    
+    The filter has a regex looking for a literal '{' in the beginning of a
+    line. Some awk implementations interpret this as a meta character, so
+    the regex is deemed broken. Example with busybox awk (POSIX):
+    
+    root@hank2:~# kamctl ps
+    awk: bad regex '^{.+"id"[       ]*:[    ]*[0-9]+[       ]*}$': Invalid contents of {}
+    root@hank2:~#
+    
+    To fix this enclose the character in square brackets. This always
+    matches for a literal '{' and is portable.
+    
+    Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
+
+diff --git a/utils/kamctl/kamctl.base b/utils/kamctl/kamctl.base
+index adeceb77f..a776e10d8 100644
+--- a/utils/kamctl/kamctl.base
++++ b/utils/kamctl/kamctl.base
+@@ -715,7 +715,7 @@ filter_json()
+ 	$AWK 'function ltrim(s) { sub(/^[ \t\r\n]+/, "", s); return s }
+ 		BEGIN { line=0; IGNORECASE=1; }
+ 		{ line++; }
+-		NR == 1 && /^{.+"id"[ \t]*:[ \t]*[0-9]+[ \t]*}$/ { print; next; }
++		NR == 1 && /^[{].+"id"[ \t]*:[ \t]*[0-9]+[ \t]*}$/ { print; next; }
+ 		NR == 1 && /^200 OK/ { next; }
+ 		/^[ \t]*"jsonrpc":[ \t]*"2.0"/ { print; next; }
+ 		/^[ \t]*"result":[ \t]*\[.+/ {


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: mips24kc
Run tested: mips24kc

Description:

Hello Jiri,

This fixes the awk issue in master. Also, I tweaked the Makefile a bit.

I plan an submitting some more pull requests for kamailio in the not too distant future (Christmas?), i.e. add procd support as well as uci config. That'll take some more testing :)

Best regards,
Seb