### PR TITLE
pjproject: fix pkg-config file

### DIFF
--- a/libs/pjproject/Makefile
+++ b/libs/pjproject/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pjproject
 PKG_VERSION:=2.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=pjproject-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.pjsip.org/release/$(PKG_VERSION)

--- a/libs/pjproject/patches/0006-fix-pkg_config-file.patch
+++ b/libs/pjproject/patches/0006-fix-pkg_config-file.patch
@@ -1,0 +1,25 @@
+--- a/libpjproject.pc.in
++++ b/libpjproject.pc.in
+@@ -2,8 +2,8 @@
+ 
+ prefix=@PREFIX@
+ exec_prefix=${prefix}
+-libdir=@LIBDIR@
+-includedir=@INCLUDEDIR@
++libdir=${exec_prefix}/lib
++includedir=${prefix}/include
+ 
+ Name: libpjproject
+ Description: Multimedia communication library
+--- a/build.mak.in
++++ b/build.mak.in
+@@ -310,8 +310,7 @@ export PJ_LIBXX_FILES := $(APP_LIBXX_FIL
+ # And here are the variables to use if application is using the
+ # library from the install location (i.e. --prefix)
+ export PJ_INSTALL_DIR := @prefix@
+-export PJ_INSTALL_INC_DIR := @includedir@
+ export PJ_INSTALL_LIB_DIR := @libdir@
+-export PJ_INSTALL_CFLAGS := -I$(PJ_INSTALL_INC_DIR) -DPJ_AUTOCONF=1 @CFLAGS@
++export PJ_INSTALL_CFLAGS := -DPJ_AUTOCONF=1 @CFLAGS@
+ export PJ_INSTALL_CXXFLAGS := @CXXFLAGS@ $(PJ_INSTALL_CFLAGS)
+ export PJ_INSTALL_LDFLAGS := -L$(PJ_INSTALL_LIB_DIR) $(APP_LDLIBS)


### PR DESCRIPTION
The .pc file uses hard-coded paths:

prefix=/usr
exec_prefix=${prefix}
libdir=/usr/lib
includedir=/usr/include

It also pushes "-I/usr/include" into CFLAGS. This commit amends all of
that.

Resolve: #483

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: master ath79
Run tested: N/A, no run-time change

Description:
Thanks @neheb for reporting!