### PR TITLE
baresip: fix recursive dependency

### DIFF
--- a/net/baresip/Makefile
+++ b/net/baresip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=baresip
 PKG_VERSION:=0.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.creytiv.com/pub
@@ -199,7 +199,7 @@ $(eval $(call BuildPlugin,oss,OSS audio driver,oss,))
 $(eval $(call BuildPlugin,plc,Packet Loss Concealment,plc,+libspandsp))
 $(eval $(call BuildPlugin,portaudio,Portaudio audio driver,portaudio,+portaudio))
 $(eval $(call BuildPlugin,presence,Presence module,presence,))
-$(eval $(call BuildPlugin,pulse,Pulseaudio audio driver,pulse,+pulseaudio))
+$(eval $(call BuildPlugin,pulse,Pulseaudio audio driver,pulse,PACKAGE_$(PKG_NAME)-mod-pulse:pulseaudio))
 $(eval $(call BuildPlugin,rtcpsummary,RTCP summary module,rtcpsummary,))
 $(eval $(call BuildPlugin,selfview,Video selfview module,selfview,))
 $(eval $(call BuildPlugin,sndfile,Audio dumper using libsndfile,sndfile,+libsndfile))


### PR DESCRIPTION
Since OpenWrt commit e82a4d9cfb ("config: regenerate *_shipped sources")
a few recursive dependencies have been discovered that were not visible
before.

$ make menuconfig
tmp/.config-package.in:103098:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:103098: symbol PACKAGE_baresip-mod-pulse depends on PACKAGE_baresip-mod-pulse
tmp/.config-package.in:121863:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:121863: symbol PACKAGE_pulseaudio-profiles depends on PACKAGE_pulseaudio-profiles
tmp/.config-package.in:121878:error: recursive dependency detected!
For a resolution refer to Documentation/kbuild/kconfig-language.txt
subsection "Kconfig recursive dependency limitations"
tmp/.config-package.in:121878: symbol PACKAGE_pulseaudio-tools depends on PACKAGE_pulseaudio-tools

The recursive dependencies were reported at [1] and [2].

This commit addresses the recursive dependency of baresip-mod-pulse. The
new dependency string may look a bit peculiar, but it works and when
specified like this pulseaudio (when selected) doesn't get compiled
automatically when the intention is only to build baresip with mod-pulse
disabled (which in general is why we have the "patsubst" in the module
builder - but this is only triggered when the dependency has a leading
"+").

[1] https://github.com/openwrt/packages/issues/9300
[2] https://forum.openwrt.org/t/make-menuconfig-errors-this-day/38673/5

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta
Compile tested: master/ath79
Run tested: N/A (dependency fix only)

Description: Fixes recursive dependency.
