### PR TITLE
asterisk: disable uriparser

### DIFF
--- a/net/asterisk/Makefile
+++ b/net/asterisk/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk
 PKG_VERSION:=18.1.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases
@@ -581,6 +581,7 @@ CONFIGURE_ARGS+= \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-res-resolver-unbound),--with-unbound="$(STAGING_DIR)/usr",--without-unbound) \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-format-ogg-vorbis),--with-vorbis="$(STAGING_DIR)/usr",--without-vorbis) \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-app-voicemail-imap),--with-imap=system,--without-imap) \
+	--without-uriparser \
 	--without-vpb \
 	--with-z="$(STAGING_DIR)/usr"
 


### PR DESCRIPTION
Maintainer: @jslachta

Uriparser is a compliant URI parsing and handling library for RFC 3986.
For now, this is not included in OpenWrt feeds, but in Turris OS
uriparser is used as dependency for Updater-ng.

When Asterisk finds in build system there is uriparser or anything else mentioned in configure,
it tries to enable it by default. This applies to every package in
OpenWrt and because of that new packages which are added to OpenWrt tries to disable almost
everything by default. Because if someone adds library, some packages
are not compiled or tested.

Fixes:
Package asterisk is missing dependencies for the following libraries:
liburiparser.so.1

Compile tested: Turris Omnia, Turris OS 6.0 (unreleased) based on the latest OpenWrt master (feeds, which were used [here](https://repo.turris.cz/hbd/omnia/packages/git-hash)) and liburiparser [here](https://gitlab.nic.cz/turris/turris-os-packages/-/blob/develop/libs/uriparser/Makefile). It can be reproduced that liburiparser is added to the build system, compiled first and then try to compile asterisk.