### PR TITLE
[18.06] asterisk-15.x: add patch for AST-2019-004

### DIFF
--- a/net/asterisk-15.x/Makefile
+++ b/net/asterisk-15.x/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk15
 PKG_VERSION:=15.3.0
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk-15.x/patches/120-AST-2018-008-15.diff
+++ b/net/asterisk-15.x/patches/120-AST-2018-008-15.diff
@@ -19,11 +19,9 @@ ASTERISK-27818
 Change-Id: Icb275a54ff8e2df6c671a6d9bda37b5d732b3b32
 ---
 
-diff --git a/res/res_pjsip/pjsip_distributor.c b/res/res_pjsip/pjsip_distributor.c
-index 51b95a2..0af447d 100644
 --- a/res/res_pjsip/pjsip_distributor.c
 +++ b/res/res_pjsip/pjsip_distributor.c
-@@ -676,6 +676,26 @@
+@@ -676,6 +676,26 @@ static void check_endpoint(pjsip_rx_data
  	ao2_unlock(unid);
  }
  
@@ -50,7 +48,7 @@ index 51b95a2..0af447d 100644
  static pj_bool_t endpoint_lookup(pjsip_rx_data *rdata)
  {
  	struct ast_sip_endpoint *endpoint;
-@@ -695,6 +715,7 @@
+@@ -694,6 +714,7 @@ static pj_bool_t endpoint_lookup(pjsip_r
  			ao2_unlink(unidentified_requests, unid);
  			ao2_ref(unid, -1);
  		}
@@ -58,7 +56,7 @@ index 51b95a2..0af447d 100644
  		return PJ_FALSE;
  	}
  
-@@ -759,6 +780,8 @@
+@@ -753,6 +774,8 @@ static pj_bool_t endpoint_lookup(pjsip_r
  			ast_sip_report_invalid_endpoint(name, rdata);
  		}
  	}
@@ -67,7 +65,7 @@ index 51b95a2..0af447d 100644
  	return PJ_FALSE;
  }
  
-@@ -842,16 +865,11 @@
+@@ -836,16 +859,11 @@ static pj_bool_t authenticate(pjsip_rx_d
  
  	ast_assert(endpoint != NULL);
  
@@ -87,7 +85,7 @@ index 51b95a2..0af447d 100644
  		pjsip_tx_data *tdata;
  		struct unidentified_request *unid;
  
-@@ -888,6 +906,10 @@
+@@ -881,6 +899,10 @@ static pj_bool_t authenticate(pjsip_rx_d
  			return PJ_TRUE;
  		}
  		pjsip_tx_data_dec_ref(tdata);
@@ -98,4 +96,3 @@ index 51b95a2..0af447d 100644
  	}
  
  	return PJ_FALSE;
-

--- a/net/asterisk-15.x/patches/150-AST-2019-001-15.diff
+++ b/net/asterisk-15.x/patches/150-AST-2019-001-15.diff
@@ -19,11 +19,9 @@ Reported by: Sotiris Ganouris
 Change-Id: Ia095cb16b4862f2f6ad6d2d2a77453fa2542371f
 ---
 
-diff --git a/res/res_pjsip_sdp_rtp.c b/res/res_pjsip_sdp_rtp.c
-index e2067cc..7f5a859 100644
 --- a/res/res_pjsip_sdp_rtp.c
 +++ b/res/res_pjsip_sdp_rtp.c
-@@ -1941,7 +1941,7 @@
+@@ -1722,7 +1722,7 @@ static int apply_negotiated_sdp_stream(s
  	}
  
  	if (set_caps(session, session_media, session_media_transport, remote_stream, 0, asterisk_stream)) {

--- a/net/asterisk-15.x/patches/160-AST-2019-003-15.diff
+++ b/net/asterisk-15.x/patches/160-AST-2019-003-15.diff
@@ -18,11 +18,9 @@ ASTERISK-28465
 Change-Id: I8b02845b53344c6babe867a3f0a5231045c7ac87
 ---
 
-diff --git a/channels/chan_sip.c b/channels/chan_sip.c
-index fe2ae1e..6251878 100644
 --- a/channels/chan_sip.c
 +++ b/channels/chan_sip.c
-@@ -10921,7 +10921,13 @@
+@@ -10917,7 +10917,13 @@ static int process_sdp(struct sip_pvt *p
  			    ast_rtp_lookup_mime_multiple2(s3, NULL, newnoncodeccapability, 0, 0));
  	}
  
@@ -36,4 +34,4 @@ index fe2ae1e..6251878 100644
 +	if ((portno != -1 || vportno != -1 || tportno != -1) && ast_format_cap_count(newjointcapability)) {
  		/* We are now ready to change the sip session and RTP structures with the offered codecs, since
  		   they are acceptable */
- 		unsigned int framing;
+ 		ast_format_cap_remove_by_type(p->jointcaps, AST_MEDIA_TYPE_UNKNOWN);

--- a/net/asterisk-15.x/patches/170-AST-2019-004-15.patch
+++ b/net/asterisk-15.x/patches/170-AST-2019-004-15.patch
@@ -1,0 +1,169 @@
+From f361e65dc2c90aaee9472f97b54083e0a2d49303 Mon Sep 17 00:00:00 2001
+From: Kevin Harwell <kharwell@digium.com>
+Date: Tue, 20 Aug 2019 15:05:45 -0500
+Subject: [PATCH] AST-2019-004 - res_pjsip_t38.c: Add NULL checks before using session media
+
+After receiving a 200 OK with a declined stream in response to a T.38
+initiated re-invite Asterisk would crash when attempting to dereference
+a NULL session media object.
+
+This patch checks to make sure the session media object is not NULL before
+attempting to use it.
+
+ASTERISK-28495
+patches:
+  ast-2019-004.patch submitted by Alexei Gradinari (license 5691)
+
+Change-Id: I168f45f4da29cfe739acf87e597baa2aae7aa572
+---
+
+--- a/res/res_pjsip_t38.c
++++ b/res/res_pjsip_t38.c
+@@ -202,7 +202,6 @@ static int t38_automatic_reject(void *ob
+ {
+ 	RAII_VAR(struct ast_sip_session *, session, obj, ao2_cleanup);
+ 	RAII_VAR(struct ast_datastore *, datastore, ast_sip_session_get_datastore(session, "t38"), ao2_cleanup);
+-	struct ast_sip_session_media *session_media;
+ 
+ 	if (!datastore) {
+ 		return 0;
+@@ -211,8 +210,7 @@ static int t38_automatic_reject(void *ob
+ 	ast_debug(2, "Automatically rejecting T.38 request on channel '%s'\n",
+ 		session->channel ? ast_channel_name(session->channel) : "<gone>");
+ 
+-	session_media = session->pending_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-	t38_change_state(session, session_media, datastore->data, T38_REJECTED);
++	t38_change_state(session, NULL, datastore->data, T38_REJECTED);
+ 	ast_sip_session_resume_reinvite(session);
+ 
+ 	return 0;
+@@ -312,28 +310,37 @@ static int t38_reinvite_response_cb(stru
+ 		int index;
+ 
+ 		session_media = session->active_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-		t38_change_state(session, session_media, state, T38_ENABLED);
++		if (!session_media) {
++			ast_log(LOG_WARNING, "Received %d response to T.38 re-invite on '%s' but no active session media\n",
++					status.code, session->channel ? ast_channel_name(session->channel) : "unknown channel");
++		} else {
++			t38_change_state(session, session_media, state, T38_ENABLED);
+ 
+-		/* Stop all the streams in the stored away active state, they'll go back to being active once
+-		 * we reinvite back.
+-		 */
+-		for (index = 0; index < AST_VECTOR_SIZE(&state->media_state->sessions); ++index) {
+-			struct ast_sip_session_media *session_media = AST_VECTOR_GET(&state->media_state->sessions, index);
++			/* Stop all the streams in the stored away active state, they'll go back to being active once
++			 * we reinvite back.
++			 */
++			for (index = 0; index < AST_VECTOR_SIZE(&state->media_state->sessions); ++index) {
++				struct ast_sip_session_media *session_media = AST_VECTOR_GET(&state->media_state->sessions, index);
+ 
+-			if (session_media && session_media->handler && session_media->handler->stream_stop) {
+-				session_media->handler->stream_stop(session_media);
++				if (session_media && session_media->handler && session_media->handler->stream_stop) {
++					session_media->handler->stream_stop(session_media);
++				}
+ 			}
++
++			return 0;
+ 		}
+ 	} else {
+ 		session_media = session->pending_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-		t38_change_state(session, session_media, state, T38_REJECTED);
+-
+-		/* Abort this attempt at switching to T.38 by resetting the pending state and freeing our stored away active state */
+-		ast_sip_session_media_state_free(state->media_state);
+-		state->media_state = NULL;
+-		ast_sip_session_media_state_reset(session->pending_media_state);
+ 	}
+ 
++	/* If no session_media then response contained a declined stream, so disable */
++	t38_change_state(session, NULL, state, session_media ? T38_REJECTED : T38_DISABLED);
++
++	/* Abort this attempt at switching to T.38 by resetting the pending state and freeing our stored away active state */
++	ast_sip_session_media_state_free(state->media_state);
++	state->media_state = NULL;
++	ast_sip_session_media_state_reset(session->pending_media_state);
++
+ 	return 0;
+ }
+ 
+@@ -416,12 +423,10 @@ static int t38_interpret_parameters(void
+ 		/* Negotiation can not take place without a valid max_ifp value. */
+ 		if (!parameters->max_ifp) {
+ 			if (data->session->t38state == T38_PEER_REINVITE) {
+-				session_media = data->session->pending_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-				t38_change_state(data->session, session_media, state, T38_REJECTED);
++				t38_change_state(data->session, NULL, state, T38_REJECTED);
+ 				ast_sip_session_resume_reinvite(data->session);
+ 			} else if (data->session->t38state == T38_ENABLED) {
+-				session_media = data->session->active_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-				t38_change_state(data->session, session_media, state, T38_DISABLED);
++				t38_change_state(data->session, NULL, state, T38_DISABLED);
+ 				ast_sip_session_refresh(data->session, NULL, NULL, NULL,
+ 					AST_SIP_SESSION_REFRESH_METHOD_INVITE, 1, state->media_state);
+ 				state->media_state = NULL;
+@@ -444,6 +449,11 @@ static int t38_interpret_parameters(void
+ 			state->our_parms.version = MIN(state->our_parms.version, state->their_parms.version);
+ 			state->our_parms.rate_management = state->their_parms.rate_management;
+ 			session_media = data->session->pending_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
++			if (!session_media) {
++				ast_log(LOG_ERROR, "Failed to negotiate parameters for reinvite on channel '%s' (No pending session media).\n",
++					data->session->channel ? ast_channel_name(data->session->channel) : "unknown channel");
++				break;
++			}
+ 			ast_udptl_set_local_max_ifp(session_media->udptl, state->our_parms.max_ifp);
+ 			t38_change_state(data->session, session_media, state, T38_ENABLED);
+ 			ast_sip_session_resume_reinvite(data->session);
+@@ -458,8 +468,13 @@ static int t38_interpret_parameters(void
+ 			}
+ 			state->our_parms = *parameters;
+ 			session_media = media_state->default_session[AST_MEDIA_TYPE_IMAGE];
++			if (!session_media) {
++				ast_log(LOG_ERROR, "Failed to negotiate parameters on channel '%s' (No default session media).\n",
++					data->session->channel ? ast_channel_name(data->session->channel) : "unknown channel");
++				break;
++			}
+ 			ast_udptl_set_local_max_ifp(session_media->udptl, state->our_parms.max_ifp);
+-			t38_change_state(data->session, session_media, state, T38_LOCAL_REINVITE);
++			t38_change_state(data->session, NULL, state, T38_LOCAL_REINVITE);
+ 			ast_sip_session_refresh(data->session, NULL, t38_reinvite_sdp_cb, t38_reinvite_response_cb,
+ 				AST_SIP_SESSION_REFRESH_METHOD_INVITE, 1, media_state);
+ 		}
+@@ -468,12 +483,10 @@ static int t38_interpret_parameters(void
+ 	case AST_T38_REFUSED:
+ 	case AST_T38_REQUEST_TERMINATE:         /* Shutdown T38 */
+ 		if (data->session->t38state == T38_PEER_REINVITE) {
+-			session_media = data->session->pending_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-			t38_change_state(data->session, session_media, state, T38_REJECTED);
++			t38_change_state(data->session, NULL, state, T38_REJECTED);
+ 			ast_sip_session_resume_reinvite(data->session);
+ 		} else if (data->session->t38state == T38_ENABLED) {
+-			session_media = data->session->active_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
+-			t38_change_state(data->session, session_media, state, T38_DISABLED);
++			t38_change_state(data->session, NULL, state, T38_DISABLED);
+ 			ast_sip_session_refresh(data->session, NULL, NULL, NULL, AST_SIP_SESSION_REFRESH_METHOD_INVITE, 1, state->media_state);
+ 			state->media_state = NULL;
+ 		}
+@@ -483,6 +496,11 @@ static int t38_interpret_parameters(void
+ 
+ 		if (data->session->t38state == T38_PEER_REINVITE) {
+ 			session_media = data->session->pending_media_state->default_session[AST_MEDIA_TYPE_IMAGE];
++			if (!session_media) {
++				ast_log(LOG_ERROR, "Failed to request parameters for reinvite on channel '%s' (No pending session media).\n",
++					data->session->channel ? ast_channel_name(data->session->channel) : "unknown channel");
++				break;
++			}
+ 			parameters.max_ifp = ast_udptl_get_far_max_ifp(session_media->udptl);
+ 			parameters.request_response = AST_T38_REQUEST_NEGOTIATE;
+ 			ast_queue_control_data(data->session->channel, AST_CONTROL_T38_PARAMETERS, &parameters, sizeof(parameters));
+@@ -757,7 +775,7 @@ static int negotiate_incoming_sdp_stream
+ 
+ 	if ((session->t38state == T38_REJECTED) || (session->t38state == T38_DISABLED)) {
+ 		ast_debug(3, "Declining; T.38 state is rejected or declined\n");
+-		t38_change_state(session, session_media, state, T38_DISABLED);
++		t38_change_state(session, NULL, state, T38_DISABLED);
+ 		return -1;
+ 	}
+ 


### PR DESCRIPTION
Add patch for a remote crash vulnerability. Crash can occur when
negotiating for T.38 with a declined stream.

CVE-2019-15297

Refreshed some other patches.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: 18.06 ar71xx
Run tested: master

Description:
Same CVE fix for 18.06. Had to fiddle with one patch hunk where the next line in our 15.x version returns a different result than in the patch. Should be fine. Refreshed some other patches.