### PR TITLE
rtpengine: bump to 8.5.2.3 + add build fix

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=rtpengine
-PKG_VERSION:=mr8.5.2.1
+PKG_VERSION:=mr8.5.2.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sipwise/rtpengine/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=7c6f0e036d9aa29485236cc9cd7157625071038f5d773c54c6dc0dc4606aed1e
+PKG_HASH:=e2c0f94984753f321e1db0a97f81af18f3e9f7005a2ca67766ddef2b6c8d4427
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=LICENSE

--- a/net/rtpengine/patches/05-support-kernels-greater-equal-5.9.9.patch
+++ b/net/rtpengine/patches/05-support-kernels-greater-equal-5.9.9.patch
@@ -1,0 +1,38 @@
+commit 46a64889071cb844550786096c251b804a234016
+Author: Richard Fuchs <rfuchs@sipwise.com>
+Date:   Thu Nov 19 11:22:26 2020 -0500
+
+    support kernels >= 5.9.9
+    
+    closes #1111
+    
+    Change-Id: I81f22bfec93b38a108b671b10bd70bf86fb1270c
+
+diff --git a/kernel-module/xt_RTPENGINE.c b/kernel-module/xt_RTPENGINE.c
+index c12edcd8..3c5e3a89 100644
+--- a/kernel-module/xt_RTPENGINE.c
++++ b/kernel-module/xt_RTPENGINE.c
+@@ -3351,7 +3351,10 @@ static int send_proxy_packet4(struct sk_buff *skb, struct re_address *src, struc
+ 		uh->check = CSUM_MANGLED_0;
+ 
+ 	skb->protocol = htons(ETH_P_IP);
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,9) || \
++		(LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,78) && LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0))
++	if (ip_route_me_harder(par->state->net, par->state->sk, skb, RTN_UNSPEC))
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
+ 	if (ip_route_me_harder(par->state->net, skb, RTN_UNSPEC))
+ #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+ 	if (ip_route_me_harder(par->net, skb, RTN_UNSPEC))
+@@ -3447,7 +3450,10 @@ static int send_proxy_packet6(struct sk_buff *skb, struct re_address *src, struc
+ 		uh->check = CSUM_MANGLED_0;
+ 
+ 	skb->protocol = htons(ETH_P_IPV6);
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,9) || \
++		(LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,78) && LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0))
++	if (ip6_route_me_harder(par->state->net, par->state->sk, skb))
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
+ 	if (ip6_route_me_harder(par->state->net, skb))
+ #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
+ 	if (ip6_route_me_harder(par->net, skb))


### PR DESCRIPTION
Patch from upstream fixes builds on recent kernels.

Closes #590

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta & me
Compile tested: master ath79
Run tested: N/A

Description:
