### PR TITLE
kamailio: update to version 5.5.0

### DIFF
--- a/net/kamailio/Makefile
+++ b/net/kamailio/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio
-PKG_VERSION:=5.4.2
+PKG_VERSION:=5.5.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://www.kamailio.org/pub/kamailio/$(PKG_VERSION)/src
 PKG_SOURCE:=kamailio-$(PKG_VERSION)_src.tar.gz
-PKG_HASH:=e710824d6810d3053ec79a39ee532c51bb91738a07f16c3a103aa07e0f8b80b5
+PKG_HASH:=d51cc08d20338fbb41f17d4fd2e4c4b67508c74f44613f0bd0c65269ff3557a3
 PKG_USE_MIPS16:=0
 
 PKG_LICENSE:=GPL-2.0+
@@ -120,6 +120,7 @@ MODULES_AVAILABLE:= \
 	ldap \
 	log_custom \
 	lost \
+	lrkproxy \
 	mangler \
 	matrix \
 	maxfwd \
@@ -212,7 +213,7 @@ MODULES_AVAILABLE:= \
 	uid_gflags \
 	uid_uri_db \
 	uri_db \
-	userblacklist \
+	userblocklist \
 	usrloc \
 	utils \
 	uuid \
@@ -552,6 +553,7 @@ $(eval $(call BuildKamailioModule,lcr,Least Cost Routing,,+kamailio-mod-tm +libp
 $(eval $(call BuildKamailioModule,ldap,LDAP connector,,+libopenldap))
 $(eval $(call BuildKamailioModule,log_custom,Logging to custom backends,,))
 $(eval $(call BuildKamailioModule,lost,HELD and LOST routing,,+kamailio-mod-http-client,))
+$(eval $(call BuildKamailioModule,lrkproxy,pylrkproxy media stream relay,,,))
 $(eval $(call BuildKamailioModule,mangler,SDP mangling,,))
 $(eval $(call BuildKamailioModule,matrix,Matrix operations,,))
 $(eval $(call BuildKamailioModule,maxfwd,Max-Forward processor,,))
@@ -644,7 +646,7 @@ $(eval $(call BuildKamailioModule,uid_domain,Domains management,,))
 $(eval $(call BuildKamailioModule,uid_gflags,Global attributes and flags,,))
 $(eval $(call BuildKamailioModule,uid_uri_db,Database URI operations,,))
 $(eval $(call BuildKamailioModule,uri_db,Database-backend SIP URI checking,,))
-$(eval $(call BuildKamailioModule,userblacklist,User blacklists,,+kamailio-lib-libtrie))
+$(eval $(call BuildKamailioModule,userblocklist,User blocklists,,+kamailio-lib-libtrie))
 $(eval $(call BuildKamailioModule,usrloc,User location,,))
 $(eval $(call BuildKamailioModule,utils,Misc utilities,,+libcurl,))
 $(eval $(call BuildKamailioModule,uuid,UUID utilities,,+libuuid))


### PR DESCRIPTION
Added new module lrkproxy. Module "userblacklist" was renamed upstream
to "userblocklist".

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: master ath79 + 19.07 ath79
Run tested: On 19.07 ath79 with rtpproxy and asterisk

```
Sat May  8 16:56:42 2021 daemon.err kamailio[13806]:  1(13813) WARNING: {20 REGISTER} sanity [sanity.c:612]: check_cl(): content length header missing in request
Sat May  8 16:56:42 2021 daemon.err kamailio[13806]:  1(13813) WARNING: {21 REGISTER} sanity [sanity.c:612]: check_cl(): content length header missing in request
Sat May  8 16:56:52 2021 daemon.err kamailio[13806]:  1(13813) NOTICE: {20 INVITE} Outbound call to local number 6001
Sat May  8 16:56:52 2021 daemon.err kamailio[13806]:  1(13813) INFO: {20 INVITE} new branch [0] to sip:6001@192.168.0.1
Sat May  8 16:56:52 2021 daemon.err rtpproxy[13780]: INFO:GLOBAL:rtpp_command_ul_handle: new IPv4/IPv4 session ~9cqKQoA4o, tag sbk7D9UQy;1 requested, type strong
Sat May  8 16:56:52 2021 daemon.err rtpproxy[13780]: INFO:~9cqKQoA4o:rtpp_command_ul_handle: new session on IPv4 port 9994 created, tag sbk7D9UQy;1
Sat May  8 16:56:52 2021 daemon.err rtpproxy[13780]: INFO:~9cqKQoA4o:rtpp_stream_prefill_addr: pre-filling caller's RTP address with 192.168.0.151:7076
Sat May  8 16:56:52 2021 daemon.err rtpproxy[13780]: INFO:~9cqKQoA4o:rtpp_stream_prefill_addr: pre-filling caller's RTCP address with 192.168.0.151:7077
```

Description:
Hi Jiri,

Upstream recently released the first 5.5.x release. They added 6 new modules. I added one which doesn't need extra dependencies. There is another new module that depends on libwebsocket (which OpenWrt offers), but it doesn't compile, so I left it out in the end.

Runtesting was fine. I did that on 19.07 (I don't have master running my router).

Kind regards,
Seb