### PR TITLE
dahdi-tools: fix compilation with musl 1.2.x

### DIFF
--- a/libs/dahdi-tools/Makefile
+++ b/libs/dahdi-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dahdi-tools
 PKG_VERSION:=3.1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/dahdi-tools/releases

--- a/libs/dahdi-tools/patches/030-cdefs.patch
+++ b/libs/dahdi-tools/patches/030-cdefs.patch
@@ -1,0 +1,10 @@
+--- a/xpp/hexfile.h
++++ b/xpp/hexfile.h
+@@ -26,6 +26,7 @@
+ #include <stdarg.h>
+ #include <stdio.h>
+ #include <stdint.h>
++#include <sys/cdefs.h>
+ #include <sys/param.h>
+ #include <syslog.h>
+ #define	PACKED	__attribute__((packed))


### PR DESCRIPTION
Maintainer: 
Compile tested: ath79