### PR TITLE
rtpengine: bump to 8.5.3.1

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -9,12 +9,14 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=rtpengine
-PKG_VERSION:=mr8.5.2.7
-PKG_RELEASE:=2
+PKG_VERSION:=8.5.3.1
+PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/sipwise/rtpengine/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=3f175f3fbfcc3da6c789337fe250de43da9e1e0074ff49d1d2eb3440b5411908
+PKG_SOURCE:=$(PKG_NAME)-mr$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/sipwise/rtpengine/tar.gz/mr$(PKG_VERSION)?
+PKG_HASH:=5c2814fb191aca40b60ca666a7614004d4ba224e194509a57aae56967d13ecf7
+
+PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-mr$(PKG_VERSION)
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=LICENSE

--- a/net/rtpengine/patches/02-pcap.patch
+++ b/net/rtpengine/patches/02-pcap.patch
@@ -8,8 +8,6 @@ Change-Id: I8c759d74c8091dd302399c3e72939fa43688f655
  daemon/recording.c | 48 +++++++++++++++++++++++-----------------------
  1 file changed, 24 insertions(+), 24 deletions(-)
 
-diff --git a/daemon/recording.c b/daemon/recording.c
-index 62d26acf4..ad36e1901 100644
 --- a/daemon/recording.c
 +++ b/daemon/recording.c
 @@ -24,7 +24,7 @@
@@ -21,7 +19,7 @@ index 62d26acf4..ad36e1901 100644
  	int linktype;
  	int headerlen;
  	void (*header)(unsigned char *, struct packet_stream *);
-@@ -40,8 +40,8 @@ static int append_meta_chunk(struct recording *recording, const char *buf, unsig
+@@ -40,8 +40,8 @@ static int append_meta_chunk(struct reco
  	__attribute__((format(printf,4,5)));
  
  // pcap methods
@@ -32,7 +30,7 @@ index 62d26acf4..ad36e1901 100644
  static void sdp_after_pcap(struct recording *, GString *str, struct call_monologue *, enum call_opmode opmode);
  static void dump_packet_pcap(struct media_packet *mp, const str *s);
  static void finish_pcap(struct call *);
-@@ -60,7 +60,7 @@ static void setup_stream_proc(struct packet_stream *);
+@@ -59,7 +59,7 @@ static void setup_stream_proc(struct pac
  static void setup_media_proc(struct call_media *);
  static void kernel_info_proc(struct packet_stream *, struct rtpengine_target_info *);
  
@@ -41,7 +39,7 @@ index 62d26acf4..ad36e1901 100644
  
  #define append_meta_chunk_str(r, str, f...) append_meta_chunk(r, (str)->s, (str)->len, f)
  #define append_meta_chunk_s(r, str, f...) append_meta_chunk(r, (str), strlen(str), f)
-@@ -71,8 +71,8 @@ static const struct recording_method methods[] = {
+@@ -70,8 +70,8 @@ static const struct recording_method met
  	{
  		.name = "pcap",
  		.kernel_support = 0,
@@ -52,7 +50,7 @@ index 62d26acf4..ad36e1901 100644
  		.sdp_after = sdp_after_pcap,
  		.dump_packet = dump_packet_pcap,
  		.finish = finish_pcap,
-@@ -96,14 +96,14 @@ static const struct recording_method methods[] = {
+@@ -94,14 +94,14 @@ static const struct recording_method met
  	},
  };
  
@@ -70,7 +68,7 @@ index 62d26acf4..ad36e1901 100644
  };
  
  
-@@ -111,7 +111,7 @@ static const struct pcap_format pcap_format_eth = {
+@@ -109,7 +109,7 @@ static const struct pcap_format pcap_for
  static char *spooldir = NULL;
  
  const struct recording_method *selected_recording_method;
@@ -79,7 +77,7 @@ index 62d26acf4..ad36e1901 100644
  
  
  
-@@ -150,9 +150,9 @@ void recording_fs_init(const char *spoolpath, const char *method_str, const char
+@@ -148,9 +148,9 @@ void recording_fs_init(const char *spool
  
  found:
  	if(!strcmp("raw", format_str))
@@ -91,7 +89,7 @@ index 62d26acf4..ad36e1901 100644
  	else {
  		ilog(LOG_ERR, "Invalid value for recording format \"%s\".", format_str);
  		exit(-1);
-@@ -207,7 +207,7 @@ static int check_main_spool_dir(const char *spoolpath) {
+@@ -205,7 +205,7 @@ static int check_main_spool_dir(const ch
   *
   * Create the "metadata" and "pcaps" directories if they are not there.
   */
@@ -100,7 +98,7 @@ index 62d26acf4..ad36e1901 100644
  	int spool_good = TRUE;
  
  	if (!check_main_spool_dir(spoolpath))
-@@ -360,7 +360,7 @@ void detect_setup_recording(struct call *call, const str *recordcall, str *metad
+@@ -352,7 +352,7 @@ void detect_setup_recording(struct call
  		ilog(LOG_INFO, "\"record-call\" flag "STR_FORMAT" is invalid flag.", STR_FMT(recordcall));
  }
  
@@ -109,7 +107,7 @@ index 62d26acf4..ad36e1901 100644
  	struct recording *recording = call->recording;
  
  	// Wireshark starts at packet index 1, so we start there, too
-@@ -441,7 +441,7 @@ static void sdp_after_pcap(struct recording *recording, GString *str, struct cal
+@@ -433,7 +433,7 @@ static void sdp_after_pcap(struct record
   * Writes metadata to metafile, closes file, and renames it to finished location.
   * Returns non-zero for failure.
   */
@@ -118,7 +116,7 @@ index 62d26acf4..ad36e1901 100644
  	// This should usually be called from a place that has the call->master_lock
  	struct recording *recording = call->recording;
  	int return_code = 0;
-@@ -522,7 +522,7 @@ static char *recording_setup_file(struct recording *recording) {
+@@ -514,7 +514,7 @@ static char *recording_setup_file(struct
  	recording_path = file_path_str(recording->meta_prefix, "/pcaps/", ".pcap");
  	recording->u.pcap.recording_path = recording_path;
  
@@ -127,7 +125,7 @@ index 62d26acf4..ad36e1901 100644
  	recording->u.pcap.recording_pdumper = pcap_dump_open(recording->u.pcap.recording_pd, recording_path);
  	if (recording->u.pcap.recording_pdumper == NULL) {
  		pcap_close(recording->u.pcap.recording_pd);
-@@ -538,7 +538,7 @@ static char *recording_setup_file(struct recording *recording) {
+@@ -530,7 +530,7 @@ static char *recording_setup_file(struct
  /**
   * Flushes PCAP file, closes the dumper and descriptors, and frees object memory.
   */
@@ -136,7 +134,7 @@ index 62d26acf4..ad36e1901 100644
  	if (recording->u.pcap.recording_pdumper != NULL) {
  		pcap_dump_flush(recording->u.pcap.recording_pdumper);
  		pcap_dump_close(recording->u.pcap.recording_pdumper);
-@@ -565,7 +565,7 @@ static unsigned int fake_ip_header(unsigned char *out, struct media_packet *mp,
+@@ -557,7 +557,7 @@ static unsigned int fake_ip_header(unsig
  	return hdr_len + inp->len;
  }
  
@@ -145,7 +143,7 @@ index 62d26acf4..ad36e1901 100644
  	memset(pkt, 0, 14);
  	uint16_t *hdr16 = (void *) pkt;
  	hdr16[6] = htons(stream->selected_sfd->socket.local.address.family->ethertype);
-@@ -580,10 +580,10 @@ static void stream_pcap_dump(struct media_packet *mp, const str *s) {
+@@ -572,10 +572,10 @@ static void stream_pcap_dump(struct medi
  	if (!pdumper)
  		return;
  
@@ -160,7 +158,7 @@ index 62d26acf4..ad36e1901 100644
  
  	// Set up PCAP packet header
  	struct pcap_pkthdr header;
-@@ -606,8 +606,8 @@ static void dump_packet_pcap(struct media_packet *mp, const str *s) {
+@@ -598,8 +598,8 @@ static void dump_packet_pcap(struct medi
  }
  
  static void finish_pcap(struct call *call) {


### PR DESCRIPTION
In other news:

 - removes "mr" from version
 - refreshes patches/02-pcap.patch

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: master ath79
Run tested: 

Description:
Bump. It remains in the same LTS strain.