### PR TITLE
dahdi-tools: version bump

### DIFF
--- a/libs/dahdi-tools/Makefile
+++ b/libs/dahdi-tools/Makefile
@@ -50,15 +50,6 @@ endef
 
 CONFIGURE_ARGS+=--disable-silent-rules
 
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) \
-		HOSTCC="$(HOSTCC)" \
-		CROSS_COMPILE="$(TARGET_CROSS)" \
-		CFLAGS="$(TARGET_CFLAGS)" \
-		CPPFLAGS="$(TARGET_CPPFLAGS)" \
-		dahdi_cfg dahdi_monitor dahdi_scan dahdi_speed dahdi_test fxotune
-endef
-
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_BUILD_DIR)/.libs/*.so* $(1)/usr/lib/

--- a/libs/dahdi-tools/Makefile
+++ b/libs/dahdi-tools/Makefile
@@ -19,7 +19,11 @@ PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Vittorio Gambaletta <openwrt@vittgam.net>
 
+PKG_BUILD_PARALLEL:=1
+
 PKG_FIXUP:=autoreconf
+
+PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -52,30 +56,28 @@ CONFIGURE_ARGS+=--disable-silent-rules
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_BUILD_DIR)/.libs/*.so* $(1)/usr/lib/
-	$(CP) $(PKG_BUILD_DIR)/.libs/*.a $(1)/usr/lib/
-
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtonezone.{a,so*} \
+		$(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/include/dahdi
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/tonezone.h $(1)/usr/include/dahdi/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/dahdi/tonezone.h \
+		$(1)/usr/include/dahdi/
 endef
 
 define Package/dahdi-cfg/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/.libs/dahdi_cfg $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dahdi_scan $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/fxotune $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/{dahdi_cfg,dahdi_scan,fxotune} \
+		$(1)/usr/sbin/
 endef
 
 define Package/dahdi-monitor/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dahdi_monitor $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dahdi_speed $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dahdi_test $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/{dahdi_monitor,dahdi_speed,dahdi_test} \
+		$(1)/usr/sbin/
 endef
 
 define Package/dahdi-tools-libtonezone/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_BUILD_DIR)/.libs/libtonezone.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libtonezone.so* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,dahdi-cfg))

--- a/libs/dahdi-tools/Makefile
+++ b/libs/dahdi-tools/Makefile
@@ -1,5 +1,5 @@
 # 
-# Copyright (C) 2014 - 2018 OpenWrt.org
+# Copyright (C) 2014 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.

--- a/libs/dahdi-tools/Makefile
+++ b/libs/dahdi-tools/Makefile
@@ -8,16 +8,18 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dahdi-tools
-PKG_VERSION:=2.11.1
-PKG_RELEASE:=3
+PKG_VERSION:=3.0.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/dahdi-tools/releases
-PKG_HASH:=53ffeb333f3e44b0c88e5b17475cdbf87d3f652eb81a6422de76250c061e2909
+PKG_HASH:=5bebb20d5ae13fa13f0e2075603013954b962be477db02271eef44b3e41557c5
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Vittorio Gambaletta <openwrt@vittgam.net>
+
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -45,6 +47,8 @@ define Package/dahdi-tools-libtonezone
   CATEGORY:=Libraries
   TITLE:=DAHDI tonezone library
 endef
+
+CONFIGURE_ARGS+=--disable-silent-rules
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \

--- a/libs/dahdi-tools/patches/010-fix-non-glibc-builds.patch
+++ b/libs/dahdi-tools/patches/010-fix-non-glibc-builds.patch
@@ -1,0 +1,26 @@
+--- a/xpp/xtalk/debug.c
++++ b/xpp/xtalk/debug.c
+@@ -26,7 +26,9 @@
+ #include <stdlib.h>
+ #include <stdarg.h>
+ #include <syslog.h>
++#ifdef __GLIBC__
+ #include <execinfo.h>
++#endif
+ #include <xtalk/debug.h>
+ #include <autoconfig.h>
+ 
+@@ -61,6 +63,7 @@ void dump_packet(int loglevel, int mask,
+ /* from glibc info(1) */
+ void print_backtrace(FILE *fp)
+ {
++#ifdef __GLIBC__
+ 	void	*array[10];
+ 	size_t	size;
+ 	char	**strings;
+@@ -71,4 +74,5 @@ void print_backtrace(FILE *fp)
+ 	for (i = 0; i < size; i++)
+ 		fprintf(fp, "%s\n", strings[i]);
+ 	free(strings);
++#endif
+ }

--- a/libs/dahdi-tools/patches/020-fix-undefined-reference-to-get_ver.patch
+++ b/libs/dahdi-tools/patches/020-fix-undefined-reference-to-get_ver.patch
@@ -1,0 +1,11 @@
+--- a/xpp/echo_loader.c
++++ b/xpp/echo_loader.c
+@@ -564,7 +564,7 @@ UINT32 Oct6100UserDriverReadBurstApi(tPO
+ 	return cOCT6100_ERR_OK;
+ }
+ 
+-inline int get_ver(struct astribank *astribank)
++static inline int get_ver(struct astribank *astribank)
+ {
+ 	return spi_send(astribank, 0, 0, 1, 1);
+ }


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: ath79
Run tested: ath79

Description:
Hello Jiri,

I've updated the telephony packages today. Apart from the version bumps I've also reverted some copyright changes introduced by me in the past, as it has been made clear to me that I'm actually not allowed to change OpenWrt copyright lines because I'm not affiliated with OpenWrt. I'm also not allowed to change copyright lines from other people (your's for instance). So I reset some copyright lines.

I left kamailio alone for now. They have 5.2.0 out, but I'll wait for a minor release bump and update then.

I haven't run-tested any of this yet, because currently I don't have access to a trunk release running on a router. I'll test what I can the coming weekend and ping you.

If anybody else can test any of the commits in the meantime of course you're welcome to do so :)

Kind regards,
Seb