### PR TITLE
freeswitch-stable: init script update

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PRG_NAME:=freeswitch
 PKG_NAME:=$(PRG_NAME)-stable
 PKG_VERSION:=1.8.5
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=$(PRG_NAME)-$(PKG_VERSION).tar.xz

--- a/net/freeswitch-stable/files/freeswitch.init
+++ b/net/freeswitch-stable/files/freeswitch.init
@@ -10,7 +10,7 @@ USE_PROCD=1
 NAME=freeswitch
 COMMAND=/usr/bin/$NAME
 
-LOGGER="/usr/bin/logger -p user.err -s -t $NAME"
+LOGGER="/usr/bin/logger -p user.err -s -t $NAME --"
 
 start_service() {
   local dir
@@ -55,16 +55,51 @@ start_service() {
   config_get dir_storage    directories storage    /tmp/$NAME/storage
   config_get dir_temp       directories temp       /tmp/$NAME/temp
 
-  for dir in "$dir_cache" "$dir_db" "$dir_localstate" \
-    "$dir_log" "$dir_recordings" "$dir_run" "$dir_storage" \
-    "$dir_temp"
-  do
-    [ ! -e "$dir" ] && {
-      mkdir -p "$dir"
-      chown "$user":"$group" "$dir"
-      chmod 750 "$dir"
-    }
-  done
+  user_exists "$user" || {
+    $LOGGER user \""$user"\" does not exist
+    exit 1
+  }
+
+  group_exists "$group" || {
+    $LOGGER group \""$group"\" does not exist
+    exit 1
+  }
+
+  # do not touch directories that already exist
+  # posix shell does not support arrays, hence using awk
+  awk \
+    -v user="$user" \
+    -v group="$group" \
+    -v a="$dir_cache" \
+    -v b="$dir_db" \
+    -v c="$dir_localstate" \
+    -v d="$dir_log" \
+    -v e="$dir_recordings" \
+    -v f="$dir_run" \
+    -v g="$dir_storage" \
+    -v h="$dir_temp" \
+    '
+      BEGIN {
+        dir[0]=a
+        dir[1]=b
+        dir[2]=c
+        dir[3]=d
+        dir[4]=e
+        dir[5]=f
+        dir[6]=g
+        dir[7]=h
+        for (x in dir) {
+          if (system("test ! -e \"" dir[x] "\"" )) {
+            delete dir[x]
+          }
+        }
+        for (x in dir) {
+          system("mkdir -p \"" dir[x] "\"" )
+          system("chmod 750 \"" dir[x] "\"" )
+          system("chown \"" user "\":\"" group "\" \"" dir[x] "\"" )
+        }
+      }
+    '
 
   config_get options general options
 


### PR DESCRIPTION
- added trailing '--' to logger to make it foolproof
- the script now checks if user and group exist
- directory creation is now done via awk script (more robust)

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: ath79
Run tested: ath79, master, checked if logging, user/group check and dir creation work

Description:
While working on asterisk init I saw some things that could also be applied to fs init.