### PR TITLE
pcapsipdump: update to trunk snapshot

### DIFF
--- a/net/pcapsipdump/Makefile
+++ b/net/pcapsipdump/Makefile
@@ -8,12 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pcapsipdump
-PKG_VERSION:=0.2
-PKG_RELEASE:=3
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/pcapsipdump
-PKG_HASH:=4d4dc2664963c08de40da47ca0dcd1eeae09edc42241bd6daa7ff8c59089dce9
+PKG_SOURCE_PROTO:=svn
+PKG_SOURCE_URL:=https://svn.code.sf.net/p/pcapsipdump/code/trunk
+PKG_SOURCE_VERSION:=151
+PKG_SOURCE_DATE=2019-10-07
+PKG_RELEASE:=1
+PKG_MIRROR_HASH:=a029b29946f0492220fc9c60ef3e7f0a7a0c660f0047957eab6802ae6b9f9ed4
 
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=LICENSE
@@ -36,10 +37,7 @@ define Package/pcapsipdump/description
  (even if there is thousands of concurrect SIP sessions).
 endef
 
-MAKE_FLAGS += \
-	CC="$(TARGET_CXX)" \
-	CPPFLAGS="$(TARGET_CXXFLAGS) -fno-rtti $(TARGET_CPPFLAGS)" \
-	LIBS="-lpcap"
+MAKE_FLAGS+=LIBS="-lpcap"
 
 define Package/pcapsipdump/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
The last official release is quite old. But pcapsipdump's trunk has seen
a steady stream of fixes and improvements. This commit updates the
package to a current SVN snapshot.

MAKE_FLAGS is simplified. The deleted ARGS are provided by OpenWrt
buildroot, no need to specify them again. All that is needed is LIBS.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: x86_64 native, ath79 master on OpenWrt
Run tested: dlink router, mips BE

Description:
Hi Jiri,

When working on upgrading this I ran into some problems. There was a tiny compile issue and an endian problem. But the pcapsipdump maintainer was very helpful (and very quick) and now fixes are upstream.

Kind regards,
Seb