### PR TITLE
[openwrt-19.07] asterisk-16.x: update keys directory in init script

### DIFF
--- a/net/asterisk-16.x/Makefile
+++ b/net/asterisk-16.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 AST_MAJOR_VERSION:=16
 PKG_NAME:=asterisk$(AST_MAJOR_VERSION)
 PKG_VERSION:=$(AST_MAJOR_VERSION).3.0
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk-16.x/files/asterisk.init
+++ b/net/asterisk-16.x/files/asterisk.init
@@ -15,7 +15,7 @@ start() {
        [ -d $DEST/var/log/asterisk ] || mkdir -p $DEST/var/log/asterisk
        [ -d $DEST/var/spool/asterisk ] || mkdir -p $DEST/var/spool/asterisk
        [ -d $DEST/var/lib/asterisk ] || mkdir -p $DEST/var/lib/asterisk
-       [ -d $DEST/var/lib/asterisk/keys ] || mkdir -p $DEST/var/lib/asterisk/keys
+       [ -d $DEST/usr/share/asterisk/keys ] || mkdir -p $DEST/usr/share/asterisk/keys
        [ -d $DEST/var/log/asterisk/cdr-csv ] || mkdir -p $DEST/var/log/asterisk/cdr-csv
 
        SERVICE_PID_FILE="/var/run/asterisk/asterisk.pid" \


### PR DESCRIPTION
Currently the init script creates "/var/lib/asterisk/keys". But the
default keys directory is actually "/usr/share/asterisk/keys".

This commit amends the init script.

Resolves #512

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: N/A (just a script change)
Run tested: 19.07.01, installed asterisk from mirrors, changed the directory in init script, ran it.

```
* Directories
  -------------
  Configuration file:          /etc/asterisk/asterisk.conf
  Configuration directory:     /etc/asterisk
  Module directory:            /usr/lib/asterisk/modules
  Spool directory:             /var/spool/asterisk
  Log directory:               /var/log/asterisk
  Run/Sockets directory:       /var/run/asterisk
  PID file:                    /var/run/asterisk/asterisk.pid
  VarLib directory:            /var/lib/asterisk
  Data directory:              /usr/share/asterisk
  ASTDB:                       /var/lib/asterisk/astdb
  IAX2 Keys directory:         /usr/share/asterisk/keys
  AGI Scripts directory:       /usr/share/asterisk/agi-bin
```

Description:
Hi Jiri,

Small update to init script as mentioned in the related issue.

Kind regards,
Seb