### PR TITLE
freeswitch-stable: bump to version 1.8.4

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -9,13 +9,13 @@ include $(TOPDIR)/rules.mk
 
 PRG_NAME:=freeswitch
 PKG_NAME:=$(PRG_NAME)-stable
-PKG_VERSION:=1.8.3
+PKG_VERSION:=1.8.4
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=$(PRG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://files.$(PRG_NAME).org/releases/$(PRG_NAME)
-PKG_HASH:=327444f2f1f6ba68b268e81797a44522f44fff725ef53a7e7e5d58efdab54adb
+PKG_HASH:=768f4a7f2d02e79f522cd4b7a26f6cef9e5663b5ac6478b9fe4725a7276ae3d3
 
 PKG_CPE_ID:=cpe:/a:freeswitch:freeswitch
 


### PR DESCRIPTION
Includes crash-fix for mod_sofia from upstream, FS-11583.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: ar71xx
Run tested: ar71xx, dir-825c1,running FS against provider
Description:
Version bump. I have this version running on 18.06. If all is well will backport this there next weekend.

Regards,
Seb
