### PR TITLE
freeswitch-stable: use qstrip

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -718,8 +718,7 @@ CONFIGURE_VARS+= \
 
 # Regarding apr_cv_mutex_robust_shared=no see
 # http://www.openwall.com/lists/musl/2016/11/26/1
-# _Don't_ remove quotes below!
-ifeq ($(CONFIG_LIBC),"musl")
+ifeq ($(call qstrip,$(CONFIG_LIBC)),musl)
 CONFIGURE_VARS+= \
 	apr_cv_mutex_robust_shared=no \
 	ac_cv_strerror_r_rc_int=yes


### PR DESCRIPTION
It's better to rely on qstrip than to look for certain quotes.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: ath79 master
Run tested: N/A, just a Makefile update

Description:
Wanted to do this for a long time, but kept forgetting about it.