### PR TITLE
dahdi-tools: remove glibc specific DECLS

### DIFF
--- a/libs/dahdi-tools/Makefile
+++ b/libs/dahdi-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dahdi-tools
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/dahdi-tools/releases

--- a/libs/dahdi-tools/patches/030-musl.patch
+++ b/libs/dahdi-tools/patches/030-musl.patch
@@ -1,0 +1,25 @@
+--- a/xpp/hexfile.h
++++ b/xpp/hexfile.h
+@@ -69,8 +69,9 @@ struct hexdata {
+ 	struct hexline		*lines[ZERO_SIZE];
+ };
+ 
+-
+-__BEGIN_DECLS
++#ifdef __cplusplus
++extern "C" {
++#endif
+ 
+ typedef void (*parse_hexfile_report_func_t)(int level, const char *msg, ...)
+ #ifdef	__GNUC__
+@@ -86,6 +87,9 @@ int dump_hexfile2(struct hexdata *hexdata, const char *outfile, uint8_t maxwidth
+ void dump_binary(struct hexdata *hexdata, const char *outfile);
+ void gen_hexline(const uint8_t *data, uint16_t addr, size_t len, FILE *output);
+ int bsd_checksum(struct hexdata *hexdata);
+-__END_DECLS
++
++#ifdef __cplusplus
++}
++#endif
+ 
+ #endif


### PR DESCRIPTION
Fixes compilation with musl 1.2.0 and above.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @VittGam 
Compile tested: ath79