### PR TITLE
[17.01] asterisk-13.x: add fixes for AST-2019-006, 007 & 008

### DIFF
--- a/net/asterisk-13.x/Makefile
+++ b/net/asterisk-13.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk13
 PKG_VERSION:=13.19.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases/

--- a/net/asterisk-13.x/patches/090-AST-2019-006-13.diff
+++ b/net/asterisk-13.x/patches/090-AST-2019-006-13.diff
@@ -1,0 +1,73 @@
+From c2279540bade208dad35f7760ebd4a7cc94731fe Mon Sep 17 00:00:00 2001
+From: Ben Ford <bford@digium.com>
+Date: Mon, 21 Oct 2019 14:55:06 -0500
+Subject: [PATCH] chan_sip.c: Prevent address change on unauthenticated SIP request.
+
+If the name of a peer is known and a SIP request is sent using that
+peer's name, the address of the peer will change even if the request
+fails the authentication challenge. This means that an endpoint can
+be altered and even rendered unusuable, even if it was in a working
+state previously. This can only occur when the nat option is set to the
+default, or auto_force_rport.
+
+This change checks the result of authentication first to ensure it is
+successful before setting the address and the nat option.
+
+ASTERISK-28589 #close
+
+Change-Id: I581c5ed1da60ca89f590bd70872de2b660de02df
+---
+
+diff --git a/channels/chan_sip.c b/channels/chan_sip.c
+index ea78d23..4a8d344 100644
+--- a/channels/chan_sip.c
++++ b/channels/chan_sip.c
+@@ -19103,18 +19103,6 @@
+ 		bogus_peer = NULL;
+ 	}
+ 
+-	/*  build_peer, called through sip_find_peer, is not able to check the
+-	 *  sip_pvt->natdetected flag in order to determine if the peer is behind
+-	 *  NAT or not when SIP_PAGE3_NAT_AUTO_RPORT or SIP_PAGE3_NAT_AUTO_COMEDIA
+-	 *  are set on the peer.  So we check for that here and set the peer's
+-	 *  address accordingly.
+-	 */
+-	set_peer_nat(p, peer);
+-
+-	if (p->natdetected && ast_test_flag(&peer->flags[2], SIP_PAGE3_NAT_AUTO_RPORT)) {
+-		ast_sockaddr_copy(&peer->addr, &p->recv);
+-	}
+-
+ 	if (!ast_apply_acl(peer->acl, addr, "SIP Peer ACL: ")) {
+ 		ast_debug(2, "Found peer '%s' for '%s', but fails host access\n", peer->name, of);
+ 		sip_unref_peer(peer, "sip_unref_peer: check_peer_ok: from sip_find_peer call, early return of AUTH_ACL_FAILED");
+@@ -19183,6 +19171,21 @@
+ 		ast_string_field_set(p, peermd5secret, NULL);
+ 	}
+ 	if (!(res = check_auth(p, req, peer->name, p->peersecret, p->peermd5secret, sipmethod, uri2, reliable))) {
++
++		/* build_peer, called through sip_find_peer, is not able to check the
++		 * sip_pvt->natdetected flag in order to determine if the peer is behind
++		 * NAT or not when SIP_PAGE3_NAT_AUTO_RPORT or SIP_PAGE3_NAT_AUTO_COMEDIA
++		 * are set on the peer. So we check for that here and set the peer's
++		 * address accordingly. The address should ONLY be set once we are sure
++		 * authentication was a success. If, for example, an INVITE was sent that
++		 * matched the peer name but failed the authentication check, the address
++		 * would be updated, which is bad.
++		 */
++		set_peer_nat(p, peer);
++		if (p->natdetected && ast_test_flag(&peer->flags[2], SIP_PAGE3_NAT_AUTO_RPORT)) {
++			ast_sockaddr_copy(&peer->addr, &p->recv);
++		}
++
+ 		/* If we have a call limit, set flag */
+ 		if (peer->call_limit)
+ 			ast_set_flag(&p->flags[0], SIP_CALL_LIMIT);
+@@ -19282,6 +19285,7 @@
+ 		}
+ 	}
+ 	sip_unref_peer(peer, "check_peer_ok: sip_unref_peer: tossing temp ptr to peer from sip_find_peer");
++
+ 	return res;
+ }
+ 

--- a/net/asterisk-13.x/patches/100-AST-2019-007-13.diff
+++ b/net/asterisk-13.x/patches/100-AST-2019-007-13.diff
@@ -1,0 +1,46 @@
+From 1b9281a5ded62e5d30af2959e5aa33bc5a0fc285 Mon Sep 17 00:00:00 2001
+From: George Joseph <gjoseph@digium.com>
+Date: Thu, 24 Oct 2019 11:41:23 -0600
+Subject: [PATCH] manager.c:  Prevent the Originate action from running the Originate app
+
+If an AMI user without the "system" authorization calls the
+Originate AMI command with the Originate application,
+the second Originate could run the "System" command.
+
+Action: Originate
+Channel: Local/1111
+Application: Originate
+Data: Local/2222,app,System,touch /tmp/owned
+
+If the "system" authorization isn't set, we now block the
+Originate app as well as the System, Exec, etc. apps.
+
+ASTERISK-28580
+Reported by: Eliel Sardañons
+
+Change-Id: Ic4c9dedc34c426f03c8c14fce334a71386d8a5fa
+---
+
+diff --git a/doc/UPGRADE-staging/AMI-Originate.txt b/doc/UPGRADE-staging/AMI-Originate.txt
+new file mode 100644
+index 0000000..f2d3133
+--- /dev/null
++++ b/doc/UPGRADE-staging/AMI-Originate.txt
+@@ -0,0 +1,5 @@
++Subject: AMI
++
++The AMI Originate action, which optionally takes a dialplan application as
++an argument, no longer accepts "Originate" as the application due to
++security concerns.
+diff --git a/main/manager.c b/main/manager.c
+index fc602bc..44e25b8 100644
+--- a/main/manager.c
++++ b/main/manager.c
+@@ -5708,6 +5708,7 @@
+ 				                                     EAGI(/bin/rm,-rf /)       */
+ 				strcasestr(app, "mixmonitor") ||  /* MixMonitor(blah,,rm -rf)  */
+ 				strcasestr(app, "externalivr") || /* ExternalIVR(rm -rf)       */
++				strcasestr(app, "originate") ||   /* Originate(Local/1234,app,System,rm -rf) */
+ 				(strstr(appdata, "SHELL") && (bad_appdata = 1)) ||       /* NoOp(${SHELL(rm -rf /)})  */
+ 				(strstr(appdata, "EVAL") && (bad_appdata = 1))           /* NoOp(${EVAL(${some_var_containing_SHELL})}) */
+ 				)) {

--- a/net/asterisk-13.x/patches/110-AST-2019-008-13.diff
+++ b/net/asterisk-13.x/patches/110-AST-2019-008-13.diff
@@ -1,0 +1,35 @@
+From c257794330db49f4079a7108d51da60696269b36 Mon Sep 17 00:00:00 2001
+From: Ben Ford <bford@digium.com>
+Date: Fri, 08 Nov 2019 13:21:15 -0600
+Subject: [PATCH] res_pjsip_session.c: Check for port of zero on incoming SDP.
+
+If a re-invite comes in initiating T.38, but there is no c line in the
+SDP and the port is also 0, a crash can occur. A check is now done on
+the port to see if the steam is already declined, preventing the crash.
+The logic was moved to res_pjsip_session.c because it is handled in a
+similar manner in later versions of Asterisk.
+
+ASTERISK-28612
+Reported by: Salah Ahmed
+
+Change-Id: Ifc4a0d05b32c7f2156e77fc8435a6ecaa6abada0
+---
+
+diff --git a/res/res_pjsip_session.c b/res/res_pjsip_session.c
+index 81f36a7..12cf41d 100644
+--- a/res/res_pjsip_session.c
++++ b/res/res_pjsip_session.c
+@@ -235,6 +235,13 @@
+ 			continue;
+ 		}
+ 
++		/* If we have a port of 0, ignore this stream */
++		if (!sdp->media[i]->desc.port) {
++			ast_debug(1, "Declining incoming SDP media stream '%s' at position '%d'\n",
++				session_media->stream_type, i);
++			continue;
++		}
++
+ 		if (session_media->handler) {
+ 			handler = session_media->handler;
+ 			ast_debug(1, "Negotiating incoming SDP media stream '%s' using %s SDP handler\n",


### PR DESCRIPTION
https://downloads.asterisk.org/pub/security/AST-2019-006.html
https://downloads.asterisk.org/pub/security/AST-2019-007.html
https://downloads.asterisk.org/pub/security/AST-2019-008.html

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: I tried to compile on 17.01, but menuconfig filed (unrelated to these patches). I think on the build bots this will be OK. Patches applied fine.
Run tested: N/A

Description:
Security patches from upstream.