### PR TITLE
kamailio-5.x: remove rtp_media_server package

### DIFF
--- a/net/kamailio-5.x/Makefile
+++ b/net/kamailio-5.x/Makefile
@@ -165,7 +165,6 @@ MODULES_AVAILABLE:= \
 	rr \
 	rtimer \
 	rtjson \
-	rtp_media_server \
 	rtpengine \
 	rtpproxy \
 	sanity \
@@ -601,7 +600,6 @@ $(eval $(call BuildKamailio5Module,rls,Resource List Server,,+kamailio5-mod-pres
 $(eval $(call BuildKamailio5Module,rr,Record-Route and Route,,))
 $(eval $(call BuildKamailio5Module,rtimer,Routing Timer,,))
 $(eval $(call BuildKamailio5Module,rtjson,SIP routing based on JSON API,,))
-$(eval $(call BuildKamailio5Module,rtp_media_server,Embedded RTP server,,@BROKEN +bcunit +kamailio5-mod-tm +mediastreamer2 +ortp,))
 $(eval $(call BuildKamailio5Module,rtpengine,RTP engine,,+kamailio5-mod-tm))
 $(eval $(call BuildKamailio5Module,rtpproxy,RTP proxy,,+kamailio5-mod-tm))
 $(eval $(call BuildKamailio5Module,sanity,SIP sanity checks,,+kamailio5-mod-sl))


### PR DESCRIPTION
menuconfig is currently showing warnings for kamailio:

WARNING: Makefile 'package/feeds/telephony/kamailio-5.x/Makefile' has a dependency on 'bcunit', which does not exist
WARNING: Makefile 'package/feeds/telephony/kamailio-5.x/Makefile' has a dependency on 'mediastreamer2', which does not exist
WARNING: Makefile 'package/feeds/telephony/kamailio-5.x/Makefile' has a dependency on 'ortp', which does not exist

This commit removes the non-existent dependencies to clear the warnings.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: N/A
Run tested: N/A

Description:
Thanks to @hnyman for mentioning the _warnings_ in #480 