### PR TITLE
asterisk: link in libdl when linking to liblua

### DIFF
--- a/net/asterisk/Makefile
+++ b/net/asterisk/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk
 PKG_VERSION:=18.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk/patches/150-lua-ldl.patch
+++ b/net/asterisk/patches/150-lua-ldl.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -2581,7 +2581,7 @@ for ver in ; do
+ done
+ 
+ # Some distributions (like openSUSE and NetBSD) remove the 5.x suffix.
+-AST_EXT_LIB_CHECK([LUA], [lua], [luaL_newstate], [lua.h], [-lm])
++AST_EXT_LIB_CHECK([LUA], [lua], [luaL_newstate], [lua.h], [-lm -ldl])
+ 
+ # Accept either RADIUS client library, their APIs are fully compatible,
+ # just different header filenames and different SONAMEs


### PR DESCRIPTION
Currently building for archs target against glibc fails:

checking for mandatory modules:  CAP GSM ILBC LIBEDIT LIBXML2 LUA PJPROJECT SQLITE3 SRTP ZLIB... fail

configure: ***
configure: *** The LUA installation appears to be missing or broken.

Checking config.log reveals:

/home/sk/tmp/sdk/openwrt-sdk-archs38-generic_gcc-8.4.0_glibc.Linux-x86_64/staging_dir/toolchain-arc_archs_gcc-8.4.0_glibc/bin/../lib/gcc/arc-openwrt-linux-gnu/8.4.0/../../../../arc-openwrt-linux-gnu/bin/ld: /home/sk/tmp/sdk/openwrt-sdk-archs38-generic_gcc-8.4.0_glibc.Linux-x86_64/staging_dir/target-arc_archs_glibc/usr/lib/liblua.so: undefined reference to `dlopen'
/home/sk/tmp/sdk/openwrt-sdk-archs38-generic_gcc-8.4.0_glibc.Linux-x86_64/staging_dir/toolchain-arc_archs_gcc-8.4.0_glibc/bin/../lib/gcc/arc-openwrt-linux-gnu/8.4.0/../../../../arc-openwrt-linux-gnu/bin/ld: /home/sk/tmp/sdk/openwrt-sdk-archs38-generic_gcc-8.4.0_glibc.Linux-x86_64/staging_dir/target-arc_archs_glibc/usr/lib/liblua.so: undefined reference to `dlclose'
/home/sk/tmp/sdk/openwrt-sdk-archs38-generic_gcc-8.4.0_glibc.Linux-x86_64/staging_dir/toolchain-arc_archs_gcc-8.4.0_glibc/bin/../lib/gcc/arc-openwrt-linux-gnu/8.4.0/../../../../arc-openwrt-linux-gnu/bin/ld: /home/sk/tmp/sdk/openwrt-sdk-archs38-generic_gcc-8.4.0_glibc.Linux-x86_64/staging_dir/target-arc_archs_glibc/usr/lib/liblua.so: undefined reference to `dlerror'
/home/sk/tmp/sdk/openwrt-sdk-archs38-generic_gcc-8.4.0_glibc.Linux-x86_64/staging_dir/toolchain-arc_archs_gcc-8.4.0_glibc/bin/../lib/gcc/arc-openwrt-linux-gnu/8.4.0/../../../../arc-openwrt-linux-gnu/bin/ld: /home/sk/tmp/sdk/openwrt-sdk-archs38-generic_gcc-8.4.0_glibc.Linux-x86_64/staging_dir/target-arc_archs_glibc/usr/lib/liblua.so: undefined reference to `dlsym'

This commit adds "-ldl" to lua linker flags so compilation against glibc
works. This has no ill effect on musl where libdl is just an empty
library archive.

This is not something that should be sent upstream, as they maybe
support non-Linux platforms as well.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: archs-glibc + ath79-musl
Run tested: no

Description:
Hi Jiri,

Small compile fix for glibc builds (lua related).

Kind regards,
Seb