### PR TITLE
siproxd: fix UID variable conflict in init

### DIFF
--- a/net/siproxd/Makefile
+++ b/net/siproxd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=siproxd
 PKG_VERSION:=0.8.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/siproxd

--- a/net/siproxd/files/siproxd.init
+++ b/net/siproxd/files/siproxd.init
@@ -11,8 +11,8 @@ CONF_DIR="/var/etc/siproxd"
 REG_DIR="/var/lib/siproxd"
 PID_DIR="/var/run/siproxd"
 PLUGIN_DIR="/usr/lib/siproxd/"
-UID="nobody"
-GID="nogroup"
+SIPROXD_UID="nobody"
+SIPROXD_GID="nogroup"
 
 # Some options need special handling or conflict with procd/jail setup.
 append CONF_SKIP "interface_inbound interface_outbound chrootjail"
@@ -74,7 +74,7 @@ apply_defaults() {
 	default_conf tcp_keepalive 20
 	default_conf default_expires 600
 	default_conf daemonize 0
-	default_conf user "$UID"
+	default_conf user "$SIPROXD_UID"
 	default_conf registration_file "$REG_DIR/siproxd-$sec.reg"
 	default_conf plugindir "$PLUGIN_DIR"
 }
@@ -116,7 +116,7 @@ section_end() {
 	[ -d "$plugin_dir" ] && procd_add_jail_mount "$plugin_dir"
 	# Ensure registration file exists for jail
 	[ -f "$reg_file" ] || touch "$reg_file"
-	chown "$UID:$GID" "$reg_file"
+	chown "$SIPROXD_UID:$SIPROXD_GID" "$reg_file"
 	procd_add_jail_mount_rw "$reg_file"
 	procd_close_instance
 }
@@ -163,7 +163,7 @@ service_triggers()
 start_service() {
 	mkdir -p "$CONF_DIR" "$REG_DIR" "$PID_DIR"
 	chmod 755 "$CONF_DIR" "$REG_DIR" "$PID_DIR"
-	chown "$UID:$GID" "$REG_DIR"
+	chown "$SIPROXD_UID:$SIPROXD_GID" "$REG_DIR"
 
 	siproxd_cb
 	config_load 'siproxd'


### PR DESCRIPTION
**Maintainer**: @jslachta
**Compile tested**: qemu/malta-mips32-be, master branch
**Run tested**: qemu/malta-mips32-be, master branch
**IB tested**: ar71xx/mips32-be, 19.07.6 (confirmed absence of  'readonly variable' warning)

**Description**:
Variable 'UID' is set readonly in some calling contexts, yielding errors during e.g. ImageBuilder usage:
```
  ...
  Enabling rpcd
  ./etc/init.d/siproxd: line 14: UID: readonly variable
  Enabling siproxd
  Enabling sysctl
  ...
```
Rename UID and GID variables as SIPROXD_UID and SIPROXD_GID.

Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
