### PR TITLE
circleci: allow dots in subject line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
                fi
 
                subject="$(git show -s --format=%s $commit)"
-               if echo "$subject" | grep -q -e '^[0-9A-Za-z,+/_-]\+: ' -e '^Revert '; then
+               if echo "$subject" | grep -q -e '^[0-9A-Za-z,.+/_-]\+: ' -e '^Revert '; then
                  echo_green "Commit subject line seems ok ($subject)"
                else
                  echo_red "Commit subject line MUST start with '<package name>: ' ($subject)"


### PR DESCRIPTION
We like to use "kamailio-5.x:" and "asterisk-16.x:" in commit message
subject lines. So relax the regex for it to allow the dots.

Closes #442 

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: N/A, tested the regex locally
Run tested: N/A, not a package

Description:
Hi Jiri,

As discussed in #442 this relaxes the circleci regex a bit.

Kind regards,
Seb