### PR TITLE
rtpproxy & kamailio: fix hotplug script file names

### DIFF
--- a/net/kamailio-5.x/Makefile
+++ b/net/kamailio-5.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio5
 PKG_VERSION:=5.1.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL := \
 	https://sources.openwrt.org \
@@ -276,7 +276,7 @@ $(foreach c,kamailio.cfg kamctlrc,$(call Package/kamailio5/install/conffile,$(1)
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
 	$(INSTALL_BIN) \
 		./files/kamailio.hotplug \
-		$(1)/etc/hotplug.d/iface
+		$(1)/etc/hotplug.d/iface/99-kamailio
 	$(CP) \
 		$(PKG_INSTALL_DIR)/usr/lib/kamailio/kamctl \
 		$(1)/usr/lib/kamailio/

--- a/net/rtpproxy/Makefile
+++ b/net/rtpproxy/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rtpproxy
 PKG_VERSION:=2.1.0-20170914
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/sippy/rtpproxy.git
@@ -73,7 +73,7 @@ define Package/rtpproxy/install
 	$(INSTALL_CONF) ./files/rtpproxy.config $(1)/etc/config/rtpproxy
 
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
-	$(INSTALL_BIN) ./files/rtpproxy.hotplug $(1)/etc/hotplug.d/iface
+	$(INSTALL_BIN) ./files/rtpproxy.hotplug $(1)/etc/hotplug.d/iface/90-rtpproxy
 endef
 
 define Package/rtpproxy/postinst


### PR DESCRIPTION

Maintainer: @jslachta 
Compile tested: ar71xx
Run tested: ar71xx

Description:
Hello Jiri,

I did a copy-and-paste error earlier. The hotplug scripts weren't named properly. This fixes these.

Kind regards,
Seb
