### PR TITLE
spandsp3: new package

### DIFF
--- a/libs/spandsp3/Makefile
+++ b/libs/spandsp3/Makefile
@@ -1,0 +1,74 @@
+#
+# Copyright (C) 2020 Sebastian Kemper <sebastian_ml@gmx.net>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=spandsp3
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/freeswitch/spandsp.git
+PKG_SOURCE_DATE=2020-08-14
+PKG_SOURCE_VERSION:=6ec23e5a7e411a22d59e5678d12c4d2942c4a4b6
+PKG_RELEASE:=1
+PKG_MIRROR_HASH:=fcfa13576a25ff27e3746c3db30de89d2afceb963072b352a34e7a4a9f492ae5
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
+
+PKG_LICENSE:=LGPL-2.1-or-later GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:= \
+	Jiri Slachta <jiri@slachta.eu> \
+	Sebastian Kemper <sebastian_ml@gmx.net>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libspandsp3
+  SUBMENU:=Telephony
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=spandsp3 library
+  DEPENDS:=+libjpeg-turbo +libtiff
+  URL:=https://github.com/freeswitch/spandsp
+  ABI_VERSION:=3
+endef
+
+# Use fixed point math when soft float support is enabled for target devices.
+ifeq ($(CONFIG_SOFT_FLOAT),y)
+CONFIGURE_ARGS+= \
+	--enable-fixed-point
+endif
+
+define Build/InstallDev
+	$(INSTALL_DIR) \
+		$(1)/usr/lib/spandsp3/{include/spandsp/private,lib}
+
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libspandsp* \
+		$(1)/usr/lib/spandsp3/lib
+
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/spandsp.h \
+		$(1)/usr/lib/spandsp3/include
+
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/spandsp/*.h \
+		$(1)/usr/lib/spandsp3/include/spandsp
+
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/include/spandsp/private/*.h \
+		$(1)/usr/lib/spandsp3/include/spandsp/private
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/spandsp.pc \
+		$(1)/usr/lib/pkgconfig/spandsp3.pc
+endef
+
+define Package/libspandsp3/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libspandsp.so.$(ABI_VERSION)* \
+		$(1)/usr/lib
+endef
+
+$(eval $(call BuildPackage,libspandsp3))

--- a/libs/spandsp3/patches/01-spandsp3-pkg-config.patch
+++ b/libs/spandsp3/patches/01-spandsp3-pkg-config.patch
@@ -1,0 +1,18 @@
+--- a/spandsp.pc.in
++++ b/spandsp.pc.in
+@@ -1,12 +1,12 @@
+ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+-libdir=@libdir@
+-includedir=@includedir@
++libdir=${exec_prefix}/lib/spandsp3/lib
++includedir=${prefix}/lib/spandsp3/include
+ 
+ Name: spandsp
+ Description: A DSP library for telephony.
+ Requires:
+ Version: @VERSION@
+-Libs: -L${libdir} -lspandsp
++Libs: -L${libdir} -l:libspandsp.so.3
+ Libs.private: -ltiff -lm
+ Cflags: -I${includedir}


### PR DESCRIPTION
This commit adds an updated spandsp library. This is not a drop-in
replacement for the "old" spandsp library. Applications that want to use
it need to be updated a bit, according to upstream info [1].

In an effort to not cause any problems for OpenWrt, this package
installs the library and headers in the staging directory into
non-standard paths:

Library: $(STAGING_DIR/usr/lib/spandsp3/lib
Headers: $(STAGING_DIR/usr/lib/spandsp3/include

This way they are hidden aways from all normal users (like asterisk,
baresip etc.) and won't interfere.

To use the new spandsp library users can look for the spandsp3
pkg-config file (the regular spandsp installs spandsp.pc, this package
installs spandsp3.pc). This should be enough. The first such user will
likely be the freeswitch package, once it gets updated to 1.10.5.

[1] https://github.com/freeswitch/spandsp/issues/5

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta & me
Compile tested: ath79 master
Run tested: will do so when I update freeswitch to 1.10.5 which has just been released

Description:
Hi Jiri,

spandsp has a new home [here](https://github.com/freeswitch/spandsp). This is not only from the freeswitch folks, but the "original" upstream people are also involved as far as I know.

freeswitch up to 1.10.4 always included this new spandsp version internally. But since 1.10.4 it links it in from outside. I actually patched the "keeping spandsp internal" back into 1.10.4.

For 1.10.5 I would rather drop the new spandsp version in our tree, in a way that doesn't mess with the old spandsp version nor its users. So this new package hides itself away in the staging directory. Using the new spandsp3.pc file makes it "visible".

I'm not sure how upstreams like asterisk and baresip etc. will handle this. Will they update their software to use the new spandsp? I don't know. I know that rtpengine upstream added support for the new version already. So I guess it's possible that others will as well.

With this new package "hiding" in staging we wouldn't have to worry about this. If for instance asterisk upstream added support for the new spandsp version we could just patch asterisk to look for spandsp3.pc instead of spandsp.pc. If in the end all our upstreams supported the new version we could drop the old spandsp and stop hiding the new one.

On the target the old and new spandsp won't interfere, because they have a different SONAME (2 vs. 3).

I added both you and me as maintainers.

Is this acceptable for you?

Kind regards,
Seb