### PR TITLE
dahdi-linux: bump to version 3.1.0

### DIFF
--- a/libs/dahdi-linux/Makefile
+++ b/libs/dahdi-linux/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=dahdi-linux
-PKG_VERSION:=3.0.0
+PKG_VERSION:=3.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/dahdi-linux/releases
-PKG_HASH:=02a8a680d20a3e243f37259edc3554ab9a488595a28562c45c33da3792d12caa
+PKG_HASH:=db5b758437d066a7edad34b54313f08a4ccdde28373492986b72c798e8561b4d
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE

--- a/libs/dahdi-linux/patches/100-add-support-for-hfc-s-pci.patch
+++ b/libs/dahdi-linux/patches/100-add-support-for-hfc-s-pci.patch
@@ -1716,7 +1716,7 @@
 +	hfc_proc_dahdi_hfcs_dir = proc_mkdir(hfc_DRIVER_NAME, proc_root_driver);
 +#endif
 +
-+	ret = dahdi_pci_module(&hfc_driver);
++	ret = pci_register_driver(&hfc_driver);
 +	return ret;
 +}
 +

--- a/libs/dahdi-linux/patches/120-pci-header.patch
+++ b/libs/dahdi-linux/patches/120-pci-header.patch
@@ -1,0 +1,13 @@
+--- a/include/dahdi/kernel.h
++++ b/include/dahdi/kernel.h
+@@ -59,8 +59,10 @@
+ #include <linux/poll.h>
+ 
+ #ifdef CONFIG_PCI
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0)
+ #include <linux/pci-aspm.h>
+ #endif
++#endif
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)
+ #define HAVE_NET_DEVICE_OPS


### PR DESCRIPTION
This commit provides compatibility with kernel 5.4.

Except for the version bump this commit updates the HFC-S PCI driver to
not rely on the macro "dahdi_pci_module" anymore, because it has been
removed upstream in commit 4af6f69.

Also, a patch is added that makes the include of "<linux/pci-aspm.h>"
conditional on the kernel version, because starting with kernel 5.4 this
header has been removed and its contents merged into "pci.h".

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: x86_64
Run tested: N/A, don't have the hardware for it

Description:
Hi Jiri,

Some targets were upgraded to kernel 5.4. For these targets most of telephony feed is currently failing, because dahdi-linux won't compile ([link](https://downloads.openwrt.org/snapshots/faillogs/x86_64/telephony/)).

I found that upgrading from 3.0.0 to 3.1.0 brings us a whole lot closer to being able to compile dahdi-linux against kernel 5.4. Two smaller issues I found that also prevent a successful compile, so I fixed both in this commit as well.

Like this I can compile all of the telephony feed fine in full master environment. Well, for kamailio the other pull request is still needed, because otherwise it still fails due to libpq pkg-config file issue.

All in all we should be good with kernel 5.4.

Thanks!
Seb