### PR TITLE
freeswitch-stable: revert libpq pc file workaround

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PRG_NAME:=freeswitch
 PKG_NAME:=$(PRG_NAME)-stable
 PKG_VERSION:=1.10.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=$(PRG_NAME)-$(PKG_VERSION).-release.tar.xz
@@ -673,11 +673,6 @@ endif
 # would have the core link to it.
 CONFIGURE_ARGS+= \
 	--without-pgsql
-
-# libpq pkg-config file is broken, see
-# https://github.com/openwrt/packages/pull/11507
-CONFIGURE_ARGS+= \
-	--disable-core-pgsql-pkgconfig
 
 # Don't want host-php
 CONFIGURE_VARS+= \


### PR DESCRIPTION
The libpq pkg-config file has been fixed in packages, so we can revert
the commit that introduced the workaround.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: x86_64 master
Run tested: No runtime impact

Description:
Hi all,

This reverts the previous commit, as the libpq pc file has been finally fixed in packages.

Regards,
Seb