### PR TITLE
[21.02] sofia-sip: add upstream fix for memory leak

### DIFF
--- a/libs/sofia-sip/Makefile
+++ b/libs/sofia-sip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sofia-sip
 
 PKG_VERSION:=1.13.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/freeswitch/$(PKG_NAME)/tar.gz/v${PKG_VERSION}?

--- a/libs/sofia-sip/patches/02-NUA_handles-mem-leak-fix.patch
+++ b/libs/sofia-sip/patches/02-NUA_handles-mem-leak-fix.patch
@@ -1,0 +1,67 @@
+commit 8071e8accd250bd1d7758dd16166382b48a6e6d4
+Author: Andrey Volk <andywolk@gmail.com>
+Date:   Wed Mar 10 18:37:18 2021 +0300
+
+    NUA handles must be able to unref via stack (nua_handle_unref_user() API) when they are already destroyed or nua is in shutdown
+
+--- a/libsofia-sip-ua/nua/nua.c
++++ b/libsofia-sip-ua/nua/nua.c
+@@ -1165,11 +1165,7 @@ void nua_unref_user(nua_t *nua)
+ 
+ void nua_handle_unref_user(nua_handle_t *nh)
+ {
+-	enter;
+-	if (NH_IS_VALID(nh)) {
+-	  nua_signal(nh->nh_nua, nh, NULL, nua_r_handle_unref, 0, NULL, TAG_NULL());
+-	}
+-	else {
+-	  SU_DEBUG_1(("nua: nua_r_handle_unref with invalid handle %p\n", (void *)nh));
+-	}
++	assert(nh);
++	nh_enter;
++	nua_signal(nh->nh_nua, nh, NULL, nua_r_handle_unref, 0, NULL, TAG_NULL());
+ }
+--- a/libsofia-sip-ua/nua/nua_common.c
++++ b/libsofia-sip-ua/nua/nua_common.c
+@@ -376,6 +376,8 @@ char const *nua_event_name(nua_event_t e
+   case nua_r_nit_respond: return "nua_r_nit_respond";
+   case nua_r_set_params: return "nua_r_set_params";
+   case nua_r_ack: return "nua_r_ack";
++  case nua_r_handle_unref: return "nua_r_handle_unref";
++  case nua_r_unref: return "nua_r_unref";
+   default: return "NUA_UNKNOWN";
+   }
+ }
+--- a/libsofia-sip-ua/nua/nua_stack.c
++++ b/libsofia-sip-ua/nua/nua_stack.c
+@@ -514,7 +514,7 @@ int nua_signal(nua_t *nua, nua_handle_t
+ 
+     assert(tend == t); (void)tend; assert(b == bend); (void)bend;
+ 
+-    e->e_always = event == nua_r_destroy || event == nua_r_shutdown;
++    e->e_always = event == nua_r_destroy || event == nua_r_shutdown || event == nua_r_handle_unref || event == nua_r_unref;
+     e->e_event = event;
+     e->e_nh = nh ? nua_handle_ref(nh) : NULL;
+     e->e_status = status;
+@@ -549,10 +549,10 @@ void nua_stack_signal(nua_t *nua, su_msg
+   nua_event_data_t *e = ee->ee_data;
+   nua_handle_t *nh = e->e_nh;
+   tagi_t *tags = e->e_tags;
+-  nua_event_t event;
++  nua_event_t event = (enum nua_event_e)e->e_event;
+   int error = 0;
+ 
+-  if (nh) {
++  if (nh && event != nua_r_handle_unref) {
+     if (!nh->nh_prev)
+       nh_append(nua, nh);
+     if (!nh->nh_ref_by_stack) {
+@@ -575,8 +575,6 @@ void nua_stack_signal(nua_t *nua, su_msg
+ 
+   su_msg_save(nua->nua_signal, msg);
+ 
+-  event = (enum nua_event_e)e->e_event;
+-
+   if (nua->nua_shutdown && !e->e_always) {
+     /* Shutting down */
+     nua_stack_event(nua, nh, NULL, event,


### PR DESCRIPTION
Upstream provided a patch for a memory leak in Sofia SIP (see [1] for
more information).

[1] https://github.com/signalwire/freeswitch/issues/1174

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: master + 19.07 ath79
Run tested: 19.07 ath79, made a few test calls

Description: Mem leak fix from upstream
