### PR TITLE
rtpengine: fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=rtpengine
 PKG_VERSION:=mr8.5.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sipwise/rtpengine/tar.gz/$(PKG_VERSION)?

--- a/net/rtpengine/patches/200-openssl-deprecated.patch
+++ b/net/rtpengine/patches/200-openssl-deprecated.patch
@@ -1,0 +1,47 @@
+--- a/daemon/dtls.c
++++ b/daemon/dtls.c
+@@ -5,6 +5,8 @@
+ #include <glib.h>
+ #include <openssl/ssl.h>
+ #include <openssl/x509.h>
++#include <openssl/bn.h>
++#include <openssl/rsa.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <openssl/err.h>
+@@ -239,10 +241,10 @@ static int cert_init(void) {
+ 
+ 	/* cert lifetime */
+ 
+-	if (!X509_gmtime_adj(X509_get_notBefore(x509), -60*60*24))
++	if (!X509_gmtime_adj(X509_getm_notBefore(x509), -60*60*24))
+ 		goto err;
+ 
+-	if (!X509_gmtime_adj(X509_get_notAfter(x509), CERT_EXPIRY_TIME))
++	if (!X509_gmtime_adj(X509_getm_notAfter(x509), CERT_EXPIRY_TIME))
+ 		goto err;
+ 
+ 	/* sign it */
+--- a/lib/ssllib.c
++++ b/lib/ssllib.c
+@@ -35,10 +35,6 @@ static void make_OpenSSL_thread_safe(void) {
+ 	CRYPTO_THREADID_set_callback(cb_openssl_threadid);
+ 	CRYPTO_set_locking_callback(cb_openssl_lock);
+ }
+-#else
+-static void make_OpenSSL_thread_safe(void) {
+-	;
+-}
+ #endif
+ 
+ 
+@@ -46,7 +42,9 @@ void rtpe_ssl_init(void) {
+ 	struct timespec ts;
+ 	clock_gettime(CLOCK_REALTIME, &ts);
+ 	srandom(ts.tv_sec ^ ts.tv_nsec);
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	SSL_library_init();
+ 	SSL_load_error_strings();
+ 	make_OpenSSL_thread_safe();
++#endif
+ }


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @micmac1 
Compile tested: ath79