### PR TITLE
[19.07] asterisk-16.x: add patch for AST-2019-004

### DIFF
--- a/net/asterisk-16.x/Makefile
+++ b/net/asterisk-16.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 AST_MAJOR_VERSION:=16
 PKG_NAME:=asterisk$(AST_MAJOR_VERSION)
 PKG_VERSION:=$(AST_MAJOR_VERSION).3.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk-16.x/patches/160-AST-2019-004-16.patch
+++ b/net/asterisk-16.x/patches/160-AST-2019-004-16.patch
@@ -1,0 +1,171 @@
+From 69ed619a6d9b64a297d3099b6455756912e21d0b Mon Sep 17 00:00:00 2001
+From: Kevin Harwell <kharwell@digium.com>
+Date: Tue, 20 Aug 2019 15:05:45 -0500
+Subject: [PATCH] AST-2019-004 - res_pjsip_t38.c: Add NULL checks before using session media
+
+After receiving a 200 OK with a declined stream in response to a T.38
+initiated re-invite Asterisk would crash when attempting to dereference
+a NULL session media object.
+
+This patch checks to make sure the session media object is not NULL before
+attempting to use it.
+
+ASTERISK-28495
+patches:
+  ast-2019-004.patch submitted by Alexei Gradinari (license 5691)
+
+Change-Id: I168f45f4da29cfe739acf87e597baa2aae7aa572
+---
+
+diff --git a/res/res_pjsip_t38.c b/res/res_pjsip_t38.c
+index 11804e2..e5c6090 100644
+--- a/res/res_pjsip_t38.c
++++ b/res/res_pjsip_t38.c
+@@ -203,7 +203,6 @@
+ {
+ 	RAII_VAR(struct ast_sip_session *, session, obj, ao2_cleanup);
+ 	RAII_VAR(struct ast_datastore *, datastore, ast_sip_session_get_datastore(session, "t38"), ao2_cleanup);
+-	struct ast_sip_session_media *session_media;
+ 
+ 	if (!datastore) {
+ 		return 0;
+@@ -212,8 +211,7 @@
+ 	ast_debug(2, "Automatically rejecting T.38 request on channel '%s'\n",
+ 		session->channel ? ast_channel_name(session->channel) : "<gone>");
+ 
+-	session_media = session->pending_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-	t38_change_state(session, session_media, datastore->data, T38_REJECTED);
++	t38_change_state(session, NULL, datastore->data, T38_REJECTED);
+ 	ast_sip_session_resume_reinvite(session);
+ 
+ 	return 0;
+@@ -322,28 +320,37 @@
+ 		int index;
+ 
+ 		session_media = session->active_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-		t38_change_state(session, session_media, state, T38_ENABLED);
++		if (!session_media) {
++			ast_log(LOG_WARNING, "Received %d response to T.38 re-invite on '%s' but no active session media\n",
++					status.code, session->channel ? ast_channel_name(session->channel) : "unknown channel");
++		} else {
++			t38_change_state(session, session_media, state, T38_ENABLED);
+ 
+-		/* Stop all the streams in the stored away active state, they'll go back to being active once
+-		 * we reinvite back.
+-		 */
+-		for (index = 0; index < AST_VECTOR_SIZE(&state->media_state->sessions); ++index) {
+-			struct ast_sip_session_media *session_media = AST_VECTOR_GET(&state->media_state->sessions, index);
++			/* Stop all the streams in the stored away active state, they'll go back to being active once
++			 * we reinvite back.
++			 */
++			for (index = 0; index < AST_VECTOR_SIZE(&state->media_state->sessions); ++index) {
++				struct ast_sip_session_media *session_media = AST_VECTOR_GET(&state->media_state->sessions, index);
+ 
+-			if (session_media && session_media->handler && session_media->handler->stream_stop) {
+-				session_media->handler->stream_stop(session_media);
++				if (session_media && session_media->handler && session_media->handler->stream_stop) {
++					session_media->handler->stream_stop(session_media);
++				}
+ 			}
++
++			return 0;
+ 		}
+ 	} else {
+ 		session_media = session->pending_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-		t38_change_state(session, session_media, state, T38_REJECTED);
+-
+-		/* Abort this attempt at switching to T.38 by resetting the pending state and freeing our stored away active state */
+-		ast_sip_session_media_state_free(state->media_state);
+-		state->media_state = NULL;
+-		ast_sip_session_media_state_reset(session->pending_media_state);
+ 	}
+ 
++	/* If no session_media then response contained a declined stream, so disable */
++	t38_change_state(session, NULL, state, session_media ? T38_REJECTED : T38_DISABLED);
++
++	/* Abort this attempt at switching to T.38 by resetting the pending state and freeing our stored away active state */
++	ast_sip_session_media_state_free(state->media_state);
++	state->media_state = NULL;
++	ast_sip_session_media_state_reset(session->pending_media_state);
++
+ 	return 0;
+ }
+ 
+@@ -426,12 +433,10 @@
+ 		/* Negotiation can not take place without a valid max_ifp value. */
+ 		if (!parameters->max_ifp) {
+ 			if (data->session->t38state == T38_PEER_REINVITE) {
+-				session_media = data->session->pending_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-				t38_change_state(data->session, session_media, state, T38_REJECTED);
++				t38_change_state(data->session, NULL, state, T38_REJECTED);
+ 				ast_sip_session_resume_reinvite(data->session);
+ 			} else if (data->session->t38state == T38_ENABLED) {
+-				session_media = data->session->active_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-				t38_change_state(data->session, session_media, state, T38_DISABLED);
++				t38_change_state(data->session, NULL, state, T38_DISABLED);
+ 				ast_sip_session_refresh(data->session, NULL, NULL, NULL,
+ 					AST_SIP_SESSION_REFRESH_METHOD_INVITE, 1, state->media_state);
+ 				state->media_state = NULL;
+@@ -454,6 +459,11 @@
+ 			state->our_parms.version = MIN(state->our_parms.version, state->their_parms.version);
+ 			state->our_parms.rate_management = state->their_parms.rate_management;
+ 			session_media = data->session->pending_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
++			if (!session_media) {
++				ast_log(LOG_ERROR, "Failed to negotiate parameters for reinvite on channel '%s' (No pending session media).\n",
++					data->session->channel ? ast_channel_name(data->session->channel) : "unknown channel");
++				break;
++			}
+ 			ast_udptl_set_local_max_ifp(session_media->udptl, state->our_parms.max_ifp);
+ 			t38_change_state(data->session, session_media, state, T38_ENABLED);
+ 			ast_sip_session_resume_reinvite(data->session);
+@@ -468,8 +478,13 @@
+ 			}
+ 			state->our_parms = *parameters;
+ 			session_media = media_state->default_session[AST_MEDIA_TYPE_IMAGE];
++			if (!session_media) {
++				ast_log(LOG_ERROR, "Failed to negotiate parameters on channel '%s' (No default session media).\n",
++					data->session->channel ? ast_channel_name(data->session->channel) : "unknown channel");
++				break;
++			}
+ 			ast_udptl_set_local_max_ifp(session_media->udptl, state->our_parms.max_ifp);
+-			t38_change_state(data->session, session_media, state, T38_LOCAL_REINVITE);
++			t38_change_state(data->session, NULL, state, T38_LOCAL_REINVITE);
+ 			ast_sip_session_refresh(data->session, NULL, t38_reinvite_sdp_cb, t38_reinvite_response_cb,
+ 				AST_SIP_SESSION_REFRESH_METHOD_INVITE, 1, media_state);
+ 		}
+@@ -478,12 +493,10 @@
+ 	case AST_T38_REFUSED:
+ 	case AST_T38_REQUEST_TERMINATE:         /* Shutdown T38 */
+ 		if (data->session->t38state == T38_PEER_REINVITE) {
+-			session_media = data->session->pending_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-			t38_change_state(data->session, session_media, state, T38_REJECTED);
++			t38_change_state(data->session, NULL, state, T38_REJECTED);
+ 			ast_sip_session_resume_reinvite(data->session);
+ 		} else if (data->session->t38state == T38_ENABLED) {
+-			session_media = data->session->active_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-			t38_change_state(data->session, session_media, state, T38_DISABLED);
++			t38_change_state(data->session, NULL, state, T38_DISABLED);
+ 			ast_sip_session_refresh(data->session, NULL, NULL, NULL, AST_SIP_SESSION_REFRESH_METHOD_INVITE, 1, state->media_state);
+ 			state->media_state = NULL;
+ 		}
+@@ -493,6 +506,11 @@
+ 
+ 		if (data->session->t38state == T38_PEER_REINVITE) {
+ 			session_media = data->session->pending_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
++			if (!session_media) {
++				ast_log(LOG_ERROR, "Failed to request parameters for reinvite on channel '%s' (No pending session media).\n",
++					data->session->channel ? ast_channel_name(data->session->channel) : "unknown channel");
++				break;
++			}
+ 			parameters.max_ifp = ast_udptl_get_far_max_ifp(session_media->udptl);
+ 			parameters.request_response = AST_T38_REQUEST_NEGOTIATE;
+ 			ast_queue_control_data(data->session->channel, AST_CONTROL_T38_PARAMETERS, &parameters, sizeof(parameters));
+@@ -788,7 +806,7 @@
+ 
+ 	if ((session->t38state == T38_REJECTED) || (session->t38state == T38_DISABLED)) {
+ 		ast_debug(3, "Declining; T.38 state is rejected or declined\n");
+-		t38_change_state(session, session_media, state, T38_DISABLED);
++		t38_change_state(session, NULL, state, T38_DISABLED);
+ 		return 0;
+ 	}
+ 


### PR DESCRIPTION
Add patch for a remote crash vulnerability. Crash can occur when
negotiating for T.38 with a declined stream.

CVE-2019-15297

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: master (uses same Asterisk version)
Run tested: master

Description:
Same CVE fix as for master