### PR TITLE
bcg729: add pkg-config file

### DIFF
--- a/libs/bcg729/Makefile
+++ b/libs/bcg729/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcg729
 PKG_VERSION:=1.0.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.linphone.org/releases/sources/bcg729
@@ -51,11 +51,14 @@ CMAKE_OPTIONS += \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/bcg729
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/bcg729/*.h $(1)/usr/include/bcg729
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libbcg729.so* $(1)/usr/lib/
-	$(INSTALL_DIR) $(1)/usr/lib/cmake/Bcg729
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/Bcg729/cmake/*.cmake $(1)/usr/lib/cmake/Bcg729
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/bcg729/*.h \
+		$(1)/usr/include/bcg729
+	$(INSTALL_DIR) $(1)/usr/lib/{cmake/Bcg729,pkgconfig}
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libbcg729.so* $(1)/usr/lib
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/lib$(PKG_NAME).pc \
+		$(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/Bcg729/cmake/*.cmake \
+		$(1)/usr/lib/cmake/Bcg729
 endef
 
 define Package/bcg729/install

--- a/libs/bcg729/patches/01-install-pkg-config-file.patch
+++ b/libs/bcg729/patches/01-install-pkg-config-file.patch
@@ -1,0 +1,30 @@
+commit a5907daf1b111e4ad7aab4f558f57e2af1e37e55
+Author: Peter Wu <peter@lekensteyn.nl>
+Date:   Mon Feb 4 13:08:10 2019 +0100
+
+    CMake: install pkg-config files for parity with autotools
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a271876..e1496a7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -92,6 +92,19 @@ configure_file(Bcg729Config.cmake.in
+ 	@ONLY
+ )
+ 
++set(prefix "${CMAKE_INSTALL_PREFIX}")
++set(exec_prefix "\${prefix}")
++set(includedir  "\${prefix}/include")
++set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
++configure_file(libbcg729.pc.in
++	"${CMAKE_CURRENT_BINARY_DIR}/libbcg729.pc"
++	@ONLY
++)
++install(FILES
++	"${CMAKE_CURRENT_BINARY_DIR}/libbcg729.pc"
++	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
++)
++
+ set(CONFIG_PACKAGE_LOCATION "${CMAKE_INSTALL_DATADIR}/Bcg729/cmake")
+ install(EXPORT Bcg729Targets
+ 	FILE Bcg729Targets.cmake


### PR DESCRIPTION
Patch from upstream.

With the .pc file available we can drop a hack in rtpproxy's Makefile.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: master ath79
Run tested: N/A, no runtime change

Description:
Add .pc file.