### PR TITLE
asterisk-1{3,6}.x: fix AST-2019-002 & AST-2019-003

### DIFF
--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk13
 PKG_VERSION:=13.24.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk-13.x/patches/110-AST-2019-002-13.diff
+++ b/net/asterisk-13.x/patches/110-AST-2019-002-13.diff
@@ -1,0 +1,35 @@
+From a9d8b56831146166abc7fb8abe8ae8aaff295358 Mon Sep 17 00:00:00 2001
+From: George Joseph <gjoseph@digium.com>
+Date: Wed, 12 Jun 2019 12:03:04 -0600
+Subject: [PATCH] res_pjsip_messaging:  Check for body in in-dialog message
+
+We now check that a body exists and it has a length > 0 before
+attempting to process it.
+
+ASTERISK-28447
+Reported-by: Gil Richard
+
+Change-Id: Ic469544b22ab848734636588d4c93426cc6f4b1f
+---
+
+diff --git a/res/res_pjsip_messaging.c b/res/res_pjsip_messaging.c
+index 10c5f29..76d37f2 100644
+--- a/res/res_pjsip_messaging.c
++++ b/res/res_pjsip_messaging.c
+@@ -91,10 +91,13 @@
+ 	static const pj_str_t text = { "text", 4};
+ 	static const pj_str_t application = { "application", 11};
+ 
++	if (!(rdata->msg_info.msg->body && rdata->msg_info.msg->body->len > 0)) {
++		return res;
++	}
++
+ 	/* We'll accept any text/ or application/ content type */
+-	if (rdata->msg_info.msg->body && rdata->msg_info.msg->body->len
+-		&& (pj_stricmp(&rdata->msg_info.msg->body->content_type.type, &text) == 0
+-			|| pj_stricmp(&rdata->msg_info.msg->body->content_type.type, &application) == 0)) {
++	if (pj_stricmp(&rdata->msg_info.msg->body->content_type.type, &text) == 0
++			|| pj_stricmp(&rdata->msg_info.msg->body->content_type.type, &application) == 0) {
+ 		res = PJSIP_SC_OK;
+ 	} else if (rdata->msg_info.ctype
+ 		&& (pj_stricmp(&rdata->msg_info.ctype->media.type, &text) == 0

--- a/net/asterisk-13.x/patches/120-AST-2019-003-13.diff
+++ b/net/asterisk-13.x/patches/120-AST-2019-003-13.diff
@@ -1,0 +1,39 @@
+From 3ab9291a563656dfebcb7de67c86351541f3de1c Mon Sep 17 00:00:00 2001
+From: Francesco Castellano <francesco.castellano@messagenet.it>
+Date: Fri, 28 Jun 2019 18:15:31 +0200
+Subject: [PATCH] chan_sip: Handle invalid SDP answer to T.38 re-invite
+
+The chan_sip module performs a T.38 re-invite using a single media
+stream of udptl, and expects the SDP answer to be the same.
+
+If an SDP answer is received instead that contains an additional
+media stream with no joint codec a crash will occur as the code
+assumes that at least one joint codec will exist in this
+scenario.
+
+This change removes this assumption.
+
+ASTERISK-28465
+
+Change-Id: I8b02845b53344c6babe867a3f0a5231045c7ac87
+---
+
+diff --git a/channels/chan_sip.c b/channels/chan_sip.c
+index 7c8928d..223ff3c 100644
+--- a/channels/chan_sip.c
++++ b/channels/chan_sip.c
+@@ -10911,7 +10911,13 @@
+ 			    ast_rtp_lookup_mime_multiple2(s3, NULL, newnoncodeccapability, 0, 0));
+ 	}
+ 
+-	if (portno != -1 || vportno != -1 || tportno != -1) {
++	/* When UDPTL is negotiated it is expected that there are no compatible codecs as audio or
++	 * video is not being transported, thus we continue in this function further up if that is
++	 * the case. If we receive an SDP answer containing both a UDPTL stream and another media
++	 * stream however we need to check again to ensure that there is at least one joint codec
++	 * instead of assuming there is one.
++	 */
++	if ((portno != -1 || vportno != -1 || tportno != -1) && ast_format_cap_count(newjointcapability)) {
+ 		/* We are now ready to change the sip session and RTP structures with the offered codecs, since
+ 		   they are acceptable */
+ 		unsigned int framing;

--- a/net/asterisk-16.x/Makefile
+++ b/net/asterisk-16.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 AST_MAJOR_VERSION:=16
 PKG_NAME:=asterisk$(AST_MAJOR_VERSION)
 PKG_VERSION:=$(AST_MAJOR_VERSION).3.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk-16.x/patches/140-AST-2019-002-16.diff
+++ b/net/asterisk-16.x/patches/140-AST-2019-002-16.diff
@@ -1,0 +1,40 @@
+From 785bf3a755e47d92caef110e6040295764d08127 Mon Sep 17 00:00:00 2001
+From: George Joseph <gjoseph@digium.com>
+Date: Wed, 12 Jun 2019 12:03:04 -0600
+Subject: [PATCH] res_pjsip_messaging:  Check for body in in-dialog message
+
+We now check that a body exists and it has a length > 0 before
+attempting to process it.
+
+ASTERISK-28447
+Reported-by: Gil Richard
+
+Change-Id: Ic469544b22ab848734636588d4c93426cc6f4b1f
+---
+ res/res_pjsip_messaging.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/res/res_pjsip_messaging.c b/res/res_pjsip_messaging.c
+index 0e10a8f047..930cf84a53 100644
+--- a/res/res_pjsip_messaging.c
++++ b/res/res_pjsip_messaging.c
+@@ -90,10 +90,13 @@ static enum pjsip_status_code check_content_type_in_dialog(const pjsip_rx_data *
+ 	static const pj_str_t text = { "text", 4};
+ 	static const pj_str_t application = { "application", 11};
+ 
++	if (!(rdata->msg_info.msg->body && rdata->msg_info.msg->body->len > 0)) {
++		return res;
++	}
++
+ 	/* We'll accept any text/ or application/ content type */
+-	if (rdata->msg_info.msg->body && rdata->msg_info.msg->body->len
+-		&& (pj_stricmp(&rdata->msg_info.msg->body->content_type.type, &text) == 0
+-			|| pj_stricmp(&rdata->msg_info.msg->body->content_type.type, &application) == 0)) {
++	if (pj_stricmp(&rdata->msg_info.msg->body->content_type.type, &text) == 0
++			|| pj_stricmp(&rdata->msg_info.msg->body->content_type.type, &application) == 0) {
+ 		res = PJSIP_SC_OK;
+ 	} else if (rdata->msg_info.ctype
+ 		&& (pj_stricmp(&rdata->msg_info.ctype->media.type, &text) == 0
+-- 
+2.21.0
+

--- a/net/asterisk-16.x/patches/150-AST-2019-003-16.diff
+++ b/net/asterisk-16.x/patches/150-AST-2019-003-16.diff
@@ -1,0 +1,39 @@
+From 1e4df0215af4f192ed06a7fc7589c799f1ec6091 Mon Sep 17 00:00:00 2001
+From: Francesco Castellano <francesco.castellano@messagenet.it>
+Date: Fri, 28 Jun 2019 18:15:31 +0200
+Subject: [PATCH] chan_sip: Handle invalid SDP answer to T.38 re-invite
+
+The chan_sip module performs a T.38 re-invite using a single media
+stream of udptl, and expects the SDP answer to be the same.
+
+If an SDP answer is received instead that contains an additional
+media stream with no joint codec a crash will occur as the code
+assumes that at least one joint codec will exist in this
+scenario.
+
+This change removes this assumption.
+
+ASTERISK-28465
+
+Change-Id: I8b02845b53344c6babe867a3f0a5231045c7ac87
+---
+
+diff --git a/channels/chan_sip.c b/channels/chan_sip.c
+index 898b646..a609ff8 100644
+--- a/channels/chan_sip.c
++++ b/channels/chan_sip.c
+@@ -10965,7 +10965,13 @@
+ 			    ast_rtp_lookup_mime_multiple2(s3, NULL, newnoncodeccapability, 0, 0));
+ 	}
+ 
+-	if (portno != -1 || vportno != -1 || tportno != -1) {
++	/* When UDPTL is negotiated it is expected that there are no compatible codecs as audio or
++	 * video is not being transported, thus we continue in this function further up if that is
++	 * the case. If we receive an SDP answer containing both a UDPTL stream and another media
++	 * stream however we need to check again to ensure that there is at least one joint codec
++	 * instead of assuming there is one.
++	 */
++	if ((portno != -1 || vportno != -1 || tportno != -1) && ast_format_cap_count(newjointcapability)) {
+ 		/* We are now ready to change the sip session and RTP structures with the offered codecs, since
+ 		   they are acceptable */
+ 		unsigned int framing;


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: ath79 master
Run tested: N/A

Description:
CVE fixes. This if for master and the last of the PRs.

Small reminder, it'd be great if we could get rid of asterisk 13. CVE-patching the asterisk packages is double the work always :-)