### PR TITLE
asterisk-15.x (18.06): add patch for AST-2019-001

### DIFF
--- a/net/asterisk-15.x/Makefile
+++ b/net/asterisk-15.x/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk15
 PKG_VERSION:=15.3.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk-15.x/patches/150-AST-2019-001-15.diff
+++ b/net/asterisk-15.x/patches/150-AST-2019-001-15.diff
@@ -1,0 +1,34 @@
+From 476d60f850c75ca9142aaf783992db74efea6a49 Mon Sep 17 00:00:00 2001
+From: George Joseph <gjoseph@digium.com>
+Date: Wed, 30 Jan 2019 12:25:55 -0700
+Subject: [PATCH] res_pjsip_sdp_rtp:  Fix return code from apply_negotiated_sdp_stream
+
+apply_negotiated_sdp_stream was returning a "1" when no joint
+capabilities were found on an outgoing call instead of a "-1".
+This indicated to res_pjsip_session that the handler DID handle
+the sdp when in fact it didn't.  Without the appropriate setup,
+a subsequent media frame coming in would have an invalid stream_num
+and cause a seg fault when the stream was attempted to be retrieved.
+
+apply_negotiated_sdp_stream now returns the correct "-1" and any
+media is now discarded before it reaches the core stream processing.
+
+ASTERISK-28620
+Reported by: Sotiris Ganouris
+
+Change-Id: Ia095cb16b4862f2f6ad6d2d2a77453fa2542371f
+---
+
+diff --git a/res/res_pjsip_sdp_rtp.c b/res/res_pjsip_sdp_rtp.c
+index e2067cc..7f5a859 100644
+--- a/res/res_pjsip_sdp_rtp.c
++++ b/res/res_pjsip_sdp_rtp.c
+@@ -1941,7 +1941,7 @@
+ 	}
+ 
+ 	if (set_caps(session, session_media, session_media_transport, remote_stream, 0, asterisk_stream)) {
+-		return 1;
++		return -1;
+ 	}
+ 
+ 	/* Set the channel uniqueid on the RTP instance now that it is becoming active */


### PR DESCRIPTION
Remote crash vulnerability with SDP protocol violation.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: 18.06 ar71xx
Run tested: master on ath79, see other pull request

Description:
Same patch.