### PR TITLE
[19.07] asterisk-16.x: fix compile with PKG_ASLR_PIE

### DIFF
--- a/net/asterisk-16.x/Makefile
+++ b/net/asterisk-16.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 AST_MAJOR_VERSION:=16
 PKG_NAME:=asterisk$(AST_MAJOR_VERSION)
 PKG_VERSION:=$(AST_MAJOR_VERSION).3.0
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk-16.x/patches/056-fix-check_expr2-build.patch
+++ b/net/asterisk-16.x/patches/056-fix-check_expr2-build.patch
@@ -1,6 +1,33 @@
+From 06e8d5ad8e4728a716bf357c8d7f70367ae10280 Mon Sep 17 00:00:00 2001
+From: Sebastian Kemper <sebastian_ml@gmx.net>
+Date: Sun, 12 Jan 2020 12:37:46 +0100
+Subject: [PATCH] check_expr2: fix cross-compile/hardening issues
+
+When building check_expr2 with ASLR PIE hardening enabled the linker
+fails. This is resolved by adding the regular compiler flags when
+building the object files from ast_expr2f.c and ast_expr2.c.
+
+Note: The STANDALONE define is removed because it is already defined in
+_ASTCFLAGS. YY_NO_INPUT is defined so that the compile survives
+'--enable-dev-mode'.
+
+ASTERISK-28685 #close
+
+Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
+Change-Id: If435b7db9f9ad8266245bda51c81c220f9658915
+Taken just Makefile changes from commit: 06e8d5ad8e4728a716bf357c8d7f70367ae10280
 --- a/utils/Makefile
 +++ b/utils/Makefile
 @@ -187,7 +187,6 @@ check_expr2: $(ASTTOPDIR)/main/ast_expr2
+ 
+ check_expr2: $(ASTTOPDIR)/main/ast_expr2f.c $(ASTTOPDIR)/main/ast_expr2.c $(ASTTOPDIR)/main/ast_expr2.h astmm.o
+ 	$(ECHO_PREFIX) echo "   [CC] ast_expr2f.c -> ast_expr2fz.o"
+-	$(CC) -g -c -I$(ASTTOPDIR)/include -DSTANDALONE $(ASTTOPDIR)/main/ast_expr2f.c -o ast_expr2fz.o
++	$(CC) -g -c -I$(ASTTOPDIR)/include $(_ASTCFLAGS) $(ASTTOPDIR)/main/ast_expr2f.c -o ast_expr2fz.o
+ 	$(ECHO_PREFIX) echo "   [CC] ast_expr2.c -> ast_expr2z.o"
+-	$(CC) -g -c -I$(ASTTOPDIR)/include -DSTANDALONE2 $(ASTTOPDIR)/main/ast_expr2.c -o ast_expr2z.o
++	$(CC) -g -c -I$(ASTTOPDIR)/include $(_ASTCFLAGS) -DSTANDALONE2 $(ASTTOPDIR)/main/ast_expr2.c -o ast_expr2z.o
+ 	$(ECHO_PREFIX) echo "   [LD] ast_expr2fz.o ast_expr2z.o  -> check_expr2"
  	$(CC) -g -o check_expr2 ast_expr2fz.o ast_expr2z.o astmm.o -lm $(_ASTLDFLAGS)
  	$(ECHO_PREFIX) echo "   [RM] ast_expr2fz.o ast_expr2z.o"
  	rm ast_expr2z.o ast_expr2fz.o


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt 19.07

Description:

As requested in #502, I would like to have it fixed in OpenWrt 19.07 as well. 
____

CFLAGS aren't used when compiling objects for check_expr2. This commits
adds the flags, which fixes the compilation when PKG_ASLR_PIE is
enabled. Note: The STANDALONE define is removed because it is already
defined in _ASTCFLAGS.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
(cherry picked from commit 357949967f330ae1e6d199d1c362f2666de82c43)

____

Patch from @micmac1 was [accepted](https://gerrit.asterisk.org/c/asterisk/+/13874) and it is part of 16.9.0 release.
