### PR TITLE
siproxd: add wiki link and fix debug log capture

### DIFF
--- a/net/siproxd/Makefile
+++ b/net/siproxd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=siproxd
 PKG_VERSION:=0.8.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/siproxd

--- a/net/siproxd/Makefile
+++ b/net/siproxd/Makefile
@@ -39,7 +39,7 @@ define Package/siproxd
 endef
 
 define Package/siproxd/description
- Siproxd is a proxy/masquerading daemon for the SIP protocol.
+ Siproxd is a proxy/masquerading daemon for the SIP protocol. Refer to https://openwrt.org/docs/guide-user/services/voip/siproxd for configuration details and examples.
 endef
 
 define Package/siproxd/conffiles

--- a/net/siproxd/files/siproxd.init
+++ b/net/siproxd/files/siproxd.init
@@ -110,6 +110,7 @@ section_end() {
 	procd_set_param command "$PROG" --config "$conf_file"
 	procd_set_param pidfile "$pid_file"
 	procd_set_param respawn
+	procd_set_param stderr 1
 	procd_add_jail siproxd log
 	procd_add_jail_mount /etc/passwd /etc/group /etc/TZ /dev/null
 	procd_add_jail_mount "$conf_file"


### PR DESCRIPTION
**Maintainer**: @jslachta 
**Compile tested**: ar71xx, DIR-835, LEDE-17.01.5
**Run tested**: (as above) Confirmed wiki link in package metadata and capture of debug output in syslog
**CC**: @micmac1 

**Description**:
Hi Jiri, Seb,
This is a follow-up from the examples/docs/wiki discussions in https://github.com/openwrt/telephony/issues/384 and https://github.com/openwrt/telephony/pull/387, and adds a package-metadata link to the OpenWrt wiki for `siproxd`.  While troubleshooting #384 I also noticed debug output wasn't being captured to syslog, so also fixed that. Please have a look...

Best regards,
Tony

