### PR TITLE
asterisk-16.x-chan-lantiq: add compile fix

### DIFF
--- a/net/asterisk-16.x-chan-lantiq/Makefile
+++ b/net/asterisk-16.x-chan-lantiq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk16-chan-lantiq
 PKG_VERSION:=20180215
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/kochstefan/asterisk_channel_lantiq.git

--- a/net/asterisk-16.x-chan-lantiq/patches/01-Use-ast_malloc-and-ast_free-instead-of-malloc-and-free.patch
+++ b/net/asterisk-16.x-chan-lantiq/patches/01-Use-ast_malloc-and-ast_free-instead-of-malloc-and-free.patch
@@ -1,0 +1,43 @@
+commit 30f9a094c1c60e0d68e4ea189f48ecb47aebb485
+Author: arny <arnysch@gmx.net>
+Date:   Thu May 2 20:07:28 2019 +0200
+
+    Use ast_malloc and ast_free instead of malloc and free
+    in order to get rid of build errors with asterisk16 in OpenWrt
+    
+    Signed-off-by: arny <arnysch@gmx.net>
+
+diff --git a/src/channels/chan_lantiq.c b/src/channels/chan_lantiq.c
+index a8fc869..90002ab 100644
+--- a/src/channels/chan_lantiq.c
++++ b/src/channels/chan_lantiq.c
+@@ -563,9 +563,9 @@ lantiq_dev_binary_buffer_create(const char *path, uint8_t **ppBuf, uint32_t *pBu
+ 		goto on_exit;
+ 	}
+ 
+-	*ppBuf = malloc(file_stat.st_size);
++	*ppBuf = ast_malloc(file_stat.st_size);
+ 	if (*ppBuf == NULL) {
+-		ast_log(LOG_ERROR, "binary file %s memory allocation failed\n", path);
++		// Message already logged by ast_malloc
+ 		goto on_exit;
+ 	}
+ 
+@@ -583,7 +583,7 @@ on_exit:
+ 		fclose(fd);
+ 
+ 	if (*ppBuf != NULL && status)
+-		free(*ppBuf);
++		ast_free(*ppBuf);
+ 
+ 	return status;
+ }
+@@ -609,7 +609,7 @@ static int32_t lantiq_dev_firmware_download(int32_t fd, const char *path)
+ 	}
+ 
+ 	if (firmware != NULL)
+-		free(firmware);
++		ast_free(firmware);
+ 
+ 	return 0;
+ }


### PR DESCRIPTION
Patch from upstream pull request
(https://github.com/kochstefan/asterisk_channel_lantiq/pull/3).

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: xrx200
Run tested: N/A

Description:
Hello Jiri,

When I swapped the astmm patch with the one from Timo Teräs I didn't rerun the compile tests of the external plugins. chan-lantiq fails.

astmm.h:160:2: error: "Do_not_use_malloc__use_ast_malloc" undeclared (first use in this function)

Thanks to @arnysch for the patch!

Kind regards,
Seb