### PR TITLE
freeswitch-stable: improve init script

### DIFF
--- a/net/freeswitch-stable/Makefile
+++ b/net/freeswitch-stable/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PRG_NAME:=freeswitch
 PKG_NAME:=$(PRG_NAME)-stable
 PKG_VERSION:=1.10.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=$(PRG_NAME)-$(PKG_VERSION).-release.tar.xz
@@ -366,9 +366,10 @@ $(call Package/$(PKG_NAME)/Default)
   MENU:=1
   USERID:=$(PRG_NAME)=372:$(PRG_NAME)=372
   DEPENDS:= \
-	  +@OPENSSL_WITH_DEPRECATED \
 	  $(CXX_DEPENDS) \
 	  $(ICONV_DEPENDS) \
+	  +!BUSYBOX_DEFAULT_SU:shadow-su \
+	  +@OPENSSL_WITH_DEPRECATED \
 	  +FS_STABLE_WITH_FREETYPE:libfreetype \
 	  +FS_STABLE_WITH_ODBC:unixodbc \
 	  +FS_STABLE_WITH_PNG:libpng \

--- a/net/freeswitch-stable/files/freeswitch.conf
+++ b/net/freeswitch-stable/files/freeswitch.conf
@@ -1,8 +1,6 @@
 
 config freeswitch 'general'
 	option enabled '0'
-	option user 'freeswitch'
-	option group 'freeswitch'
 	option log_stderr '1'
 	option log_stdout '1'
 	option options '-nonat -np'

--- a/net/freeswitch-stable/files/freeswitch.init
+++ b/net/freeswitch-stable/files/freeswitch.init
@@ -13,26 +13,9 @@ COMMAND=/usr/bin/$NAME
 LOGGER="/usr/bin/logger -p user.err -s -t $NAME --"
 
 start_service() {
-  local dir
-  local enabled
-
-  local user
-  local group
-
-  local log_stderr
-  local log_stdout
-
-  local dir_cache
-  local dir_db
-  local dir_etc=/etc/$NAME
-  local dir_localstate=/var/lib/$NAME
-  local dir_log
-  local dir_recordings
-  local dir_run=/var/run/$NAME
-  local dir_storage
-  local dir_temp
-
-  local options
+  dir_etc=/etc/$NAME
+  dir_localstate=/var/lib/$NAME
+  dir_run=/var/run/$NAME
 
   config_load $NAME
 
@@ -41,9 +24,6 @@ start_service() {
     $LOGGER service not enabled in /etc/config/$NAME
     exit 1
   fi
-
-  config_get user  general user  $NAME
-  config_get group general group $NAME
 
   config_get_bool log_stderr general log_stderr 1
   config_get_bool log_stdout general log_stdout 1
@@ -55,53 +35,33 @@ start_service() {
   config_get dir_storage    directories storage    /tmp/$NAME/storage
   config_get dir_temp       directories temp       /tmp/$NAME/temp
 
-  user_exists "$user" || {
-    $LOGGER user \""$user"\" does not exist
-    exit 1
-  }
-
-  group_exists "$group" || {
-    $LOGGER group \""$group"\" does not exist
-    exit 1
-  }
-
-  # do not touch directories that already exist
-  # posix shell does not support arrays, hence using awk
-  awk \
-    -v user="$user" \
-    -v group="$group" \
-    -v a="$dir_cache" \
-    -v b="$dir_db" \
-    -v c="$dir_localstate" \
-    -v d="$dir_log" \
-    -v e="$dir_recordings" \
-    -v f="$dir_run" \
-    -v g="$dir_storage" \
-    -v h="$dir_temp" \
-    '
-      BEGIN {
-        dir[0]=a
-        dir[1]=b
-        dir[2]=c
-        dir[3]=d
-        dir[4]=e
-        dir[5]=f
-        dir[6]=g
-        dir[7]=h
-        for (x in dir) {
-          if (system("test ! -e \"" dir[x] "\"" )) {
-            delete dir[x]
-          }
-        }
-        for (x in dir) {
-          system("mkdir -p \"" dir[x] "\"" )
-          system("chmod 750 \"" dir[x] "\"" )
-          system("chown \"" user "\":\"" group "\" \"" dir[x] "\"" )
-        }
-      }
-    '
-
   config_get options general options
+
+  for i in "$dir_localstate" "$dir_run"; do
+    if ! [ -e "$i" ]; then
+      mkdir -m 0750 -p "$i"
+      [ -d "$i" ] && chown $NAME:$NAME "$i"
+    fi
+  done
+
+  command -v su >/dev/null
+  ret=$?
+  if [ 0 != "$ret" ]; then
+    $LOGGER utility \"su\" not available
+    $LOGGER will not attempt to create directories
+  else
+    for i in "$dir_cache" \
+             "$dir_db" \
+             "$dir_log" \
+             "$dir_recordings" \
+             "$dir_storage" \
+             "$dir_temp";
+    do
+      if ! [ -e "$i" ]; then
+        su -s /bin/sh -c "mkdir -m 0750 -p \"$i\"" $NAME
+      fi
+    done
+  fi
 
   procd_open_instance
   # starting with full path seems cleaner judging by 'ps' output
@@ -111,13 +71,13 @@ start_service() {
     -cache "$dir_cache" \
     -conf "$dir_etc" \
     -db "$dir_db" \
-    -g "$group" \
+    -g "$NAME" \
     -log "$dir_log" \
     -recordings "$dir_recordings" \
     -run "$dir_run" \
     -storage "$dir_storage" \
     -temp "$dir_temp" \
-    -u "$user" \
+    -u "$NAME" \
     $options \
     -c
   # forward stderr to logd
@@ -126,4 +86,3 @@ start_service() {
   procd_set_param stdout $log_stdout
   procd_close_instance
 }
-


### PR DESCRIPTION
This is in response to a posting on oss-security ([1]).

This commit removes the ability to choose a user/group via
/etc/config/freeswitch. This makes the init script simpler. If anybody
wants to play around with the user/group then it's up to them to fix the
permissions.

The complex awk script is deleted and basically replaced by two
for-loops. The first loop creates /var/lib/freeswitch and
/var/run/freeswitch and chowns them to the user freeswitch, in case they
don't exist already.

The second loop checks if the other directories (either default or
specified by the user) exist. If any directory is missing it uses "su"
to create that directory as user "freeswitch".

The reasoning behind this is that a) this works for the defaults
(example: "/tmp/freeswitch/db") and b) the user can specify anything
he/she wants in "/etc/config/freeswitch", which could be all kinds of
strange directories. The "mkdir" may now fail, as we're not calling it
as root anymore, but we err on the side of caution, as the saying goes.

In both loops an umask of 027 is used, replacing the calls to "chmod". A
dependency on the "su" utility is added to the Makefile.

"local" also gets removed because it is undefined in POSIX.

[1] https://www.openwall.com/lists/oss-security/2020/04/30/1

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: master ath79
Run tested: 19.07 ath79

Description: Init script update
