### PR TITLE
baresip: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/baresip/Makefile
+++ b/net/baresip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=baresip
 PKG_VERSION:=0.6.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.creytiv.com/pub

--- a/net/baresip/patches/010-openssl-deprecated.patch
+++ b/net/baresip/patches/010-openssl-deprecated.patch
@@ -1,0 +1,11 @@
+--- a/modules/debug_cmd/debug_cmd.c
++++ b/modules/debug_cmd/debug_cmd.c
+@@ -56,7 +56,7 @@ static int print_system_info(struct re_printf *pf, void *arg)
+ 
+ #ifdef USE_OPENSSL
+ 	err |= re_hprintf(pf, " OpenSSL:  %s\n",
+-			  SSLeay_version(SSLEAY_VERSION));
++			  OpenSSL_version(OPENSSL_VERSION));
+ #endif
+ 
+ 	return err;


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jslachta 
Compile tested: ath79