### PR TITLE
[21.02] freeswitch: fix 003-modmake-fix.patch

### DIFF
--- a/net/freeswitch/Makefile
+++ b/net/freeswitch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeswitch
 PKG_VERSION:=1.10.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=freeswitch-$(PKG_VERSION).-release.tar.xz

--- a/net/freeswitch/patches/003-modmake-fix.patch
+++ b/net/freeswitch/patches/003-modmake-fix.patch
@@ -11,10 +11,3 @@
  DEFAULT_ARGS = --build=$(build) --host=$(host) --target=$(target) --prefix="$(prefix)" --exec_prefix="$(exec_prefix)" --libdir="$(libdir)" --disable-shared --with-pic
  
  moddir=@modulesdir@
-@@ -18,4 +18,4 @@ extraclean-modules: extraclean
- print_tests:
- 	@set +e; \
- 	test -z "$(TESTS)" || for i in $(TESTS); do echo $(subdir)/$$i; done;
--	
-\ No newline at end of file
-+	


### PR DESCRIPTION
Somehow this white space change slipped in unintentionally.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: N/A
Run tested: N/A
Description: Remove an unintended change in the modmake patch.
