### PR TITLE
kamailio-5.x: use pg_config for now

### DIFF
--- a/net/kamailio-5.x/Makefile
+++ b/net/kamailio-5.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio5
 PKG_VERSION:=5.3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://www.kamailio.org/pub/kamailio/$(PKG_VERSION)/src
 PKG_SOURCE:=kamailio-$(PKG_VERSION)$(PKG_VARIANT)_src.tar.gz

--- a/net/kamailio-5.x/patches/150-use-pg_config.patch
+++ b/net/kamailio-5.x/patches/150-use-pg_config.patch
@@ -1,0 +1,21 @@
+--- a/src/modules/db_postgres/Makefile
++++ b/src/modules/db_postgres/Makefile
+@@ -9,11 +9,14 @@ NAME=db_postgres.so
+ # the autodetection
+ # CROSS_COMPILE=true
+ 
++# libpq pkg-config file is broken, see
++# https://github.com/openwrt/packages/pull/11507
+ ifeq ($(CROSS_COMPILE),)
+-LIBPQ_BUILDER = $(shell \
+-	if pkg-config --exists libpq; then \
+-		echo 'pkg-config libpq'; \
+-	fi)
++#LIBPQ_BUILDER = $(shell \
++#	if pkg-config --exists libpq; then \
++#		echo 'pkg-config libpq'; \
++#	fi)
++LIBPQ_BUILDER :=
+ ifneq ($(LIBPQ_BUILDER),)
+ 	DEFS += $(shell $(LIBPQ_BUILDER) --cflags)
+ 	LIBS += $(shell $(LIBPQ_BUILDER) --libs)


### PR DESCRIPTION
libpq's pkg-config file is currently broken. Use pg_config instead.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: ath79 master
Run tested: N/A, no runtime change

Description:
Hi Jiri,

postgresql's pc config file is broken. I've sent a patch upstream and also raised [pull request in packages repo](https://github.com/openwrt/packages/pull/11507).

There's no movement there, so I suggest for now to use pg_config. I did the same with freeswitch and it worked out fine.

Kind regards,
Seb