### PR TITLE
(for 17.01) asterisk-13.x: fix AST-2019-003

### DIFF
--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk13
 PKG_VERSION:=13.19.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases/

--- a/net/asterisk-13.x/patches/080-AST-2019-003-13.diff
+++ b/net/asterisk-13.x/patches/080-AST-2019-003-13.diff
@@ -1,0 +1,39 @@
+From 3ab9291a563656dfebcb7de67c86351541f3de1c Mon Sep 17 00:00:00 2001
+From: Francesco Castellano <francesco.castellano@messagenet.it>
+Date: Fri, 28 Jun 2019 18:15:31 +0200
+Subject: [PATCH] chan_sip: Handle invalid SDP answer to T.38 re-invite
+
+The chan_sip module performs a T.38 re-invite using a single media
+stream of udptl, and expects the SDP answer to be the same.
+
+If an SDP answer is received instead that contains an additional
+media stream with no joint codec a crash will occur as the code
+assumes that at least one joint codec will exist in this
+scenario.
+
+This change removes this assumption.
+
+ASTERISK-28465
+
+Change-Id: I8b02845b53344c6babe867a3f0a5231045c7ac87
+---
+
+diff --git a/channels/chan_sip.c b/channels/chan_sip.c
+index 7c8928d..223ff3c 100644
+--- a/channels/chan_sip.c
++++ b/channels/chan_sip.c
+@@ -10911,7 +10911,13 @@
+ 			    ast_rtp_lookup_mime_multiple2(s3, NULL, newnoncodeccapability, 0, 0));
+ 	}
+ 
+-	if (portno != -1 || vportno != -1 || tportno != -1) {
++	/* When UDPTL is negotiated it is expected that there are no compatible codecs as audio or
++	 * video is not being transported, thus we continue in this function further up if that is
++	 * the case. If we receive an SDP answer containing both a UDPTL stream and another media
++	 * stream however we need to check again to ensure that there is at least one joint codec
++	 * instead of assuming there is one.
++	 */
++	if ((portno != -1 || vportno != -1 || tportno != -1) && ast_format_cap_count(newjointcapability)) {
+ 		/* We are now ready to change the sip session and RTP structures with the offered codecs, since
+ 		   they are acceptable */
+ 		unsigned int framing;


### PR DESCRIPTION
https://downloads.asterisk.org/pub/security/AST-2019-003.html

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: ar71xx 17.01
Run tested: N/A

Description:
Hi Jiri,

I'm raising PRs for AST-2019-002 and AST-2019-003, released today. They're both remote crash vulns, but only concern in-dialog messaging, severity is low/minor according to upstream.

While they affect 13, 15 and 16, AST-2019-002 seems to not be applicable to versions which don't contain at least commit "bridge_softmix: Forward TEXT frames". The function "check_content_type_any_text()" or "check_content_type_in_dialog()" simply don't exist then. So in this case I'll only add the upstream patch for AST-2019-003.

Regards,
Seb