### PR TITLE
rtpengine: prevent picking up host system flags

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=rtpengine
 PKG_VERSION:=mr8.3.1.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sipwise/rtpengine/tar.gz/$(PKG_VERSION)?
@@ -212,6 +212,18 @@ MAKE_VARS+=RTPENGINE_VERSION=$(PKG_VERSION)
 ifeq ($(BUILD_VARIANT),no-transcode)
   MAKE_VARS+=with_transcoding=no
 endif
+
+# rtpengine uses Debian's dpkg utility programs if it can find them. But
+# we don't want build host flags to leak into our cross-compile.
+define Build/Prepare
+	$(call Build/Prepare/Default)
+ifeq ($(QUILT),)
+	cd "$(PKG_BUILD_DIR)" && \
+		$(FIND) . -maxdepth 2 -name "*Makefile" | \
+		xargs  -I{} $(SED) \
+		'/shell which dpkg-/s/dpkg/OpenWrt-has-no-dpkg/' {}
+endif
+endef
 
 define Build/Configure
 endef

--- a/net/rtpengine/patches/04-prevent-systemd-detection.patch
+++ b/net/rtpengine/patches/04-prevent-systemd-detection.patch
@@ -1,0 +1,17 @@
+--- a/lib/lib.Makefile
++++ b/lib/lib.Makefile
+@@ -35,10 +35,10 @@ ifeq ($(RTPENGINE_VERSION),)
+ endif
+ CFLAGS+=	-DRTPENGINE_VERSION="\"$(RTPENGINE_VERSION)\""
+ 
+-# look for libsystemd
+-ifeq ($(shell pkg-config --exists libsystemd && echo yes),yes)
+-have_libsystemd := yes
+-endif
++# No libsystemd in OpenWrt, but pkg-config could find build host's.
++#ifeq ($(shell pkg-config --exists libsystemd && echo yes),yes)
++have_libsystemd := no
++#endif
+ ifeq ($(have_libsystemd),yes)
+ CFLAGS+=	$(shell pkg-config --cflags libsystemd)
+ CFLAGS+=	-DHAVE_LIBSYSTEMD


### PR DESCRIPTION
lib/lib.Makefile looks for libsystemd and dpkg-buildflags. These are not
available in OpenWrt, but they could be picked up from the build host.

This commit extends 01-cflags.patch a bit to prevent that.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: master ath79
Run tested: no runtime-change

Description:
Hi all,

Saw this going wrong on one build bot ("truecz-dock-01"). I'm betting it has dpkg-buildflags installed which introduces some host system flags into the build. The commit also prevents libsystemd detection, as a precautionary measure.

Kind regards,
Seb