### PR TITLE
freeswitch: fix compilation with musl 1.2.0

### DIFF
--- a/net/freeswitch/Makefile
+++ b/net/freeswitch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeswitch
 PKG_VERSION:=1.10.5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=freeswitch-$(PKG_VERSION).-release.tar.xz

--- a/net/freeswitch/patches/040-gentls_cert_update_message_digest.patch
+++ b/net/freeswitch/patches/040-gentls_cert_update_message_digest.patch
@@ -22,8 +22,6 @@ Date:   Wed Nov 13 20:29:50 2019 +0100
     
     Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
 
-diff --git a/scripts/gentls_cert.in b/scripts/gentls_cert.in
-index 43aa8ac605..dd56c9f6dc 100644
 --- a/scripts/gentls_cert.in
 +++ b/scripts/gentls_cert.in
 @@ -89,7 +89,7 @@ setup_ca() {

--- a/net/freeswitch/patches/230-mod_radius_cdr.patch
+++ b/net/freeswitch/patches/230-mod_radius_cdr.patch
@@ -11,23 +11,12 @@
  $(RADCLIENT_LA): $(RADCLIENT_BUILDDIR)/Makefile
 --- /dev/null
 +++ b/src/mod/event_handlers/mod_radius_cdr/freeradius-client-1.1.6-configure-in.diff
-@@ -0,0 +1,32 @@
-+diff --git a/configure.in b/configure.in
-+index 4f194bd..647e9b9 100644
+@@ -0,0 +1,21 @@
 +--- a/configure.in
 ++++ b/configure.in
-+@@ -209,7 +209,7 @@ AC_CHECK_FUNCS(stricmp random rand snprintf vsnprintf)
-+ if test "$ac_cv_func_uname" = 'yes'
-+ then
-+ 	AC_MSG_CHECKING([for field domainname in struct utsname])
-+-	AC_TRY_RUN([
-++	AC_COMPILE_IFELSE([
-+ 	#include <sys/utsname.h>
-+ 	
-+ 	main(int argc, char **argv)
-+@@ -224,13 +224,11 @@ then
-+ 	)
-+ fi
++@@ -234,13 +234,11 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([
++                   enable_getrandom=getentropy],
++                  [AC_MSG_RESULT(no)])
 + 
 +-AC_MSG_CHECKING([for /dev/urandom])
 +-if test -c /dev/urandom
@@ -43,4 +32,4 @@
 ++  AC_DEFINE(HAVE_DEV_URANDOM)
 + fi
 + 
-+ dnl Determine PATH setting
++ AC_ARG_WITH([nettle], [AS_HELP_STRING([--with-nettle],

--- a/net/freeswitch/patches/410-mod_rayo_enable-f-no-common-compilation.patch
+++ b/net/freeswitch/patches/410-mod_rayo_enable-f-no-common-compilation.patch
@@ -4,8 +4,6 @@ Date:   Tue Sep 1 12:13:28 2020 -0400
 
     [mod_rayo] Enable -fno-common compilation
 
-diff --git a/src/mod/event_handlers/mod_rayo/iks_helpers.h b/src/mod/event_handlers/mod_rayo/iks_helpers.h
-index e221abe390..b98dbf5be6 100644
 --- a/src/mod/event_handlers/mod_rayo/iks_helpers.h
 +++ b/src/mod/event_handlers/mod_rayo/iks_helpers.h
 @@ -51,8 +51,7 @@ struct xmpp_error {


### PR DESCRIPTION
Fix patch 230 as it's a patch of a patch with fuzz and wrong offsets.

Refresh other patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @micmac1 
Compile tested: powerpc