### PR TITLE
asterisk-16.x: upgrade pbx-lua dep to liblua5.3

### DIFF
--- a/net/asterisk-16.x/Makefile
+++ b/net/asterisk-16.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 AST_MAJOR_VERSION:=16
 PKG_NAME:=asterisk$(AST_MAJOR_VERSION)
 PKG_VERSION:=$(AST_MAJOR_VERSION).3.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases
@@ -920,7 +920,7 @@ $(eval $(call BuildAsteriskModule,odbc,ODBC,ODBC support.,+libpthread +libc +uni
 $(eval $(call BuildAsteriskModule,pbx-ael,Asterisk Extension Logic,Asterisk Extension Language compiler.,+$(PKG_NAME)-res-ael-share,extensions.ael,pbx_ael,,))
 $(eval $(call BuildAsteriskModule,pbx-dundi,Dundi,Distributed Universal Number Discovery.,,dundi.conf,pbx_dundi,,))
 $(eval $(call BuildAsteriskModule,pbx-loopback,Loopback switch,Loopback switch.,,,pbx_loopback,,))
-$(eval $(call BuildAsteriskModule,pbx-lua,Lua,Lua PBX switch.,+liblua,extensions.lua,pbx_lua,,))
+$(eval $(call BuildAsteriskModule,pbx-lua,Lua,Lua PBX switch.,+liblua5.3,extensions.lua,pbx_lua,,))
 $(eval $(call BuildAsteriskModule,pbx-realtime,Realtime Switch,Realtime switch.,,,pbx_realtime,,))
 $(eval $(call BuildAsteriskModule,pbx-spool,Call Spool,Outgoing spool support.,,,pbx_spool,,))
 $(eval $(call BuildAsteriskModule,pgsql,PostgreSQL,PostgreSQL support.,+libpq,cel_pgsql.conf cdr_pgsql.conf res_pgsql.conf,cel_pgsql cdr_pgsql res_config_pgsql,,))


### PR DESCRIPTION
Recently liblua5.3 was added in the base repo. When both default liblua
and liblua5.3 are staged, asterisk will prefer the latter. But then the
dependency is wrong, because the linked-to lib is in liblua5.3.

This commit upgrades the dependency from liblua to liblua5.3.

Resolves #441.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: ath79, master
Run tested: N/A, just a dep fix

Description:
Hi Jiri,

I hope you're enjoying the summer!

Kind regards,
Seb