### PR TITLE
asterisk-16.x: fix compile with PKG_ASLR_PIE

### DIFF
--- a/net/asterisk-16.x/Makefile
+++ b/net/asterisk-16.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 AST_MAJOR_VERSION:=16
 PKG_NAME:=asterisk$(AST_MAJOR_VERSION)
 PKG_VERSION:=$(AST_MAJOR_VERSION).6.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk-16.x/patches/056-fix-check_expr2-build.patch
+++ b/net/asterisk-16.x/patches/056-fix-check_expr2-build.patch
@@ -1,6 +1,15 @@
 --- a/utils/Makefile
 +++ b/utils/Makefile
-@@ -187,7 +187,6 @@ check_expr2: $(ASTTOPDIR)/main/ast_expr2
+@@ -180,14 +180,13 @@ conf2ael: conf2ael.o ast_expr2f.o ast_ex
+ 
+ check_expr2: $(ASTTOPDIR)/main/ast_expr2f.c $(ASTTOPDIR)/main/ast_expr2.c $(ASTTOPDIR)/main/ast_expr2.h astmm.o
+ 	$(ECHO_PREFIX) echo "   [CC] ast_expr2f.c -> ast_expr2fz.o"
+-	$(CC) -g -c -I$(ASTTOPDIR)/include -DSTANDALONE $(ASTTOPDIR)/main/ast_expr2f.c -o ast_expr2fz.o
++	$(CC) -g -c -I$(ASTTOPDIR)/include $(_ASTCFLAGS) $(ASTTOPDIR)/main/ast_expr2f.c -o ast_expr2fz.o
+ 	$(ECHO_PREFIX) echo "   [CC] ast_expr2.c -> ast_expr2z.o"
+-	$(CC) -g -c -I$(ASTTOPDIR)/include -DSTANDALONE2 $(ASTTOPDIR)/main/ast_expr2.c -o ast_expr2z.o
++	$(CC) -g -c -I$(ASTTOPDIR)/include $(_ASTCFLAGS) -DSTANDALONE2 $(ASTTOPDIR)/main/ast_expr2.c -o ast_expr2z.o
+ 	$(ECHO_PREFIX) echo "   [LD] ast_expr2fz.o ast_expr2z.o  -> check_expr2"
  	$(CC) -g -o check_expr2 ast_expr2fz.o ast_expr2z.o astmm.o -lm $(_ASTLDFLAGS)
  	$(ECHO_PREFIX) echo "   [RM] ast_expr2fz.o ast_expr2z.o"
  	rm ast_expr2z.o ast_expr2fz.o


### PR DESCRIPTION
CFLAGS aren't used when compiling objects for check_expr2. This commits
adds the flags, which fixes the compilation when PKG_ASLR_PIE is
enabled. Note: The STANDALONE define is removed because it is already
defined in _ASTCFLAGS.

Fixes #502

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: ath79 master
Run tested: ath79 19.07, copied over the check_expr2 executable and checked a file from the tests directory.

Description:
Fix ASLR PIE build fail

Hi Jiri, happy new year! :)