### PR TITLE
net/freeswitch-stable: remove old warning

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -437,17 +437,6 @@ if [ -z "$${IPKG_INSTROOT}" ]; then
   echo "| https://openwrt.org/docs/guide-user/services/voip/freeswitch      |"
   echo "o-------------------------------------------------------------=^_^=-o"
   echo
-  [ -f /etc/hotplug.d/iface/99-freeswitch ] && {
-    echo "o-------------------------------------------------------------------o"
-    echo "| WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING   |"
-    echo "o-------------------------------------------------------------------o"
-    echo "| Please remove freeswitch-stable-misc-hotplug. The hotplug script  |"
-    echo "| is now part of the main freeswitch-stable package. Please run:    |"
-    echo "|                                                                   |"
-    echo "| opkg remove freeswitch-stable-misc-hotplug                        |"
-    echo "o-------------------------------------------------------------=^_^=-o"
-    echo
-  }
 fi
 exit 0
 endef


### PR DESCRIPTION
This warning is not relevant anymore.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: N/A
Run tested: N/A

Description:
Remove obsolete comment.