### PR TITLE
rtpengine: build fix and patch improvement

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=rtpengine
 PKG_VERSION:=mr8.3.1.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sipwise/rtpengine/tar.gz/$(PKG_VERSION)?
@@ -21,7 +21,11 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
-PKG_BUILD_PARALLEL:=1
+# When building in parallel, some files (like streambuf.c or dtmflib.c)
+# are generated multiple times by the rtpengine build system.
+# Intermittently they then contain garbage, leading to redefinition
+# errors.
+PKG_BUILD_PARALLEL:=0
 
 PKG_BUILD_DEPENDS:=gperf/host
 

--- a/net/rtpengine/patches/01-cflags.patch
+++ b/net/rtpengine/patches/01-cflags.patch
@@ -1,41 +1,55 @@
---- a/daemon/Makefile
-+++ b/daemon/Makefile
-@@ -51,7 +51,7 @@ endif
- endif
- endif
- 
--CFLAGS=		-g -Wall -Wstrict-prototypes -pthread -fno-strict-aliasing
-+CFLAGS+=	-g -Wall -Wstrict-prototypes -pthread -fno-strict-aliasing
- CFLAGS+=	-std=c99
- CFLAGS+=	$(shell pkg-config --cflags glib-2.0)
- CFLAGS+=	$(shell pkg-config --cflags gthread-2.0)
 --- a/lib/lib.Makefile
 +++ b/lib/lib.Makefile
-@@ -47,8 +47,6 @@ endif
- 
- ifeq ($(DBG),yes)
- CFLAGS+=	-D__DEBUG=1
--else
--CFLAGS+=	-O3
+@@ -62,3 +62,6 @@ ifneq ($(DBG),yes)
+     LDLIBS+=	$(shell dpkg-buildflags --get LDLIBS)
+   endif
  endif
++
++CFLAGS+=$(OpenWrt_CFLAGS)
++LDFLAGS+=$(OpenWrt_LDFLAGS)
+--- a/daemon/Makefile
++++ b/daemon/Makefile
+@@ -1,3 +1,6 @@
++OpenWrt_CFLAGS:=$(CFLAGS)
++OpenWrt_LDFLAGS:=$(LDFLAGS)
++
+ TARGET=		rtpengine
  
- 
---- a/iptables-extension/Makefile
-+++ b/iptables-extension/Makefile
-@@ -1,5 +1,5 @@
- CC?=gcc
--CFLAGS		= -O2 -Wall -Wstrict-prototypes -shared -fPIC
-+CFLAGS		+= -Wall -Wstrict-prototypes -shared -fPIC
- ifneq ($(RTPENGINE_VERSION),)
-   CFLAGS	+= -DRTPENGINE_VERSION="\"$(RTPENGINE_VERSION)\""
- else
+ with_iptables_option ?= yes
 --- a/recording-daemon/Makefile
 +++ b/recording-daemon/Makefile
-@@ -1,6 +1,6 @@
+@@ -1,3 +1,6 @@
++OpenWrt_CFLAGS:=$(CFLAGS)
++OpenWrt_LDFLAGS:=$(LDFLAGS)
++
  TARGET=		rtpengine-recording
  
--CFLAGS=		-g -Wall -Wstrict-prototypes -pthread -I. -I../lib/ -I../kernel-module/
-+CFLAGS+=	-g -Wall -Wstrict-prototypes -pthread -I. -I../lib/ -I../kernel-module/
- CFLAGS+=	-std=c99 -fno-strict-aliasing
- CFLAGS+=	-D_GNU_SOURCE -D_POSIX_SOURCE -D_POSIX_C_SOURCE
- CFLAGS+=	$(shell pkg-config --cflags glib-2.0)
+ CFLAGS=		-g -Wall -Wstrict-prototypes -pthread -I. -I../lib/ -I../kernel-module/
+--- a/iptables-extension/Makefile
++++ b/iptables-extension/Makefile
+@@ -1,3 +1,6 @@
++OpenWrt_CFLAGS:=$(CFLAGS)
++OpenWrt_LDFLAGS:=$(LDFLAGS)
++
+ CC?=gcc
+ CFLAGS		= -O2 -Wall -Wstrict-prototypes -shared -fPIC
+ ifneq ($(RTPENGINE_VERSION),)
+@@ -22,6 +25,9 @@ else
+ XTABLES = $(shell test -e /usr/include/xtables.h && echo 1)
+ endif
+ 
++CFLAGS+=$(OpenWrt_CFLAGS)
++LDFLAGS+=$(OpenWrt_LDFLAGS)
++
+ IPTABLES	= $(shell test -e /usr/include/iptables.h && echo 1)
+ IP6TABLES	= $(shell test -e /usr/include/ip6tables.h && echo 1)
+ 
+@@ -37,7 +43,7 @@ WORK=1
+ module: libxt_RTPENGINE.so
+ 
+ libxt_RTPENGINE.so: libxt_RTPENGINE.c
+-	$(CC) $(CFLAGS) -o libxt_RTPENGINE.so libxt_RTPENGINE.c
++	$(CC) $(LDFLAGS) $(CFLAGS) -o libxt_RTPENGINE.so libxt_RTPENGINE.c
+ 
+ else
+ 


### PR DESCRIPTION
Maintainer: me
Compile tested: master ath79
Run tested: I gave this a quick spin on 19.07.

Description:
Hi all,

This updates the CFLAGS patch a bit. I think it's better this way. The second commit contains a workaround for a sporadic build failure.

No size increases. No big changes anyway.

Kind regards,
Seb