### PR TITLE
dahdi-linux: bump to 3.0.0

### DIFF
--- a/libs/dahdi-linux/Makefile
+++ b/libs/dahdi-linux/Makefile
@@ -9,19 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=dahdi-linux
-PKG_VERSION:=2.11.1-20180111
-PKG_RELEASE:=2
+PKG_VERSION:=3.0.0
+PKG_RELEASE:=1
 
-#PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-#PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/dahdi-linux/releases
-#PKG_HASH:=f59f382365118205e77d2874f1c0e1546e936247bcc45f07a43bc21778bee9df
-
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/asterisk/dahdi-linux.git
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=26597a5cac2930c191ae540c03c7406745c03e36
-PKG_MIRROR_HASH:=0eaad3c3ed63efa61e6b807bd70e9b5287271f5dd63af9f41c026a5f979b81d3
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/dahdi-linux/releases
+PKG_HASH:=02a8a680d20a3e243f37259edc3554ab9a488595a28562c45c33da3792d12caa
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE
@@ -34,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 define KernelPackage/dahdi
   SUBMENU:=Voice over IP
   TITLE:=DAHDI basic infrastructure
-  DEPENDS:=@USB_SUPPORT +kmod-lib-crc-ccitt
+  DEPENDS:=@!(LINUX_4_9||LINUX_4_14) @USB_SUPPORT +kmod-lib-crc-ccitt
   URL:=http://www.asterisk.org/
   FILES:= $(PKG_BUILD_DIR)/drivers/dahdi/dahdi.$(LINUX_KMOD_SUFFIX)
   AUTOLOAD:=$(call AutoProbe,dahdi)

--- a/libs/dahdi-linux/patches/003-fix-oslec-build.patch
+++ b/libs/dahdi-linux/patches/003-fix-oslec-build.patch
@@ -1,6 +1,6 @@
 --- a/drivers/dahdi/Kbuild
 +++ b/drivers/dahdi/Kbuild
-@@ -61,9 +61,8 @@ obj-m += $(DAHDI_MODULES_EXTRA)
+@@ -54,9 +54,8 @@ obj-m += $(DAHDI_MODULES_EXTRA)
  # If you want to build OSLEC, include the code in the standard location:
  # drivers/staging/echo . The DAHDI OSLEC echo canceller will be built as
  # well:
@@ -10,4 +10,4 @@
 -obj-m += ../staging/echo/echo.o
  endif
  
- CFLAGS_MODULE += -I$(DAHDI_INCLUDE) -I$(src)
+ CFLAGS_MODULE += -I$(DAHDI_INCLUDE) -I$(src) -Wno-format-truncation

--- a/libs/dahdi-linux/patches/100-add-support-for-hfc-s-pci.patch
+++ b/libs/dahdi-linux/patches/100-add-support-for-hfc-s-pci.patch
@@ -1,8 +1,8 @@
 --- a/drivers/dahdi/Kbuild
 +++ b/drivers/dahdi/Kbuild
-@@ -13,6 +13,7 @@ obj-$(DAHDI_BUILD_ALL)$(CONFIG_DAHDI_WCT
+@@ -12,6 +12,7 @@ obj-$(DAHDI_BUILD_ALL)$(CONFIG_DAHDI_WCT
+ obj-$(DAHDI_BUILD_ALL)$(CONFIG_DAHDI_WCTC4XXP)		+= wctc4xxp/
  obj-$(DAHDI_BUILD_ALL)$(CONFIG_DAHDI_WCTDM24XXP)	+= wctdm24xxp/
- obj-$(DAHDI_BUILD_ALL)$(CONFIG_DAHDI_WCTE12XP)		+= wcte12xp/
  obj-$(DAHDI_BUILD_ALL)$(CONFIG_DAHDI_WCTE13XP)		+= wcte13xp.o
 +obj-$(DAHDI_BUILD_ALL)$(CONFIG_DAHDI_HFCS)		+= hfcs/
  
@@ -10,9 +10,9 @@
  CFLAGS_wcte13xp-base.o += -I$(src)/oct612x -I$(src)/oct612x/include -I$(src)/oct612x/octdeviceapi -I$(src)/oct612x/octdeviceapi/oct6100api
 --- a/drivers/dahdi/Kconfig
 +++ b/drivers/dahdi/Kconfig
-@@ -291,4 +291,14 @@ config DAHDI_WCTE11XP
- 
+@@ -223,4 +223,14 @@ config DAHDI_DYNAMIC_LOC
  	  If unsure, say Y.
+ 
  
 +config DAHDI_HFCS
 +	tristate "Support for various HFC-S PCI BRI adapters"


### PR DESCRIPTION
This commit goes back from using a git checkout to using a regular
upstream tarball. Version bumped to 3.0.0 which works with kernels
equal to or greater than 4.15. Patches refreshed.

resolves #427

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: ath79 against kernel 4.19.50
Run tested: don't have the hardware

Description:
Hi Jiri,

Petr sent a patch to openwrt-devel earlier today ([here](https://lists.infradead.org/pipermail/openwrt-devel/2019-June/017666.html)) that switches all but two targets to 4.19. Once this gets merged would be the right time to commit this bump PR.

I'll ping again once this happens.

Kind regards,
Seb