### PR TITLE
[19.07] asterisk-16.x: add fixes for AST-2019-006 and 007

### DIFF
--- a/net/asterisk-16.x/Makefile
+++ b/net/asterisk-16.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 AST_MAJOR_VERSION:=16
 PKG_NAME:=asterisk$(AST_MAJOR_VERSION)
 PKG_VERSION:=$(AST_MAJOR_VERSION).3.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk-16.x/patches/170-AST-2019-006-16.diff
+++ b/net/asterisk-16.x/patches/170-AST-2019-006-16.diff
@@ -1,0 +1,73 @@
+From 8cdaa93e658a46e7baf6b606468b5e2c88a0133b Mon Sep 17 00:00:00 2001
+From: Ben Ford <bford@digium.com>
+Date: Mon, 21 Oct 2019 14:55:06 -0500
+Subject: [PATCH] chan_sip.c: Prevent address change on unauthenticated SIP request.
+
+If the name of a peer is known and a SIP request is sent using that
+peer's name, the address of the peer will change even if the request
+fails the authentication challenge. This means that an endpoint can
+be altered and even rendered unusuable, even if it was in a working
+state previously. This can only occur when the nat option is set to the
+default, or auto_force_rport.
+
+This change checks the result of authentication first to ensure it is
+successful before setting the address and the nat option.
+
+ASTERISK-28589 #close
+
+Change-Id: I581c5ed1da60ca89f590bd70872de2b660de02df
+---
+
+diff --git a/channels/chan_sip.c b/channels/chan_sip.c
+index 6ac2e61..4d79a47 100644
+--- a/channels/chan_sip.c
++++ b/channels/chan_sip.c
+@@ -19245,18 +19245,6 @@
+ 		bogus_peer = NULL;
+ 	}
+ 
+-	/*  build_peer, called through sip_find_peer, is not able to check the
+-	 *  sip_pvt->natdetected flag in order to determine if the peer is behind
+-	 *  NAT or not when SIP_PAGE3_NAT_AUTO_RPORT or SIP_PAGE3_NAT_AUTO_COMEDIA
+-	 *  are set on the peer.  So we check for that here and set the peer's
+-	 *  address accordingly.
+-	 */
+-	set_peer_nat(p, peer);
+-
+-	if (p->natdetected && ast_test_flag(&peer->flags[2], SIP_PAGE3_NAT_AUTO_RPORT)) {
+-		ast_sockaddr_copy(&peer->addr, &p->recv);
+-	}
+-
+ 	if (!ast_apply_acl(peer->acl, addr, "SIP Peer ACL: ")) {
+ 		ast_debug(2, "Found peer '%s' for '%s', but fails host access\n", peer->name, of);
+ 		sip_unref_peer(peer, "sip_unref_peer: check_peer_ok: from sip_find_peer call, early return of AUTH_ACL_FAILED");
+@@ -19325,6 +19313,21 @@
+ 		ast_string_field_set(p, peermd5secret, NULL);
+ 	}
+ 	if (!(res = check_auth(p, req, peer->name, p->peersecret, p->peermd5secret, sipmethod, uri2, reliable))) {
++
++		/* build_peer, called through sip_find_peer, is not able to check the
++		 * sip_pvt->natdetected flag in order to determine if the peer is behind
++		 * NAT or not when SIP_PAGE3_NAT_AUTO_RPORT or SIP_PAGE3_NAT_AUTO_COMEDIA
++		 * are set on the peer. So we check for that here and set the peer's
++		 * address accordingly. The address should ONLY be set once we are sure
++		 * authentication was a success. If, for example, an INVITE was sent that
++		 * matched the peer name but failed the authentication check, the address
++		 * would be updated, which is bad.
++		 */
++		set_peer_nat(p, peer);
++		if (p->natdetected && ast_test_flag(&peer->flags[2], SIP_PAGE3_NAT_AUTO_RPORT)) {
++			ast_sockaddr_copy(&peer->addr, &p->recv);
++		}
++
+ 		/* If we have a call limit, set flag */
+ 		if (peer->call_limit)
+ 			ast_set_flag(&p->flags[0], SIP_CALL_LIMIT);
+@@ -19424,6 +19427,7 @@
+ 		}
+ 	}
+ 	sip_unref_peer(peer, "check_peer_ok: sip_unref_peer: tossing temp ptr to peer from sip_find_peer");
++
+ 	return res;
+ }
+ 

--- a/net/asterisk-16.x/patches/180-AST-2019-007-16.diff
+++ b/net/asterisk-16.x/patches/180-AST-2019-007-16.diff
@@ -1,0 +1,46 @@
+From 7574be5110e049a44b8c8ead52cd1c2a5d442afa Mon Sep 17 00:00:00 2001
+From: George Joseph <gjoseph@digium.com>
+Date: Thu, 24 Oct 2019 11:41:23 -0600
+Subject: [PATCH] manager.c:  Prevent the Originate action from running the Originate app
+
+If an AMI user without the "system" authorization calls the
+Originate AMI command with the Originate application,
+the second Originate could run the "System" command.
+
+Action: Originate
+Channel: Local/1111
+Application: Originate
+Data: Local/2222,app,System,touch /tmp/owned
+
+If the "system" authorization isn't set, we now block the
+Originate app as well as the System, Exec, etc. apps.
+
+ASTERISK-28580
+Reported by: Eliel Sardañons
+
+Change-Id: Ic4c9dedc34c426f03c8c14fce334a71386d8a5fa
+---
+
+diff --git a/doc/UPGRADE-staging/AMI-Originate.txt b/doc/UPGRADE-staging/AMI-Originate.txt
+new file mode 100644
+index 0000000..f2d3133
+--- /dev/null
++++ b/doc/UPGRADE-staging/AMI-Originate.txt
+@@ -0,0 +1,5 @@
++Subject: AMI
++
++The AMI Originate action, which optionally takes a dialplan application as
++an argument, no longer accepts "Originate" as the application due to
++security concerns.
+diff --git a/main/manager.c b/main/manager.c
+index f138801..1963151 100644
+--- a/main/manager.c
++++ b/main/manager.c
+@@ -5744,6 +5744,7 @@
+ 				                                     EAGI(/bin/rm,-rf /)       */
+ 				strcasestr(app, "mixmonitor") ||  /* MixMonitor(blah,,rm -rf)  */
+ 				strcasestr(app, "externalivr") || /* ExternalIVR(rm -rf)       */
++				strcasestr(app, "originate") ||   /* Originate(Local/1234,app,System,rm -rf) */
+ 				(strstr(appdata, "SHELL") && (bad_appdata = 1)) ||       /* NoOp(${SHELL(rm -rf /)})  */
+ 				(strstr(appdata, "EVAL") && (bad_appdata = 1))           /* NoOp(${EVAL(${some_var_containing_SHELL})}) */
+ 				)) {


### PR DESCRIPTION
https://downloads.asterisk.org/pub/security/AST-2019-006.html
https://downloads.asterisk.org/pub/security/AST-2019-007.html

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: 19.07, ath79
Run tested: N/A, upstream security fixes, should be OK

Description:
Fix two security issues with patches from upstream.