### PR TITLE
rtpengine: bump to 8.5.1.2, disable parallel build

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -9,19 +9,23 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=rtpengine
-PKG_VERSION:=mr8.5.1.1
-PKG_RELEASE:=2
+PKG_VERSION:=mr8.5.1.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sipwise/rtpengine/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=170377d663f9f9da790aa1ff262001940bfc4e930547807182fcceb8d8ee987e
+PKG_HASH:=ffc85d736ee58c4f74374ebc336fd14e43031be7bbd6acff27447cc25aff9558
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
-PKG_BUILD_PARALLEL:=1
+# When building in parallel, some files (like streambuf.c or dtmflib.c)
+# are generated multiple times by the rtpengine build system.
+# Intermittently they then contain garbage, leading to redefinition
+# errors.
+PKG_BUILD_PARALLEL:=0
 
 PKG_BUILD_DEPENDS:=gperf/host
 


### PR DESCRIPTION
Minor version bump. This also partially reverts
7e7ab06ccda2befbd517a1b974da44fd6643f72e by disabling parallel builds,
as there are sporadic build failures again

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: master ath79
Run tested: no, minor version bump only includes a single commit

Description:
Minor version bump and go back to disable parallel builds.