### PR TITLE
kamailio-5.x: build fixes

### DIFF
--- a/net/kamailio-5.x/Makefile
+++ b/net/kamailio-5.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio5
 PKG_VERSION:=5.4.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://www.kamailio.org/pub/kamailio/$(PKG_VERSION)/src
 PKG_SOURCE:=kamailio-$(PKG_VERSION)$(PKG_VARIANT)_src.tar.gz
@@ -407,7 +407,7 @@ EXTRA_MODULES:= \
 # When CONFIG_CPU_TYPE matches one of the identifiers in the list below, set
 # ARCH to "mips2" to get FAST_LOCK support.
 ifeq ($(call qstrip,$(CONFIG_ARCH)),mips)
-CPU_MIPS2:=mips32 24kc 34kc 74kc
+CPU_MIPS2:=mips32 24kc 34kc 4kec 74kc
 endif
 
 MAKE_FLAGS += \

--- a/net/kamailio-5.x/patches/150-erlang-fix-flags.patch
+++ b/net/kamailio-5.x/patches/150-erlang-fix-flags.patch
@@ -1,0 +1,30 @@
+--- a/src/modules/erlang/Makefile
++++ b/src/modules/erlang/Makefile
+@@ -5,20 +5,21 @@ include ../../Makefile.defs
+ auto_gen=
+ NAME=erlang.so
+ 
+-ERLANG=$(shell which erl)
++# In OpenWrt Erlang resides in standard locations, no special flags required
++#ERLANG=$(shell which erl)
+ 
+ ifneq ($(ERLANG),)
+ ERLANG_LIBDIR=$(shell $(ERLANG) -noshell -eval 'io:format("~n~s/lib~n", [[code:lib_dir("erl_interface")]]).' -s erlang halt | tail -n 1)
+ ERLANG_INCDIR=$(shell $(ERLANG) -noshell -eval 'io:format("~n~s/include~n", [[code:lib_dir("erl_interface")]]).' -s erlang halt | tail -n 1)
+ endif
+ 
+-ifeq ($(ERLANG_LIBDIR)$(ERLANG_INCDIR),)
+-$(error Not found Erlang)
+-endif
++#ifeq ($(ERLANG_LIBDIR)$(ERLANG_INCDIR),)
++#$(error Not found Erlang)
++#endif
+ 
+-LIBS=-L$(ERLANG_LIBDIR) -lei -lpthread
++LIBS=-lei -lpthread
+ 
+-DEFS+=-I$(ERLANG_INCDIR)
++#DEFS+=-I$(ERLANG_INCDIR)
+ DEFS+=-D_REENTRANT
+ 
+ 


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: archs38 + rtl838x
Run tested: don't have the hardware, but these are build-fixes only anyway.

Description:
Hi Jiri,

I was going around https://downloads.openwrt.org/snapshots/faillogs/ looking for builds that fail. I found Kamailio failing on uClibc targets due to Erlang (I expect the same for glibc). Kamailio also fails to build for the new rtl838x target. Fixes for both issues are included here.

I found one more build failure: asterisk-chan-sccp on uClibc targets. This is because OpenWrt doesn't build uClibc with XLOCALE support, I think. I can live with that :)

Kind regards,
Seb