### PR TITLE
[19.07] asterisk/pjproject: add patches for recently published Asterisk security notices

### DIFF
--- a/libs/pjproject/Makefile
+++ b/libs/pjproject/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pjproject
 PKG_VERSION:=2.8
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=pjproject-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://www.pjsip.org/release/$(PKG_VERSION)

--- a/libs/pjproject/patches/240-fix-sdp-neg-modify-local-offer.patch
+++ b/libs/pjproject/patches/240-fix-sdp-neg-modify-local-offer.patch
@@ -1,0 +1,33 @@
+diff --git a/pjmedia/src/pjmedia/sdp_neg.c b/pjmedia/src/pjmedia/sdp_neg.c
+index 3b85b4273..a14009662 100644
+--- a/pjmedia/src/pjmedia/sdp_neg.c
++++ b/pjmedia/src/pjmedia/sdp_neg.c
+@@ -304,7 +304,6 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_modify_local_offer2(
+ {
+     pjmedia_sdp_session *new_offer;
+     pjmedia_sdp_session *old_offer;
+-    char media_used[PJMEDIA_MAX_SDP_MEDIA];
+     unsigned oi; /* old offer media index */
+     pj_status_t status;
+ 
+@@ -323,8 +322,19 @@ PJ_DEF(pj_status_t) pjmedia_sdp_neg_modify_local_offer2(
+     /* Change state to STATE_LOCAL_OFFER */
+     neg->state = PJMEDIA_SDP_NEG_STATE_LOCAL_OFFER;
+ 
++    /* When there is no active local SDP in state PJMEDIA_SDP_NEG_STATE_DONE,
++     * it means that the previous initial SDP nego must have been failed,
++     * so we'll just set the local SDP offer here.
++     */
++    if (!neg->active_local_sdp) {
++	neg->initial_sdp_tmp = NULL;
++	neg->initial_sdp = pjmedia_sdp_session_clone(pool, local);
++	neg->neg_local_sdp = pjmedia_sdp_session_clone(pool, local);
++
++	return PJ_SUCCESS;
++    }
++
+     /* Init vars */
+-    pj_bzero(media_used, sizeof(media_used));
+     old_offer = neg->active_local_sdp;
+     new_offer = pjmedia_sdp_session_clone(pool, local);
+ 

--- a/net/asterisk-16.x/Makefile
+++ b/net/asterisk-16.x/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 AST_MAJOR_VERSION:=16
 PKG_NAME:=asterisk$(AST_MAJOR_VERSION)
 PKG_VERSION:=$(AST_MAJOR_VERSION).3.0
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk-16.x/patches/180-AST-2019-007-16.diff
+++ b/net/asterisk-16.x/patches/180-AST-2019-007-16.diff
@@ -21,9 +21,6 @@ Reported by: Eliel Sardañons
 Change-Id: Ic4c9dedc34c426f03c8c14fce334a71386d8a5fa
 ---
 
-diff --git a/doc/UPGRADE-staging/AMI-Originate.txt b/doc/UPGRADE-staging/AMI-Originate.txt
-new file mode 100644
-index 0000000..f2d3133
 --- /dev/null
 +++ b/doc/UPGRADE-staging/AMI-Originate.txt
 @@ -0,0 +1,5 @@
@@ -32,11 +29,9 @@ index 0000000..f2d3133
 +The AMI Originate action, which optionally takes a dialplan application as
 +an argument, no longer accepts "Originate" as the application due to
 +security concerns.
-diff --git a/main/manager.c b/main/manager.c
-index f138801..1963151 100644
 --- a/main/manager.c
 +++ b/main/manager.c
-@@ -5744,6 +5744,7 @@
+@@ -5697,6 +5697,7 @@ static int action_originate(struct manse
  				                                     EAGI(/bin/rm,-rf /)       */
  				strcasestr(app, "mixmonitor") ||  /* MixMonitor(blah,,rm -rf)  */
  				strcasestr(app, "externalivr") || /* ExternalIVR(rm -rf)       */

--- a/net/asterisk-16.x/patches/210-AST-2021-001-16.diff
+++ b/net/asterisk-16.x/patches/210-AST-2021-001-16.diff
@@ -1,0 +1,87 @@
+From 757b7f8d7cfee4f541e8d7586e2408556a74201d Mon Sep 17 00:00:00 2001
+From: Ivan Poddubnyi <ivan.poddubny@gmail.com>
+Date: Mon, 28 Dec 2020 13:43:23 +0100
+Subject: [PATCH] res_pjsip_diversion: Fix adding more than one histinfo to
+ Supported
+
+New responses sent within a PJSIP sessions are based on those that were
+sent before. Therefore, adding/modifying a header once causes it to be
+sent on all responses that follow.
+
+Sending 181 Call Is Being Forwarded many times first adds "histinfo"
+duplicated more and more, and eventually overflows past the array
+boundary.
+
+This commit adds a check preventing adding "histinfo" more than once,
+and skipping it if there is no more space in the header.
+
+Similar overflow situations can also occur in res_pjsip_path and
+res_pjsip_outbound_registration so those were also modified to
+check the bounds and suppress duplicate Supported values.
+
+ASTERISK-29227
+Reported by: Ivan Poddubny
+
+Change-Id: Id43704a1f1a0293e35cc7f844026f0b04f2ac322
+---
+ res/res_pjsip_diversion.c             | 14 ++++++++++++++
+ res/res_pjsip_outbound_registration.c | 12 ++++++++++++
+ res/res_pjsip_path.c                  | 12 ++++++++++++
+ 3 files changed, 38 insertions(+)
+
+--- a/res/res_pjsip_outbound_registration.c
++++ b/res/res_pjsip_outbound_registration.c
+@@ -580,6 +580,7 @@ static int handle_client_registration(vo
+ 
+ 	if (client_state->support_path) {
+ 		pjsip_supported_hdr *hdr;
++		int i;
+ 
+ 		hdr = pjsip_msg_find_hdr(tdata->msg, PJSIP_H_SUPPORTED, NULL);
+ 		if (!hdr) {
+@@ -593,6 +594,17 @@ static int handle_client_registration(vo
+ 			pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr *)hdr);
+ 		}
+ 
++		/* Don't add the value if it's already there */
++		for (i = 0; i < hdr->count; ++i) {
++			if (pj_stricmp(&hdr->values[i], &PATH_NAME) == 0) {
++				return 1;
++			}
++		}
++
++		if (hdr->count >= PJSIP_GENERIC_ARRAY_MAX_COUNT) {
++			return 0;
++		}
++
+ 		/* add on to the existing Supported header */
+ 		pj_strassign(&hdr->values[hdr->count++], &PATH_NAME);
+ 	}
+--- a/res/res_pjsip_path.c
++++ b/res/res_pjsip_path.c
+@@ -122,6 +122,7 @@ static int path_get_string(pj_pool_t *po
+ static int add_supported(pjsip_tx_data *tdata)
+ {
+ 	pjsip_supported_hdr *hdr;
++	int i;
+ 
+ 	hdr = pjsip_msg_find_hdr(tdata->msg, PJSIP_H_SUPPORTED, NULL);
+ 	if (!hdr) {
+@@ -134,6 +135,17 @@ static int add_supported(pjsip_tx_data *
+ 		pjsip_msg_add_hdr(tdata->msg, (pjsip_hdr *)hdr);
+ 	}
+ 
++	/* Don't add the value if it's already there */
++	for (i = 0; i < hdr->count; ++i) {
++		if (pj_stricmp(&hdr->values[i], &PATH_SUPPORTED_NAME) == 0) {
++			return 0;
++		}
++	}
++
++	if (hdr->count >= PJSIP_GENERIC_ARRAY_MAX_COUNT) {
++		return -1;
++	}
++
+ 	/* add on to the existing Supported header */
+ 	pj_strassign(&hdr->values[hdr->count++], &PATH_SUPPORTED_NAME);
+ 


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: 19.07 sdk ath79
Run tested: 19.07.6, made some test calls, also sent some DTMFs

Description:
Hi Jiri,

I went through the following notices:

https://downloads.asterisk.org/pub/security/AST-2021-001.html
https://downloads.asterisk.org/pub/security/AST-2021-002.html
https://downloads.asterisk.org/pub/security/AST-2021-003.html
https://downloads.asterisk.org/pub/security/AST-2021-004.html
https://downloads.asterisk.org/pub/security/AST-2021-005.html
https://downloads.asterisk.org/pub/security/AST-2021-006.html

I also looked at the Debian tracker:

https://security-tracker.debian.org/tracker/source-package/asterisk

It seems to me that in the 19.07 branch we only need to take care of two of them, AST-2021-001 and AST-2021-005. The other bugs were added after asterisk 16.3.0.

Kind regards,
Seb