### PR TITLE
pcapsipdump: fix missing libbsd depend

### DIFF
--- a/net/pcapsipdump/Makefile
+++ b/net/pcapsipdump/Makefile
@@ -13,7 +13,7 @@ PKG_SOURCE_PROTO:=svn
 PKG_SOURCE_URL:=https://svn.code.sf.net/p/pcapsipdump/code/trunk
 PKG_SOURCE_VERSION:=151
 PKG_SOURCE_DATE=2019-10-07
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MIRROR_HASH:=a029b29946f0492220fc9c60ef3e7f0a7a0c660f0047957eab6802ae6b9f9ed4
 
 PKG_LICENSE:=GPL-2.0+
@@ -26,7 +26,7 @@ define Package/pcapsipdump
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Telephony
-  DEPENDS:=+libpcap $(CXX_DEPENDS)
+  DEPENDS:=$(CXX_DEPENDS) +USE_GLIBC:libbsd +libpcap
   TITLE:=SIP sessions dumping tool
   URL:=http://sourceforge.net/projects/pcapsipdump/
 endef

--- a/net/pcapsipdump/patches/01-use-libc-strlcpy-if-available-v2.patch
+++ b/net/pcapsipdump/patches/01-use-libc-strlcpy-if-available-v2.patch
@@ -1,0 +1,64 @@
+--- a/Makefile
++++ b/Makefile
+@@ -2,8 +2,12 @@ LIBS ?= -lpcap -lstdc++
+ RELEASEFLAGS ?= -O3 -Wall
+ #CXXFLAGS ?= --std=c++0x
+ 
++# check if libc provides BSD's strlcpy
++ifeq ($(shell $(CXX) $(CXXFLAGS) -D_BSD_SOURCE $(LDFLAGS) $(DEFS) -o /dev/null \
++	make-checks/strlcpy.cpp 2>/dev/null; echo $$?),0)
++	BSDSTR_DEFS := -D_BSD_SOURCE -DUSE_LIBC_STRLCPY
+ # auto-detect if bsd/strings.h is available
+-ifeq ($(shell $(CXX) $(CXXFLAGS) $(LDFLAGS) $(DEFS) -E -o /dev/null \
++else ifeq ($(shell $(CXX) $(CXXFLAGS) $(LDFLAGS) $(DEFS) -E -o /dev/null \
+     	make-checks/libbsd.cpp 2>/dev/null; echo $$?),0)
+ 	BSDSTR_DEFS := -DUSE_BSD_STRING_H
+ 	BSDSTR_LIBS := -lbsd
+--- a/pcapsipdump_lib.h
++++ b/pcapsipdump_lib.h
+@@ -3,7 +3,7 @@
+ #ifndef BSD
+   #ifdef USE_BSD_STRING_H
+     #include <bsd/string.h>
+-  #else
++  #elif !defined(USE_LIBC_STRLCPY)
+     #define strlcpy strncpy
+   #endif
+ #endif
+--- a/make-checks/all.mk
++++ b/make-checks/all.mk
+@@ -1,5 +1,5 @@
+-make-checks/all: make-checks/cxx make-checks/libpcap make-checks/libbsd
++make-checks/all: make-checks/cxx make-checks/libpcap make-checks/strlcpy make-checks/libbsd
+ 	@touch make-checks/all
+ 
+ make-checks/clean:
+-	rm -f make-checks/all make-checks/cxx make-checks/libpcap make-checks/libbsd
++	rm -f make-checks/all make-checks/cxx make-checks/libpcap make-checks/strlcpy make-checks/libbsd
+--- a/make-checks/libbsd.mk
++++ b/make-checks/libbsd.mk
+@@ -2,5 +2,5 @@ CHECK_LIBBSD = $(CXX) $(CXXFLAGS) $(LDFL
+ 
+ make-checks/libbsd:
+ 	@$(CHECK_LIBBSD) || (\
+-	  echo "*** notice: recommended library not found: libbsd"; \
++	  echo "*** notice: library not found: libbsd"; \
+ 	  true)
+--- /dev/null
++++ b/make-checks/strlcpy.cpp
+@@ -0,0 +1,6 @@
++#include <string.h>
++int main(int argc, char **argv) {
++	char dst[10];
++	strlcpy(dst, "test", sizeof(dst));
++	return 0;
++}
+--- /dev/null
++++ b/make-checks/strlcpy.mk
+@@ -0,0 +1,6 @@
++CHECK_STRLCPY = $(CXX) $(CXXFLAGS) -D_BSD_SOURCE $(LDFLAGS) make-checks/strlcpy.cpp -o make-checks/strlcpy 2>/dev/null
++
++make-checks/strlcpy:
++	@$(CHECK_STRLCPY) || (\
++	  echo "*** notice: your libc doesn't provide strlcpy()"; \
++	  true)


### PR DESCRIPTION
When libbsd is available in staging it will be picked up by pcapsipdump
during the compile. The binary will link to libbsd, causing an
additional dependency. Currently the builds on the bots are failing
because of this.

The only function pcapsipdump is using from libbsd is strlcpy(). This
function is also provided by uClibc as well as musl.

Attached patch adds a detection mechanism that checks whether libc
provides strlcpy(). This way the dependency on libbsd is only required if
building against a libc which doesn't package strlcpy(), like glibc.
DEPENDS are updated to reflect that.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: ath79 master against musl, arc770 master against uClibc, x86_64 native compile against glibc
Run tested: ath79 master + musl on dlink router

Description:
Hi all,

Well, the previous pull request didn't work out so well on the build bots :) At home I didn't have libbsd in staging, so no problem. I had actually searched for it in packages and not found it, so I thought I didn't need to worry. But libbsd is in the base packages :)

Anyway, this solves that. The patch is submitted upstream, too.

Kind regards,
Seb