### PR TITLE
kamailio-5.x: remove "-funroll-loops"

### DIFF
--- a/net/kamailio-5.x/Makefile
+++ b/net/kamailio-5.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio5
 PKG_VERSION:=5.3.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://www.kamailio.org/pub/kamailio/$(PKG_VERSION)/src
 PKG_SOURCE:=kamailio-$(PKG_VERSION)$(PKG_VARIANT)_src.tar.gz
@@ -424,6 +424,13 @@ MAKE_FLAGS += \
 
 MAKE_VARS += \
 	PYTHON3=python$(PYTHON3_VERSION)
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	# Upstream adds "-funroll-loops" to compiler flags, which increases
+	# binary size significantly. Remove this flag.
+	$(SED) 's/[ ]*-funroll-loops//' $(PKG_BUILD_DIR)/src/Makefile.defs
+endef
 
 define Build/Configure
 endef


### PR DESCRIPTION
Since recent commit 60ea8ff OpenWrt flags are added to CC_EXTRA_OPTS
instead of CFLAGS, allowing upstream flags to pass into our builds.
Upstream passes "-funroll-loops", which increases package sizes
significantly.

Example mips:

kamailio5_5.3.3-1_mips_24kc.ipk: 1019K
kamailio5_5.3.3-2_mips_24kc.ipk: 1,4M

This commit removes "-funroll-loops", reducing the size to previous
level.

kamailio5_5.3.3-2_mips_24kc.ipk: 1021K

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: ath79 master
Run tested: ath79 19.07

Description:
Hi Jiri,

This is a follow-up, because I saw a pretty astonishing size increase.

I don't know if "-funroll-loops" makes kamailio faster. But I think we want to keep it as slim as possible.

Kind regards,
Seb