### PR TITLE
freeswitch-stable: disable sofia-sip tests

### DIFF
--- a/net/freeswitch-stable/patches/400-disable-sofia-sip-tests.patch
+++ b/net/freeswitch-stable/patches/400-disable-sofia-sip-tests.patch
@@ -1,0 +1,11 @@
+--- a/libs/sofia-sip/Makefile.am
++++ b/libs/sofia-sip/Makefile.am
+@@ -7,7 +7,7 @@
+ 
+ AUTOMAKE_OPTIONS = foreign 1.7
+ 
+-SUBDIRS =  libsofia-sip-ua $(GLIB_SUBDIRS) packages tests s2check utils
++SUBDIRS =  libsofia-sip-ua $(GLIB_SUBDIRS) packages # tests s2check utils
+ DIST_SUBDIRS = s2check libsofia-sip-ua libsofia-sip-ua-glib utils packages \
+ 	tests win32 open_c
+ 


### PR DESCRIPTION
Upstream commit [2dced93 "[sofia-sip] Build internal tests"](https://github.com/signalwire/freeswitch/commit/2dced93d94ce4be86c57451ee842afbf435749aa) enabled the
building of tests. One of them causes build failures on the build bots:

```
Making all in s2check
make[11]: Entering directory '/builder/shared-workdir/build/sdk/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/freeswitch-1.10.3.-release/libs/sofia-sip/s2check'
         COMPILE s2tcase.o
s2tcase.c: In function 's2_tcase_add_test':
s2tcase.c:60:27: error: passing argument 2 of '_tcase_add_test' from incompatible pointer type [-Werror=incompatible-pointer-types]
       _tcase_add_test(tc, tf, name, signo, 0, start, end);
                           ^~
In file included from s2tcase.c:35:
/builder/shared-workdir/build/sdk/staging_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/usr/include/check.h:331:69: note: expected 'const TTest *' {aka 'const struct TTest *'} but argument is of type 'TFun' {aka 'void (*)(int)'}
 CK_DLL_EXP void CK_EXPORT _tcase_add_test(TCase * tc, const TTest * ttest,
                                                       ~~~~~~~~~~~~~~^~~~~
s2tcase.c:60:31: error: passing argument 3 of '_tcase_add_test' makes integer from pointer without a cast [-Werror=int-conversion]
       _tcase_add_test(tc, tf, name, signo, 0, start, end);
                               ^~~~
In file included from s2tcase.c:35:
/builder/shared-workdir/build/sdk/staging_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/usr/include/check.h:332:47: note: expected 'int' but argument is of type 'const char *'
                                           int _signal, int allowed_exit_value,
                                           ~~~~^~~~~~~
s2tcase.c:60:7: error: too many arguments to function '_tcase_add_test'
       _tcase_add_test(tc, tf, name, signo, 0, start, end);
       ^~~~~~~~~~~~~~~
In file included from s2tcase.c:35:
/builder/shared-workdir/build/sdk/staging_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/usr/include/check.h:331:27: note: declared here
 CK_DLL_EXP void CK_EXPORT _tcase_add_test(TCase * tc, const TTest * ttest,
                           ^~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

```
I can't reproduce this at home. Not with a master checkout, not with a
current SDK. But the tests are not needed for the OpenWrt packages
anyway, so this commit disables them again.

No rev bump is done because this has no effect on the packages.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: ath79 master
Run tested: N/A, build fix only, on change in the package.

Description:
Buildbots are failing the builds. I cannot repro this at home. But these are just tests that upstream recently activated, so we can just disable them again.