### PR TITLE
Asterisk 16 additions

### DIFF
--- a/libs/pjproject/Makefile
+++ b/libs/pjproject/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pjproject
 PKG_VERSION:=2.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=pjproject-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.pjsip.org/release/$(PKG_VERSION)

--- a/libs/pjproject/patches/210-outgoing_connected_line_method_update.patch
+++ b/libs/pjproject/patches/210-outgoing_connected_line_method_update.patch
@@ -1,0 +1,32 @@
+--- a/pjsip/src/pjsip-ua/sip_inv.c
++++ b/pjsip/src/pjsip-ua/sip_inv.c
+@@ -4185,6 +4185,29 @@ static void inv_on_state_calling( pjsip_
+ 
+ 	    if (tsx->status_code != 100) {
+ 
++		if (inv->role == PJSIP_ROLE_UAC) {
++		    pjsip_rx_data *rdata = e->body.tsx_state.src.rdata;
++		    pjsip_allow_hdr *allow = NULL;
++		    pjsip_msg *msg = rdata->msg_info.msg;
++
++		    if (msg) {
++			allow = (pjsip_allow_hdr*) pjsip_msg_find_hdr(msg, PJSIP_H_ALLOW,
++				NULL);
++		    }
++		    if (allow) {
++			unsigned i;
++			const pj_str_t STR_UPDATE = { "UPDATE", 6 };
++
++			for (i=0; i<allow->count; ++i) {
++			    if (pj_stricmp(&allow->values[i], &STR_UPDATE)==0) {
++				/* UPDATE is present in Allow */
++				inv->options |= PJSIP_INV_SUPPORT_UPDATE;
++				break;
++			    }
++			}
++		    }
++		}
++
+ 		if (dlg->remote.info->tag.slen)
+ 		    inv_set_state(inv, PJSIP_INV_STATE_EARLY, e);
+ 

--- a/libs/pjproject/patches/220-Fixed-2172-Avoid-double-reference-counter-decrements.patch
+++ b/libs/pjproject/patches/220-Fixed-2172-Avoid-double-reference-counter-decrements.patch
@@ -1,0 +1,37 @@
+From 1fed39fe1488abd654a5488b5e6ad59b4b973331 Mon Sep 17 00:00:00 2001
+From: nanang <nanang@localhost>
+Date: Tue, 8 Jan 2019 09:07:47 +0000
+Subject: [PATCH 1/5] Fixed #2172: Avoid double reference counter decrements in
+ timer in the scenario of race condition between pj_timer_heap_cancel() and
+ pj_timer_heap_poll().
+
+---
+ pjlib/src/pj/timer.c | 17 ++++++++++-------
+ 1 file changed, 10 insertions(+), 7 deletions(-)
+
+--- a/pjlib/src/pj/timer.c
++++ b/pjlib/src/pj/timer.c
+@@ -580,13 +580,16 @@ static int cancel_timer(pj_timer_heap_t
+ 
+     lock_timer_heap(ht);
+     count = cancel(ht, entry, flags | F_DONT_CALL);
+-    if (flags & F_SET_ID) {
+-	entry->id = id_val;
+-    }
+-    if (entry->_grp_lock) {
+-	pj_grp_lock_t *grp_lock = entry->_grp_lock;
+-	entry->_grp_lock = NULL;
+-	pj_grp_lock_dec_ref(grp_lock);
++    if (count > 0) {
++	/* Timer entry found & cancelled */
++	if (flags & F_SET_ID) {
++	    entry->id = id_val;
++	}
++	if (entry->_grp_lock) {
++	    pj_grp_lock_t *grp_lock = entry->_grp_lock;
++	    entry->_grp_lock = NULL;
++	    pj_grp_lock_dec_ref(grp_lock);
++	}
+     }
+     unlock_timer_heap(ht);
+ 

--- a/libs/pjproject/patches/230-Re-2176-Removed-pop_freelist-push_freelist-after-rem.patch
+++ b/libs/pjproject/patches/230-Re-2176-Removed-pop_freelist-push_freelist-after-rem.patch
@@ -1,0 +1,32 @@
+From 9f57a5728aaec1949908bf7bbd15768fce74e315 Mon Sep 17 00:00:00 2001
+From: Nanang Izzuddin <nanang@teluu.com>
+Date: Wed, 13 Feb 2019 06:51:09 +0000
+Subject: [PATCH] Re #2176: Removed pop_freelist() + push_freelist() after
+ remove_node() as they are not only unnecessary, they cause problem.
+
+git-svn-id: https://svn.pjsip.org/repos/pjproject/trunk@5934 74dad513-b988-da41-8d7b-12977e46ad98
+---
+ pjlib/src/pj/timer.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+--- a/pjlib/src/pj/timer.c
++++ b/pjlib/src/pj/timer.c
+@@ -633,7 +633,8 @@ PJ_DEF(unsigned) pj_timer_heap_poll( pj_
+     {
+ 	pj_timer_entry *node = remove_node(ht, 0);
+ 	/* Avoid re-use of this timer until the callback is done. */
+-	pj_timer_id_t node_timer_id = pop_freelist(ht);
++	///Not necessary, even causes problem (see also #2176).
++	///pj_timer_id_t node_timer_id = pop_freelist(ht);
+ 	pj_grp_lock_t *grp_lock;
+ 
+ 	++count;
+@@ -653,7 +654,7 @@ PJ_DEF(unsigned) pj_timer_heap_poll( pj_
+ 
+ 	lock_timer_heap(ht);
+ 	/* Now, the timer is really free for re-use. */
+-	push_freelist(ht, node_timer_id);
++	///push_freelist(ht, node_timer_id);
+     }
+     if (ht->cur_size && next_delay) {
+ 	*next_delay = ht->heap[0]->_timer_value;

--- a/net/asterisk-g72x/Makefile
+++ b/net/asterisk-g72x/Makefile
@@ -48,12 +48,19 @@ $(call Package/asterisk-g72x/Default)
   VARIANT:=asterisk15
 endef
 
+define Package/asterisk16-codec-g729
+$(call Package/asterisk-g72x/Default)
+  DEPENDS+=asterisk16
+  VARIANT:=asterisk16
+endef
+
 define Package/description/Default
  Asterisk G.729 codec based on bcg729 implementation.
 endef
 
 Package/asterisk13-codec-g729/description = $(Package/description/Default)
 Package/asterisk15-codec-g729/description = $(Package/description/Default)
+Package/asterisk16-codec-g729/description = $(Package/description/Default)
 
 CONFIGURE_ARGS+= \
 	--with-bcg729 \
@@ -71,6 +78,12 @@ CONFIGURE_ARGS+= \
 	--with-asterisk150
 endif
 
+ifeq ($(BUILD_VARIANT),asterisk16)
+CONFIGURE_ARGS+= \
+	--with-asterisk-includes=$(STAGING_DIR)/usr/include/asterisk-16/include \
+	--with-asterisk160
+endif
+
 define Package/Install/Default
 	$(INSTALL_DIR) $(1)/usr/lib/asterisk/modules
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/asterisk/modules/codec_g729.so \
@@ -79,6 +92,8 @@ endef
 
 Package/asterisk13-codec-g729/install = $(Package/Install/Default)
 Package/asterisk15-codec-g729/install = $(Package/Install/Default)
+Package/asterisk16-codec-g729/install = $(Package/Install/Default)
 
 $(eval $(call BuildPackage,asterisk13-codec-g729))
 $(eval $(call BuildPackage,asterisk15-codec-g729))
+$(eval $(call BuildPackage,asterisk16-codec-g729))

--- a/net/asterisk-opus/Makefile
+++ b/net/asterisk-opus/Makefile
@@ -53,6 +53,12 @@ $(call Package/$(PKG_NAME)/Default)
   VARIANT:=asterisk15
 endef
 
+define Package/asterisk16-codec-opus
+$(call Package/$(PKG_NAME)/Default)
+  DEPENDS+=asterisk16
+  VARIANT:=asterisk16
+endef
+
 define Package/description/Default
   Opus is the default audio codec in WebRTC. WebRTC is available in
   Asterisk via SIP over WebSockets (WSS). Nevertheless, Opus can be used
@@ -69,6 +75,7 @@ endef
 
 Package/asterisk13-codec-opus/description = $(Package/description/Default)
 Package/asterisk15-codec-opus/description = $(Package/description/Default)
+Package/asterisk16-codec-opus/description = $(Package/description/Default)
 
 ifeq ($(BUILD_VARIANT),asterisk13)
 TARGET_CFLAGS+=-I$(STAGING_DIR)/usr/include/asterisk-13/include
@@ -76,6 +83,10 @@ endif
 
 ifeq ($(BUILD_VARIANT),asterisk15)
 TARGET_CFLAGS+=-I$(STAGING_DIR)/usr/include/asterisk-15/include
+endif
+
+ifeq ($(BUILD_VARIANT),asterisk16)
+TARGET_CFLAGS+=-I$(STAGING_DIR)/usr/include/asterisk-16/include
 endif
 
 define Package/Install/Default
@@ -86,9 +97,11 @@ endef
 
 Package/asterisk13-codec-opus/install = $(Package/Install/Default)
 Package/asterisk15-codec-opus/install = $(Package/Install/Default)
+Package/asterisk16-codec-opus/install = $(Package/Install/Default)
 
 define Build/Configure
 endef
 
 $(eval $(call BuildPackage,asterisk13-codec-opus))
 $(eval $(call BuildPackage,asterisk15-codec-opus))
+$(eval $(call BuildPackage,asterisk16-codec-opus))


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: arm/master
Run tested: arm/master

Description:
It seems asterisk gets no testing at all with musl, so I had to add two patches to get it working in the first place. But this exact version submitted here is running on my openwrt cubieboard2 for a few weeks now - and it works for me.

With this new package I chose to not add all the deprecated modules. With the idea that we can add those if there's demand for it.

* Add two pjproject patches, taken from the asterisk 16 tree
* Add the new v16 LTS release
* Add asterisk 16 variants of g72x and opus

Thanks!