### PR TITLE
freeswitch: mod-rayo not compiling with gcc-10

### DIFF
--- a/net/freeswitch/patches/410-rayo-gcc10.patch
+++ b/net/freeswitch/patches/410-rayo-gcc10.patch
@@ -1,0 +1,20 @@
+--- a/src/mod/event_handlers/mod_rayo/Makefile.am
++++ b/src/mod/event_handlers/mod_rayo/Makefile.am
+@@ -8,7 +8,7 @@ IKS_LA=$(IKS_BUILDDIR)/src/libiksemel.la
+ noinst_LTLIBRARIES = librayomod.la
+ librayomod_la_SOURCES = mod_rayo.c iks_helpers.c nlsml.c rayo_components.c rayo_cpa_component.c rayo_cpa_detector.c rayo_elements.c rayo_fax_components.c
+ librayomod_la_SOURCES += rayo_input_component.c rayo_output_component.c rayo_prompt_component.c rayo_record_component.c sasl.c srgs.c xmpp_streams.c rayo_exec_component.c
+-librayomod_la_CFLAGS = $(AM_CFLAGS) -I$(switch_builddir)/libs/iksemel/include $(PCRE_CFLAGS)
++librayomod_la_CFLAGS = $(AM_CFLAGS) -I$(switch_builddir)/libs/iksemel/include $(PCRE_CFLAGS) -fcommon
+ 
+ mod_LTLIBRARIES = mod_rayo.la
+ mod_rayo_la_SOURCES  = 
+@@ -25,7 +25,7 @@ $(IKS_LA): $(IKS_BUILDDIR) $(IKS_DIR) $(
+ noinst_PROGRAMS = test/test_iks test/test_nlsml test/test_srgs
+ 
+ test_test_iks_SOURCES = test/test_iks.c
+-test_test_iks_CFLAGS = $(AM_CFLAGS) -I. -I$(switch_builddir)/libs/iksemel/include $(PCRE_CFLAGS) -DSWITCH_TEST_BASE_DIR_FOR_CONF=\"${abs_builddir}/test\" -DSWITCH_TEST_BASE_DIR_OVERRIDE=\"${abs_builddir}/test\"
++test_test_iks_CFLAGS = $(AM_CFLAGS) -I. -I$(switch_builddir)/libs/iksemel/include $(PCRE_CFLAGS) -DSWITCH_TEST_BASE_DIR_FOR_CONF=\"${abs_builddir}/test\" -DSWITCH_TEST_BASE_DIR_OVERRIDE=\"${abs_builddir}/test\" -fcommon
+ test_test_iks_LDFLAGS = $(AM_LDFLAGS) -avoid-version -no-undefined $(freeswitch_LDFLAGS) $(switch_builddir)/libfreeswitch.la $(CORE_LIBS) $(APR_LIBS)
+ test_test_iks_LDADD = librayomod.la $(IKS_LA) $(PCRE_LIBS)
+ 


### PR DESCRIPTION
Raised issue upstream ([1]). For now let's add this workaround.

[1] https://github.com/signalwire/freeswitch/issues/742

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me 
Compile tested: master
Run tested:

Description:
