### PR TITLE
circleci: fetch packages repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ jobs:
              rm .config
              cat > feeds.conf <<EOF
              src-git base https://github.com/openwrt/openwrt.git;$BRANCH
+             src-git packages https://github.com/openwrt/packages.git;$BRANCH
              src-link telephony $HOME/openwrt_telephony
              src-git luci https://github.com/openwrt/luci.git;$BRANCH
              EOF


### PR DESCRIPTION
Currently CI doesn't work, because the dependencies from the packages
repo are not available.

<snip>
WARNING: No feed for package 'libopenldap' found
WARNING: No feed for package 'libidn2' found
WARNING: No feed for package 'libssh2' found
<snip>

This commit adds the packages repo.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: N/A
Run tested: N/A

Description:
Hi Jiri,

CI is missing the packages repo. Need to add it for our deps.

Kind regards,
Seb