### PR TITLE
asterisk-chan-sccp: fix gcc8 compiles

### DIFF
--- a/net/asterisk-chan-sccp/Makefile
+++ b/net/asterisk-chan-sccp/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chan-sccp
 PKG_VERSION:=v4.3.2-20190411
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/chan-sccp/chan-sccp.git

--- a/net/asterisk-chan-sccp/patches/110-fix-compile-with-gcc8.patch
+++ b/net/asterisk-chan-sccp/patches/110-fix-compile-with-gcc8.patch
@@ -1,0 +1,38 @@
+commit 1febe062d5ba93747ff8788ce0309c6174e3a08b
+Author: Sebastian Kemper <sebastian_ml@gmx.net>
+Date:   Mon May 6 21:07:48 2019 +0200
+
+    Add missing header to sccp_utils.c
+    
+    With newer gcc versions (8.3 tested) compile of sccp_utils.c fails with:
+    
+        CC       libsccp_la-sccp_utils.lo
+      sccp_utils.c: In function 'sccp_utf8_columnwidth':
+      sccp_utils.c:1846:2: warning: implicit declaration of function 'setlocale'; did you mean 'ast_setlocale'? [-Wimplicit-function-declaration]
+        setlocale(LC_ALL, "");
+        ^~~~~~~~~
+        ast_setlocale
+      sccp_utils.c:1846:12: error: 'LC_ALL' undeclared (first use in this function); did you mean 'AI_ALL'?
+        setlocale(LC_ALL, "");
+                  ^~~~~~
+                  AI_ALL
+      sccp_utils.c:1846:12: note: each undeclared identifier is reported only once for each function it appears in
+      Makefile:852: recipe for target 'libsccp_la-sccp_utils.lo' failed
+      make[7]: *** [libsccp_la-sccp_utils.lo] Error 1
+    
+    Fix this by adding the missing header.
+    
+    Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
+
+diff --git a/src/sccp_utils.c b/src/sccp_utils.c
+index df043d1a..f917c0c9 100644
+--- a/src/sccp_utils.c
++++ b/src/sccp_utils.c
+@@ -10,6 +10,7 @@
+  *
+  */
+ 
++#include <locale.h>
+ #include "config.h"
+ #include "common.h"
+ #include "sccp_channel.h"


### PR DESCRIPTION
Patch applied upstream. Fixes compiles for arc targets, which already
use new gcc8 toolchain.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: ath79, archs
Run tested: N/A (compile fix only)

Description:
Hello Jiri,

I checked for compile failures on the build bots. Only found sccp not compiling (on ARC, which uses new toolchain already). The rest of the packages (including chan-lantiq) compile fine.

Patch was applied upstream by Diederik.

Kind regards,
Seb