### PR TITLE
kamailio-5.x: update build setup and add Python 3 module

### DIFF
--- a/net/kamailio-5.x/Makefile
+++ b/net/kamailio-5.x/Makefile
@@ -21,8 +21,9 @@ PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
-# Defining PKG_BUILD_PARALLEL to 1 would be a noop due to the way we call make
-#PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+PKG_BUILD_PARALLEL:=1
 
 MODULES_AVAILABLE:= \
 	acc \
@@ -388,9 +389,6 @@ endef
 #   "ims_diameter_server" -> libkamailio_ims
 #   "carrierroute" -> libtrie
 
-# "lib_target" is specified in order for the modules to get a proper
-# RPATH, as otherwise they would not find the internal libraries.
-
 EXTRA_MODULES:= \
 	$(if $(CONFIG_PACKAGE_kamailio5-mod-carrierroute),,carrierroute) \
 	$(if $(CONFIG_PACKAGE_kamailio5-mod-ims-diameter-server),,ims_diameter_server) \
@@ -408,35 +406,26 @@ ifeq ($(call qstrip,$(CONFIG_ARCH)),mips)
 CPU_MIPS2:=mips32 24kc 34kc 74kc
 endif
 
-PKG_MAKE_ARGS:= \
-	prefix=/ \
-	cfg_dir=/etc/kamailio/ \
-	bin_dir=/usr/sbin/ \
-	data_dir=/usr/share/kamailio/ \
-	lib_dir=/usr/lib/kamailio/ \
-	modules_dir=/usr/lib/kamailio/ \
+MAKE_FLAGS += \
+	$(if $(findstring $(call qstrip,$(CONFIG_CPU_TYPE)),$(CPU_MIPS2)),ARCH="mips2",ARCH="$(ARCH)") \
+	CC_EXTRA_OPTS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)" \
+	LD="$(TARGET_CC)" \
+	LD_EXTRA_OPTS="$(TARGET_LDFLAGS)" \
+	LIBDIR=lib \
+	PREFIX=/usr \
+	cfg_prefix="$(PKG_INSTALL_DIR)" \
+	cfg_target=/etc/kamailio \
 	group_include="standard" \
 	include_modules="$$(INCL_MODULES) $(EXTRA_MODULES)" \
-	cfg_target=/etc/kamailio/ \
-	lib_target=/usr/lib/kamailio/ \
-	run_target=/var/run/kamailio/ \
-	CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)" \
-	LD_EXTRA_OPTS="$(TARGET_LDFLAGS)" \
-	LOCALBASE="$(STAGING_DIR)/usr" \
-	SYSBASE="$(STAGING_DIR)/usr" \
-	CROSS_COMPILE=$(TARGET_CROSS) \
-	CC="$(TARGET_CC)" \
-	$(if $(findstring $(call qstrip,$(CONFIG_CPU_TYPE)),$(CPU_MIPS2)),ARCH="mips2",ARCH="$(ARCH)") \
-	DESTDIR=$(PKG_INSTALL_DIR) \
-	quiet=verbose
+	quiet=verbose \
+	run_prefix=""
 
 define Build/Configure
 endef
 
 define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) $(PKG_MAKE_ARGS) cfg
-	$(MAKE) -C $(PKG_BUILD_DIR) quiet=verbose all
-	$(MAKE) -C $(PKG_BUILD_DIR) quiet=verbose install
+	$(call Build/Compile/Default,cfg)
+	$(call Build/Compile/Default,all)
 endef
 
 $(eval $(call BuildPackage,kamailio5))

--- a/net/kamailio-5.x/Makefile
+++ b/net/kamailio-5.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio5
 PKG_VERSION:=5.3.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://www.kamailio.org/pub/kamailio/$(PKG_VERSION)/src
 PKG_SOURCE:=kamailio-$(PKG_VERSION)$(PKG_VARIANT)_src.tar.gz
@@ -33,6 +33,7 @@ MODULES_AVAILABLE:= \
 	app_jsdt \
 	app_lua \
 	app_lua_sr \
+	app_python3 \
 	app_ruby \
 	app_sqlang \
 	async \
@@ -231,6 +232,7 @@ PKG_CONFIG_DEPENDS:= \
 
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/feeds/packages/lang/python/python3-version.mk
 
 # Build reproducibly
 TARGET_CFLAGS += -DVERSION_NODATE=1
@@ -420,6 +422,9 @@ MAKE_FLAGS += \
 	quiet=verbose \
 	run_prefix=""
 
+MAKE_VARS += \
+	PYTHON3=python$(PYTHON3_VERSION)
+
 define Build/Configure
 endef
 
@@ -451,6 +456,7 @@ $(eval $(call BuildKamailio5Module,alias_db,Database-backend aliases,,))
 $(eval $(call BuildKamailio5Module,app_jsdt,Execute JavaScript scripts,,))
 $(eval $(call BuildKamailio5Module,app_lua,Execute embedded Lua scripts,,+liblua))
 $(eval $(call BuildKamailio5Module,app_lua_sr,Old Lua API,,+kamailio5-mod-app-lua,))
+$(eval $(call BuildKamailio5Module,app_python3,Python3 scripting interpreter,,+python3-light))
 $(eval $(call BuildKamailio5Module,app_ruby,Ruby scripting interpreter,,+libruby))
 $(eval $(call BuildKamailio5Module,app_sqlang,Execute Squirrel language scripts,,+libstdcpp))
 $(eval $(call BuildKamailio5Module,async,Asynchronous SIP handling functions,,+kamailio5-mod-tm +kamailio5-mod-tmx))

--- a/net/kamailio-5.x/patches/150-python3-cross-compile.patch
+++ b/net/kamailio-5.x/patches/150-python3-cross-compile.patch
@@ -1,0 +1,54 @@
+commit 05af36d34aa2668780aa111878206c6797fa98b0
+Author: Sebastian Kemper <sebastian_ml@gmx.net>
+Date:   Sun Apr 12 09:37:48 2020 +0200
+
+    app_python3: update Python3 detection mechanism
+    
+    This commit
+    
+      - removes the python calls whose output is never actually used.
+    
+      - changes the include discovery to use python3(.x)-config. This is
+        preferable because it also works for cross-compiling. Calling
+        python3(.x) directly will always provide host flags, which for
+        cross-compiling is not feasible.
+    
+      - updates LDFLAGS discovery to also work with >= Python 3.8. To
+        achieve this python3(.x)-config is first run with the argument
+        "--embed". If this does not succeed (exit status 1)
+        python3(.x)-config is run again without "--embed". This is the
+        method suggested by Python upstream to provide backwards
+        compatibility. See [1] for more details.
+    
+    [1] https://docs.python.org/3/whatsnew/3.8.html
+    
+    Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
+
+diff --git a/src/modules/app_python3/Makefile b/src/modules/app_python3/Makefile
+index 1c9ff1c6b6..d31cd6ab10 100644
+--- a/src/modules/app_python3/Makefile
++++ b/src/modules/app_python3/Makefile
+@@ -11,18 +11,16 @@ NAME=app_python3.so
+ # but no testing has been done with that.
+ PYTHON3?=python3
+ 
+-PYTHON3_VERSION=${shell ${PYTHON3} -c "import distutils.sysconfig;print(distutils.sysconfig.get_config_var('VERSION'))"}
+-PYTHON3_LIBDIR=${shell ${PYTHON3} -c "import distutils.sysconfig;print(distutils.sysconfig.get_config_var('LIBDIR'))"}
+-PYTHON3_LDFLAGS=${shell ${PYTHON3} -c "import distutils.sysconfig;print(distutils.sysconfig.get_config_var('LINKFORSHARED'))"}
+-PYTHON3_INCDIR=${shell ${PYTHON3} -c "import distutils.sysconfig;print(distutils.sysconfig.get_python_inc())"}
+-
+-LIBS=${shell ${PYTHON3}-config --ldflags}
++LIBS=${shell \
++	tmp_py3_libs=$$(${PYTHON3}-config --ldflags --embed 2>/dev/null) || \
++	tmp_py3_libs=$$(${PYTHON3}-config --ldflags); \
++	echo $$tmp_py3_libs}
+ 
+ ifeq ($(OS), freebsd)
+ LIBS+=-pthread
+ endif
+ 
+-DEFS+=-I${PYTHON3_INCDIR}
++DEFS+=${shell ${PYTHON3}-config --includes}
+ 
+ include ../../Makefile.modules
+ 


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: ath79 master + x86_64 master
Run tested: ath79 openwrt-19.07, tested with asterisk and one phone registering to it via kamailio, the other directly. All OK, calls fine. Also checked kamctl works (listing DB, removing entry, adding entry).

Description:
Hi Jiri,

While checking into Python3 I saw that Alpine sets up the build a bit differently. I like it a lot more the way they do it. I know they're not cross-compiling like us, but replicating their setup works fine for us. Like this we can also remove the manual "make" calls, which is nice.

With regards to the Python 3 module. It builds fine, but I wasn't able to run-test it because I ran out of space when trying to install python3-light :D But I'm pretty sure it's fine.

There are some additional details in the commit messages.

Kind regards,
Seb