### PR TITLE
dahdi: bump and cleanups

### DIFF
--- a/libs/dahdi-linux/Makefile
+++ b/libs/dahdi-linux/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=dahdi-linux
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/dahdi-linux/releases
@@ -20,14 +20,12 @@ PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Vittorio Gambaletta <openwrt@vittgam.net>
 
-DAHDI_MODULES_EXTRA:=
-
 include $(INCLUDE_DIR)/package.mk
 
 define KernelPackage/dahdi
   SUBMENU:=Voice over IP
   TITLE:=DAHDI basic infrastructure
-  DEPENDS:=@!(LINUX_4_9||LINUX_4_14) @USB_SUPPORT +kmod-lib-crc-ccitt
+  DEPENDS:=@USB_SUPPORT +kmod-lib-crc-ccitt
   URL:=http://www.asterisk.org/
   FILES:= $(PKG_BUILD_DIR)/drivers/dahdi/dahdi.$(LINUX_KMOD_SUFFIX)
   AUTOLOAD:=$(call AutoProbe,dahdi)
@@ -92,8 +90,7 @@ define Build/Compile
 		ARCH="$(LINUX_KARCH)" \
 		$(TARGET_CONFIGURE_OPTS) \
 		CROSS_COMPILE="$(TARGET_CROSS)" \
-		KSRC="$(LINUX_DIR)" \
-		MODULES_EXTRA="$(DAHDI_MODULES_EXTRA)"
+		KSRC="$(LINUX_DIR)"
 endef
 
 define Build/InstallDev

--- a/libs/dahdi-tools/Makefile
+++ b/libs/dahdi-tools/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dahdi-tools
-PKG_VERSION:=3.0.0
-PKG_RELEASE:=3
+PKG_VERSION:=3.1.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/dahdi-tools/releases
-PKG_HASH:=5bebb20d5ae13fa13f0e2075603013954b962be477db02271eef44b3e41557c5
+PKG_HASH:=ea852ebd274ee1cc90ff5e4ac84261b0b787b1a74e8b76ad659bc9ec4f77e67e
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @VittGam 
Compile tested: ath79 master
Run tested: on 19.07 ath70, ran some tools. I have no "dahdi" hw so I don't really know what I'm doing, but the programs seem to execute.

```
root@hank2:/tmp# dahdi_test 
Opened pseudo dahdi interface, measuring accuracy...
99.596% 99.590% 98.456% 99.591% 99.592% 99.592% 99.592% 98.451% 
99.592% 99.591% 99.592% 99.592% 98.458% 99.591% 99.593% ^C
--- Results after 15 passes ---
Best: 99.596% -- Worst: 98.451% -- Average: 99.364558%
Cumulative Accuracy (not per pass): 99.983
root@hank2:/tmp# dahdi_speed 
^C
root@hank2:/tmp# dahdi_speed -h
^C
root@hank2:/tmp# dahdi_speed -v
^C
root@hank2:/tmp# dahdi_
dahdi_cfg      dahdi_monitor  dahdi_scan     dahdi_speed    dahdi_test
root@hank2:/tmp# dahdi_
dahdi_cfg      dahdi_monitor  dahdi_scan     dahdi_speed    dahdi_test
root@hank2:/tmp# dahdi_monitor -v
Usage: dahdi_monitor <channel num> [-v[v]] [-m] [-o] [-l limit] [-f FILE | -s FILE | -r FILE1 -t FILE2] [-F FILE | -S FILE | -R FILE1 -T FILE2]
Options:
        -v: Visual mode.  Implies -m.
        -vv: Visual/Verbose mode.  Implies -m.
        -l LIMIT: Stop after reading LIMIT bytes
        -m: Separate rx/tx streams.
        -o: Output audio via OSS.  Note: Only 'normal' combined rx/tx streams are output via OSS.
        -f FILE: Save combined rx/tx stream to mono FILE. Cannot be used with -m.
        -r FILE: Save rx stream to FILE. Implies -m.
        -t FILE: Save tx stream to FILE. Implies -m.
        -s FILE: Save stereo rx/tx stream to FILE. Implies -m.
        -F FILE: Save combined pre-echocanceled rx/tx stream to FILE. Cannot be used with -m.
        -R FILE: Save pre-echocanceled rx stream to FILE. Implies -m.
        -T FILE: Save pre-echocanceled tx stream to FILE. Implies -m.
        -S FILE: Save pre-echocanceled stereo rx/tx stream to FILE. Implies -m.
Examples:
Save a stream to a file
        dahdi_monitor 1 -f stream.raw
Visualize an rx/tx stream and save them to separate files.
        dahdi_monitor 1 -v -r streamrx.raw -t streamtx.raw
Play a combined rx/tx stream via OSS and save it to a file
        dahdi_monitor 1 -o -f stream.raw
Save a combined normal rx/tx stream and a combined 'preecho' rx/tx stream to files
        dahdi_monitor 1 -f stream.raw -F streampreecho.raw
Save a normal rx/tx stream and a 'preecho' rx/tx stream to separate files
        dahdi_monitor 1 -m -r streamrx.raw -t streamtx.raw -R streampreechorx.raw -T streampreechotx.raw
root@hank2:/tmp#
```

Description:
bump and cleanups