### PR TITLE
asterisk-chan-dongle: bump + cleanup

### DIFF
--- a/net/asterisk-chan-dongle/Makefile
+++ b/net/asterisk-chan-dongle/Makefile
@@ -8,23 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk-chan-dongle
-PKG_VERSION:=1.1-20180619
-PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=https://github.com/wdoekes/asterisk-chan-dongle.git
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_SOURCE_VERSION:=fd544d628d134cfe9cc2df6b5315298e93698664
-PKG_MIRROR_HASH:=f6074feff5931024e5ac9504ffc872c58b650352e29343969327c5205228fc2f
 PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/wdoekes/asterisk-chan-dongle.git
+PKG_SOURCE_VERSION:=328b2b7ded3b3c59c2e6c7e7afca6b0ac6f146ce
+PKG_SOURCE_DATE=2020-05-28
+PKG_RELEASE:=1
+PKG_MIRROR_HASH:=b0af444840340722ecee111a7b1f819de441acf290799ae11bc18e16569c6388
 
 PKG_FIXUP:=autoreconf
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYRIGHT.txt LICENSE.txt
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 MODULES_DIR:=/usr/lib/asterisk/modules
 
@@ -37,7 +33,7 @@ define Package/asterisk-chan-dongle/Default
   SECTION:=net
   CATEGORY:=Network
   URL:=https://github.com/wdoekes/asterisk-chan-dongle
-  DEPENDS:=$(ICONV_DEPENDS) +kmod-usb-acm +kmod-usb-serial +kmod-usb-serial-option +libusb-1.0 +usb-modeswitch
+  DEPENDS:=$(ICONV_DEPENDS) +libsqlite3
   TITLE:=Huawei UMTS 3G dongle support
 endef
 
@@ -60,7 +56,8 @@ ifeq ($(BUILD_VARIANT),asterisk16)
 endif
 
 CONFIGURE_ARGS+= \
-	--with-asterisk=$(CHAN_DONGLE_AST_HEADERS)
+	--with-asterisk=$(CHAN_DONGLE_AST_HEADERS) \
+	--with-iconv=$(ICONV_PREFIX)/include
 
 TARGET_CFLAGS+= \
 	-I$(CHAN_DONGLE_AST_HEADERS)

--- a/net/asterisk-chan-dongle/patches/200-fix-iconv-detection.patch
+++ b/net/asterisk-chan-dongle/patches/200-fix-iconv-detection.patch
@@ -1,21 +1,11 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -77,7 +77,8 @@ fi
+@@ -83,7 +83,7 @@ fi
+ 
  dnl Checks for libraries.
- dnl AC_CHECK_LIB([pthread], [pthread_create])
- dnl AC_CHECK_LIB([iconv], [iconv])
--AC_SEARCH_LIBS([iconv], [c iconv])
-+dnl AC_SEARCH_LIBS([iconv], [c iconv])
-+AC_CHECK_LIB([iconv], [libiconv])
+ dnl AC_CHECK_LIB([pthread], [pthread_create])  # should use ast_pthread_join everywhere?
+-AC_SEARCH_LIBS([iconv], [c iconv],,AC_MSG_ERROR([iconv library missing]))
++AC_CHECK_LIB([iconv], [iconv],,AC_MSG_ERROR([iconv library missing]))
+ AC_CHECK_LIB([sqlite3], [sqlite3_open],,AC_MSG_ERROR([sqlite3 library missing]))
  
  dnl Checks for header files.
- AC_CHECK_HEADERS([fcntl.h stdlib.h string.h sys/time.h termios.h])
-@@ -102,7 +103,7 @@ AC_DEFUN([AC_HEADER_FIND], [
- )
- 
- AC_HEADER_FIND([asterisk.h], $with_asterisk)
--AC_HEADER_FIND([iconv.h], /usr/include /usr/local/include /opt/local/include)
-+dnl AC_HEADER_FIND([iconv.h], /usr/include /usr/local/include /opt/local/include)
- 
- AC_DEFINE([ICONV_CONST],[], [Define to const if you has iconv() const declaration of input buffer])
- AC_MSG_CHECKING([for iconv use const inbuf])

--- a/net/asterisk-chan-dongle/patches/300-use-openwrt-flags.patch
+++ b/net/asterisk-chan-dongle/patches/300-use-openwrt-flags.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -216,8 +216,6 @@ dnl Apply options to defines
+@@ -224,8 +224,6 @@ dnl Apply options to defines
  if test "x$enable_debug" = "xyes" ; then
    CFLAGS="$CFLAGS -O0 -g"
    AC_DEFINE([__DEBUG__], [1], [Build with debugging])


### PR DESCRIPTION
Bump dongle plugin to latest git revision. PKG_SOURCE_SUBDIR and
PKG_BUILD_DIR are removed because defaults are fine. PKG_VERSION is
replaced by PKG_SOURCE_DATE, which is in line with OpenWrt
recommendation.

Soft deps are removed as per request in issue #536.

iconv handling is updated. Upstream now lets us specify the include
directory, so that makes the patch simpler. The iconv lib detection is
also updated so that it never picks the libc iconv. This way we get the
same iconv handling independent of the libc in use. Now it'll be always
iconv-stub or iconv-full.

libsqlite3 dep is made explicit. There was always a dep on it, but it
was implicit via asterisk. When the dep is made explicit, the dongle
package picks up on the sqlite3 ABI_VERSION, which is nice.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: ath79 master
Run tested: no, don't have the hardware

Description:
Version bump and cleanup. This would also resolve #536, as the soft deps are removed.

Resolves #536 

Kind regards,
Seb