### PR TITLE
asterisk: fix compilation with 1.2.x

### DIFF
--- a/net/asterisk/Makefile
+++ b/net/asterisk/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk
 PKG_VERSION:=18.1.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk/patches/001-disable-semaphores-on-uclibc-otherwise-allow.patch
+++ b/net/asterisk/patches/001-disable-semaphores-on-uclibc-otherwise-allow.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1035,15 +1035,18 @@ AC_LINK_IFELSE(
+@@ -1037,15 +1037,18 @@ AC_LINK_IFELSE(
  
  # Some platforms define sem_init(), but only support sem_open(). joyous.
  AC_MSG_CHECKING(for working unnamed semaphores)

--- a/net/asterisk/patches/002-configure-fix-detection-of-re-entrant-resolver-funct.patch
+++ b/net/asterisk/patches/002-configure-fix-detection-of-re-entrant-resolver-funct.patch
@@ -18,7 +18,7 @@ Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
 
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1429,7 +1429,11 @@ AC_LINK_IFELSE(
+@@ -1431,7 +1431,11 @@ AC_LINK_IFELSE(
  			#include <arpa/nameser.h>
  			#endif
  			#include <resolv.h>],

--- a/net/asterisk/patches/130-eventfd.patch
+++ b/net/asterisk/patches/130-eventfd.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1208,7 +1208,7 @@ if test "${ac_cv_have_variable_fdset}x"
+@@ -1210,7 +1210,7 @@ if test "${ac_cv_have_variable_fdset}x"
  fi
  
  AC_MSG_CHECKING([if we have usable eventfd support])

--- a/net/asterisk/patches/140-use-default-lua.patch
+++ b/net/asterisk/patches/140-use-default-lua.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2560,7 +2560,11 @@ if test -z "$__opus_include" -o x"$__opu
+@@ -2564,7 +2564,11 @@ if test -z "$__opus_include" -o x"$__opu
  fi
  AST_EXT_LIB_CHECK([OPUSFILE], [opusfile], [op_open_callbacks], [opus/opusfile.h], [], [$__opus_include])
  

--- a/net/asterisk/patches/150-musl-12x.patch
+++ b/net/asterisk/patches/150-musl-12x.patch
@@ -1,0 +1,35 @@
+--- a/include/asterisk/compat.h
++++ b/include/asterisk/compat.h
+@@ -130,14 +130,16 @@ void timersub(struct timeval *tvend, str
+ 
+ #include <errno.h>
+ 
+-#ifdef SOLARIS
++#ifndef __BEGIN_DECLS
+ #define __BEGIN_DECLS
+ #define __END_DECLS
++#endif
+ 
+ #ifndef __P
+ #define __P(p) p
+ #endif
+ 
++#ifdef SOLARIS
+ #include <alloca.h>
+ #include <strings.h>
+ #include <pthread.h>
+--- a/utils/db1-ast/include/db.h
++++ b/utils/db1-ast/include/db.h
+@@ -68,8 +68,11 @@ typedef	unsigned long long	u_int64_t;
+ #endif /* __FreeBSD__ */
+ #endif
+ 
+-#ifdef SOLARIS
++#ifndef __P
+ #define	__P(p) p
++#endif
++
++#ifndef __BEGIN_DECLS
+ #define __BEGIN_DECLS
+ #define __END_DECLS
+ #endif


### PR DESCRIPTION
Needs _DECLS and __P definitions.

Refreshed other patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @jslachta 
Compile tested: powerpc