### PR TITLE
freeswitch-stable: fix gcc8 warnings

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PRG_NAME:=freeswitch
 PKG_NAME:=$(PRG_NAME)-stable
 PKG_VERSION:=1.8.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=$(PRG_NAME)-$(PKG_VERSION).tar.xz

--- a/net/freeswitch-stable/patches/400-switch_core_media-fix-stringop-truncation.patch
+++ b/net/freeswitch-stable/patches/400-switch_core_media-fix-stringop-truncation.patch
@@ -1,0 +1,32 @@
+commit e114c6382e68824d4498f62562714860d20804e2
+Author: Sebastian Kemper <sebastian_ml@gmx.net>
+Date:   Sun Apr 14 19:11:58 2019 +0200
+
+    FS-11783: [core] quiet gcc truncation warning
+    
+    With -Wstringop-truncation gcc warns about calls to bounded string
+    manipulation function "strncpy" that may either truncate the copied
+    string or leave the destination unchanged. To avoid the warning when the
+    result is not expected to be NUL-terminated, it is suggested to call
+    "memcpy" instead.
+    
+    src/switch_core_media.c: In function 'switch_core_media_patch_sdp':
+    src/switch_core_media.c:11854:4: error: 'strncpy' output truncated before terminating nul copying 2 bytes from a string of the same length [-Werror=stringop-truncation]
+        strncpy(q, strchr(a_engine->adv_sdp_ip, ':') ? "6 " : "4 ", 2);
+        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    
+    This commit follows gcc's recommendation.
+    
+    Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
+
+--- a/src/switch_core_media.c
++++ b/src/switch_core_media.c
+@@ -11851,7 +11851,7 @@ SWITCH_DECLARE(void) switch_core_media_p
+ 			strncpy(q, p, 7);
+ 			p += 7;
+ 			q += 7;
+-			strncpy(q, strchr(a_engine->adv_sdp_ip, ':') ? "6 " : "4 ", 2);
++			memcpy(q, strchr(a_engine->adv_sdp_ip, ':') ? "6 " : "4 ", 2);
+ 			p +=2;
+ 			q +=2;
+ 			strncpy(q, a_engine->adv_sdp_ip, strlen(a_engine->adv_sdp_ip));

--- a/net/freeswitch-stable/patches/410-mod_say_ja-fix-format-overflow.patch
+++ b/net/freeswitch-stable/patches/410-mod_say_ja-fix-format-overflow.patch
@@ -1,0 +1,42 @@
+commit 3ca75eb8efa4e50ebe083a269b75fcb1762daa91
+Author: Sebastian Kemper <sebastian_ml@gmx.net>
+Date:   Sun Apr 14 19:23:41 2019 +0200
+
+    FS-11783: [mod_say_ja] quiet overflow warning
+    
+    With -Wformat-overflow gcc warns about calls to formatted input/output
+    function "sprintf" that might overflow the destination buffer.
+    
+    In this case gcc does not know the upper bound of tm_min and assumes
+    that up to 11 bytes might be written to buffer (3 bytes). But we know
+    that tm_min can only be within the range 0 to 59.
+    
+    mod_say_ja.c: In function 'ja_say_time':
+    mod_say_ja.c:376:35: error: '%d' directive writing between 2 and 10 bytes into a region of size 3 [-Werror=format-overflow=]
+                      sprintf(buffer, "%d", tm.tm_min);
+                                       ^~
+    mod_say_ja.c:376:34: note: directive argument in the range [11, 2147483647]
+                      sprintf(buffer, "%d", tm.tm_min);
+                                      ^~~~
+    mod_say_ja.c:376:18: note: 'sprintf' output between 3 and 11 bytes into a destination of size 3
+                      sprintf(buffer, "%d", tm.tm_min);
+                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    
+    This commits adds a hint for gcc, which silences the warning.
+    
+    Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
+
+diff --git a/src/mod/say/mod_say_ja/mod_say_ja.c b/src/mod/say/mod_say_ja/mod_say_ja.c
+index 72c7c38131..d8e0692fd0 100644
+--- a/src/mod/say/mod_say_ja/mod_say_ja.c
++++ b/src/mod/say/mod_say_ja/mod_say_ja.c
+@@ -367,7 +367,8 @@ static switch_status_t ja_say_time(switch_core_session_t *session, char *tosay,
+ 			say_file("time/pm.wav");
+ 		}
+ 		say_file("time/hour-%d.wav", tm.tm_hour);
+-		if (tm.tm_min > 10) {
++		/* tm_min is always < 60 - this is just to silence gcc 8 warning */
++		if (tm.tm_min > 10 && tm.tm_min < 60) {
+ 	    		int temp;
+                 	char tch[1+1];
+                 	mod_min = tm.tm_min % 10;


### PR DESCRIPTION
Add two patches that were submitted upstream to address warnings that
occur when using gcc 8.3 (like arc does currently) which turn into
errors (-Werror).

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: arc master
Run tested: N/A

Description:
Fix some gcc 8.3 warnings