### PR TITLE
yate: increase max acceptable size of incoming SIP messages

### DIFF
--- a/net/yate/Makefile
+++ b/net/yate/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yate
 PKG_VERSION:=6.3.0-1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://yate.null.ro/tarballs/yate6/

--- a/net/yate/patches/120-increase-sip-message-size.patch
+++ b/net/yate/patches/120-increase-sip-message-size.patch
@@ -1,0 +1,11 @@
+--- a/conf.d/ysipchan.conf.sample
++++ b/conf.d/ysipchan.conf.sample
+@@ -80,7 +80,7 @@
+ 
+ ; maxpkt: int: Maximum received UDP packet size, 524 to 65528, default 1500
+ ; This parameter is applied on reload and can be overridden in UDP listener sections
+-;maxpkt=1500
++maxpkt=8192
+ 
+ ; buffer: int: Requested size of UDP socket's receive buffer, 0 to use default
+ ; This can be overridden in UDP listener sections


### PR DESCRIPTION
Some SIP UAs support lots of features and codecs which results in
large SIP messages. YATE, with its default configuration, truncates
and fails to parse received SIP messages which are larger than 1500
bytes. Let's increase the default max message size for OpenWrt users
to make it easier to use yate out-of-the-box.

The new max size of 8192 bytes has been arbitrarily chosen.

I've seen the SIP UA baresip produce messages larger than 1500 bytes
with its default configuration when authentication is used.

Signed-off-by: Robert Högberg <robert.hogberg@gmail.com>

-------------------------------

Maintainer: @jslachta 
Compile tested: No
Run tested: Only by manual configuration change. An increased maxpkt size works well for me. Verified with SIP UA baresip that had problems with YATE before the maxpkt increase.