### PR TITLE
dahdi-tools: rework patch

### DIFF
--- a/libs/dahdi-tools/Makefile
+++ b/libs/dahdi-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dahdi-tools
 PKG_VERSION:=3.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/dahdi-tools/releases

--- a/libs/dahdi-tools/patches/010-fix-non-glibc-builds.patch
+++ b/libs/dahdi-tools/patches/010-fix-non-glibc-builds.patch
@@ -4,7 +4,7 @@
  #include <stdlib.h>
  #include <stdarg.h>
  #include <syslog.h>
-+#ifdef __GLIBC__
++#ifdef HAVE_EXECINFO_H
  #include <execinfo.h>
 +#endif
  #include <xtalk/debug.h>
@@ -14,7 +14,7 @@
  /* from glibc info(1) */
  void print_backtrace(FILE *fp)
  {
-+#ifdef __GLIBC__
++#ifdef HAVE_EXECINFO_H
  	void	*array[10];
  	size_t	size;
  	char	**strings;
@@ -24,3 +24,13 @@
  	free(strings);
 +#endif
  }
+--- a/configure.ac
++++ b/configure.ac
+@@ -161,6 +161,7 @@ AC_SUBST(DAHDI_DECLARATION_AFTER_STATEME
+ # Checks for header files.
+ AC_CHECK_HEADERS([sys/soundcard.h linux/soundcard.h])
+ AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netinet/in.h stdint.h stdlib.h string.h sys/ioctl.h sys/param.h sys/socket.h sys/time.h syslog.h unistd.h])
++AC_CHECK_HEADERS([execinfo.h])
+ 
+ # Checks for typedefs, structures, and compiler characteristics.
+ AC_C_INLINE


### PR DESCRIPTION
Currently builds for ARC are failing, causing follow-up breakage. It
seems that uclibc defines __GLIBC__ on the build bots.

This commit adds a test for execinfo.h to the configure script. The
result of the test is then used in xpp/xtalk/debug.c.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: mips24kc
Run tested: not relevant, build fix

Description:

Hello Jiri,

The patch I sent earlier doesn't seem to work very well. On the build bots the ARC builds are currently failing. So they must have __GLIBC__ defined there.

I reworked the patch to explicitly check for the execinfo header. This should fix it.

Kind regards,
Seb
