### PR TITLE
kamailio-5.x: update hiredis patch

### DIFF
--- a/net/kamailio-5.x/Makefile
+++ b/net/kamailio-5.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio5
 PKG_VERSION:=5.2.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://www.kamailio.org/pub/kamailio/$(PKG_VERSION)/src
 PKG_SOURCE:=kamailio-$(PKG_VERSION)$(PKG_VARIANT)_src.tar.gz

--- a/net/kamailio-5.x/patches/140-redis_use_pkg-config.patch
+++ b/net/kamailio-5.x/patches/140-redis_use_pkg-config.patch
@@ -28,15 +28,6 @@
  
  ifeq ($(HIREDIS_BUILDER),)
  	HIREDISDEFS=-I$(LOCALBASE)/include -I$(LOCALBASE)/include/hiredis -I/usr/include/hiredis
-@@ -19,7 +17,7 @@ else
- 	HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags)
- 	HIREDISLIBS = $(shell $(HIREDIS_BUILDER) --libs)
- 
--ifeq (,$(findstring hiredis,$(HIREDISDEFS)))
-+ifneq (,$(findstring hiredis,$(HIREDISDEFS)))
- 	DEFS+=-DWITH_HIREDIS_PATH
- endif
- 
 --- a/src/modules/ndb_redis/Makefile
 +++ b/src/modules/ndb_redis/Makefile
 @@ -5,12 +5,10 @@ include ../../Makefile.defs
@@ -52,15 +43,6 @@
  
  ifeq ($(HIREDIS_BUILDER),)
  	HIREDISDEFS=-I$(LOCALBASE)/include -I$(LOCALBASE)/include/hiredis  -I/usr/include/hiredis
-@@ -19,7 +17,7 @@ else
- 	HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags)
- 	HIREDISLIBS = $(shell $(HIREDIS_BUILDER) --libs)
- 
--ifeq (,$(findstring hiredis,$(HIREDISDEFS)))
-+ifneq (,$(findstring hiredis,$(HIREDISDEFS)))
- 	DEFS+=-DWITH_HIREDIS_PATH
- endif
- 
 --- a/src/modules/topos_redis/Makefile
 +++ b/src/modules/topos_redis/Makefile
 @@ -5,12 +5,10 @@ include ../../Makefile.defs
@@ -76,12 +58,3 @@
  
  ifeq ($(HIREDIS_BUILDER),)
  	HIREDISDEFS=-I$(LOCALBASE)/include -I$(LOCALBASE)/include/hiredis  -I/usr/include/hiredis
-@@ -19,7 +17,7 @@ else
- 	HIREDISDEFS = $(shell $(HIREDIS_BUILDER) --cflags)
- 	HIREDISLIBS = $(shell $(HIREDIS_BUILDER) --libs)
- 
--ifeq (,$(findstring hiredis,$(HIREDISDEFS)))
-+ifneq (,$(findstring hiredis,$(HIREDISDEFS)))
- 	DEFS+=-DWITH_HIREDIS_PATH
- endif
- 


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: ath79, master
Run tested: not needed, only compile-related

Description:
Hello Jiri,

neheb merged the libhiredis pc file fix yesterday, so the patch can be relieved of the workaround.

Kind regards,
Seb