### PR TITLE
(18.06) freeswitch-stable: patch CVEs in included libvpx

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PRG_NAME:=freeswitch
 PKG_NAME:=$(PRG_NAME)-stable
 PKG_VERSION:=1.8.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=$(PRG_NAME)-$(PKG_VERSION).tar.xz

--- a/net/freeswitch-stable/patches/430-CVE-2019-9232_9325_9433.patch
+++ b/net/freeswitch-stable/patches/430-CVE-2019-9232_9325_9433.patch
@@ -1,0 +1,156 @@
+
+Backport of
+
+From 46e17f0cb4a80b36755c84b8bf15731d3386c08f Mon Sep 17 00:00:00 2001
+From: kyslov <kyslov@google.com>
+Date: Fri, 4 Jan 2019 17:04:09 -0800
+Subject: [PATCH] Fix OOB memory access on fuzzed data
+
+From 0681cff1ad36b3ef8ec242f59b5a6c4234ccfb88 Mon Sep 17 00:00:00 2001
+From: James Zern <jzern@google.com>
+Date: Tue, 24 Jul 2018 21:36:50 -0700
+Subject: [PATCH] vp9: fix OOB read in decoder_peek_si_internal
+
+From 52add5896661d186dec284ed646a4b33b607d2c7 Mon Sep 17 00:00:00 2001
+From: Jerome Jiang <jianj@google.com>
+Date: Wed, 23 May 2018 15:43:00 -0700
+Subject: [PATCH] VP8: Fix use-after-free in postproc.
+
+to address CVE-2019-9232 CVE-2019-9325 CVE-2019-9433
+
+--- a/libs/libvpx/test/decode_api_test.cc
++++ b/libs/libvpx/test/decode_api_test.cc
+@@ -138,8 +138,30 @@ TEST(DecodeAPI, Vp9InvalidDecode) {
+   EXPECT_EQ(VPX_CODEC_OK, vpx_codec_destroy(&dec));
+ }
+ 
+-TEST(DecodeAPI, Vp9PeekSI) {
++void TestPeekInfo(const uint8_t *const data, uint32_t data_sz,
++                  uint32_t peek_size) {
+   const vpx_codec_iface_t *const codec = &vpx_codec_vp9_dx_algo;
++  // Verify behavior of vpx_codec_decode. vpx_codec_decode doesn't even get
++  // to decoder_peek_si_internal on frames of size < 8.
++  if (data_sz >= 8) {
++    vpx_codec_ctx_t dec;
++    EXPECT_EQ(VPX_CODEC_OK, vpx_codec_dec_init(&dec, codec, NULL, 0));
++    EXPECT_EQ((data_sz < peek_size) ? VPX_CODEC_UNSUP_BITSTREAM
++                                    : VPX_CODEC_CORRUPT_FRAME,
++              vpx_codec_decode(&dec, data, data_sz, NULL, 0));
++    vpx_codec_iter_t iter = NULL;
++    EXPECT_EQ(NULL, vpx_codec_get_frame(&dec, &iter));
++    EXPECT_EQ(VPX_CODEC_OK, vpx_codec_destroy(&dec));
++  }
++
++  // Verify behavior of vpx_codec_peek_stream_info.
++  vpx_codec_stream_info_t si;
++  si.sz = sizeof(si);
++  EXPECT_EQ((data_sz < peek_size) ? VPX_CODEC_UNSUP_BITSTREAM : VPX_CODEC_OK,
++            vpx_codec_peek_stream_info(codec, data, data_sz, &si));
++}
++
++TEST(DecodeAPI, Vp9PeekStreamInfo) {
+   // The first 9 bytes are valid and the rest of the bytes are made up. Until
+   // size 10, this should return VPX_CODEC_UNSUP_BITSTREAM and after that it
+   // should return VPX_CODEC_CORRUPT_FRAME.
+@@ -150,24 +172,18 @@ TEST(DecodeAPI, Vp9PeekSI) {
+   };
+ 
+   for (uint32_t data_sz = 1; data_sz <= 32; ++data_sz) {
+-    // Verify behavior of vpx_codec_decode. vpx_codec_decode doesn't even get
+-    // to decoder_peek_si_internal on frames of size < 8.
+-    if (data_sz >= 8) {
+-      vpx_codec_ctx_t dec;
+-      EXPECT_EQ(VPX_CODEC_OK, vpx_codec_dec_init(&dec, codec, NULL, 0));
+-      EXPECT_EQ(
+-          (data_sz < 10) ? VPX_CODEC_UNSUP_BITSTREAM : VPX_CODEC_CORRUPT_FRAME,
+-          vpx_codec_decode(&dec, data, data_sz, NULL, 0));
+-      vpx_codec_iter_t iter = NULL;
+-      EXPECT_EQ(NULL, vpx_codec_get_frame(&dec, &iter));
+-      EXPECT_EQ(VPX_CODEC_OK, vpx_codec_destroy(&dec));
+-    }
+-
+-    // Verify behavior of vpx_codec_peek_stream_info.
+-    vpx_codec_stream_info_t si;
+-    si.sz = sizeof(si);
+-    EXPECT_EQ((data_sz < 10) ? VPX_CODEC_UNSUP_BITSTREAM : VPX_CODEC_OK,
+-              vpx_codec_peek_stream_info(codec, data, data_sz, &si));
++    TestPeekInfo(data, data_sz, 10);
++  }
++}
++
++TEST(DecodeAPI, Vp9PeekStreamInfoTruncated) {
++  // This profile 1 header requires 10.25 bytes, ensure
++  // vpx_codec_peek_stream_info doesn't over read.
++  const uint8_t profile1_data[10] = { 0xa4, 0xe9, 0x30, 0x68, 0x53,
++                                      0xe9, 0x30, 0x68, 0x53, 0x04 };
++
++  for (uint32_t data_sz = 1; data_sz <= 10; ++data_sz) {
++    TestPeekInfo(profile1_data, data_sz, 11);
+   }
+ }
+ #endif  // CONFIG_VP9_DECODER
+--- a/libs/libvpx/vp8/common/postproc.c
++++ b/libs/libvpx/vp8/common/postproc.c
+@@ -64,7 +64,7 @@ void vp8_deblock(VP8_COMMON *cm, YV12_BU
+   double level = 6.0e-05 * q * q * q - .0067 * q * q + .306 * q + .0065;
+   int ppl = (int)(level + .5);
+ 
+-  const MODE_INFO *mode_info_context = cm->show_frame_mi;
++  const MODE_INFO *mode_info_context = cm->mi;
+   int mbr, mbc;
+ 
+   /* The pixel thresholds are adjusted according to if or not the macroblock
+--- a/libs/libvpx/vp8/decoder/dboolhuff.h
++++ b/libs/libvpx/vp8/decoder/dboolhuff.h
+@@ -76,7 +76,7 @@ static int vp8dx_decode_bool(BOOL_DECODE
+   }
+ 
+   {
+-    register int shift = vp8_norm[range];
++    const unsigned char shift = vp8_norm[(unsigned char)range];
+     range <<= shift;
+     value <<= shift;
+     count -= shift;
+--- a/libs/libvpx/vp9/vp9_dx_iface.c
++++ b/libs/libvpx/vp9/vp9_dx_iface.c
+@@ -129,7 +129,7 @@ static vpx_codec_err_t decoder_peek_si_i
+     const uint8_t *data, unsigned int data_sz, vpx_codec_stream_info_t *si,
+     int *is_intra_only, vpx_decrypt_cb decrypt_cb, void *decrypt_state) {
+   int intra_only_flag = 0;
+-  uint8_t clear_buffer[10];
++  uint8_t clear_buffer[11];
+ 
+   if (data + data_sz <= data) return VPX_CODEC_INVALID_PARAM;
+ 
+@@ -190,6 +190,9 @@ static vpx_codec_err_t decoder_peek_si_i
+         if (profile > PROFILE_0) {
+           if (!parse_bitdepth_colorspace_sampling(profile, &rb))
+             return VPX_CODEC_UNSUP_BITSTREAM;
++          // The colorspace info may cause vp9_read_frame_size() to need 11
++          // bytes.
++          if (data_sz < 11) return VPX_CODEC_UNSUP_BITSTREAM;
+         }
+         rb.bit_offset += REF_FRAMES;  // refresh_frame_flags
+         vp9_read_frame_size(&rb, (int *)&si->w, (int *)&si->h);
+--- a/libs/libvpx/vpx_dsp/bitreader.h
++++ b/libs/libvpx/vpx_dsp/bitreader.h
+@@ -94,7 +94,7 @@ static INLINE int vpx_read(vpx_reader *r
+   }
+ 
+   {
+-    register int shift = vpx_norm[range];
++    const unsigned char shift = vpx_norm[(unsigned char)range];
+     range <<= shift;
+     value <<= shift;
+     count -= shift;
+--- a/libs/libvpx/vpx_dsp/bitreader_buffer.c
++++ b/libs/libvpx/vpx_dsp/bitreader_buffer.c
+@@ -23,7 +23,7 @@ int vpx_rb_read_bit(struct vpx_read_bit_
+     rb->bit_offset = off + 1;
+     return bit;
+   } else {
+-    rb->error_handler(rb->error_handler_data);
++    if (rb->error_handler != NULL) rb->error_handler(rb->error_handler_data);
+     return 0;
+   }
+ }


### PR DESCRIPTION
Patch taken from Debian Stretch, fixes:

CVE-2019-9232
CVE-2019-9325
CVE-2019-9433

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: x86_64 18.06
Run tested: N/A, libvpx is used for video calls, which I don't use.

Description:
Fixes libvpx CVEs. Patch taken from Debian Stretch. Debian didn't included a fix for CVE-2019-9371 in Stretch stating that it's a minor issue, see [here](https://security-tracker.debian.org/tracker/CVE-2019-9371).

