### PR TITLE
freeswitch: fix compilation with GCC11

### DIFF
--- a/net/freeswitch/Makefile
+++ b/net/freeswitch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeswitch
 PKG_VERSION:=1.10.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=freeswitch-$(PKG_VERSION).-release.tar.xz

--- a/net/freeswitch/patches/040-gcc11.patch
+++ b/net/freeswitch/patches/040-gcc11.patch
@@ -1,0 +1,31 @@
+--- a/src/include/switch_core_media.h
++++ b/src/include/switch_core_media.h
+@@ -197,7 +197,7 @@ SWITCH_DECLARE(switch_status_t) switch_c
+ SWITCH_DECLARE(void) switch_media_handle_set_media_flag(switch_media_handle_t *smh, switch_core_media_flag_t flag);
+ SWITCH_DECLARE(void) switch_media_handle_clear_media_flag(switch_media_handle_t *smh, switch_core_media_flag_t flag);
+ SWITCH_DECLARE(int32_t) switch_media_handle_test_media_flag(switch_media_handle_t *smh, switch_core_media_flag_t flag);
+-SWITCH_DECLARE(void) switch_media_handle_set_media_flags(switch_media_handle_t *smh, switch_core_media_flag_t flags[]);
++SWITCH_DECLARE(void) switch_media_handle_set_media_flags(switch_media_handle_t *smh, switch_core_media_flag_t flags[SCMF_MAX]);
+ SWITCH_DECLARE(void) switch_core_session_check_outgoing_crypto(switch_core_session_t *session);
+ SWITCH_DECLARE(const char *) switch_core_session_local_crypto_key(switch_core_session_t *session, switch_media_type_t type);
+ SWITCH_DECLARE(int) switch_core_session_check_incoming_crypto(switch_core_session_t *session,
+--- a/src/include/switch_rtp.h
++++ b/src/include/switch_rtp.h
+@@ -234,7 +234,7 @@ SWITCH_DECLARE(switch_status_t) switch_r
+ 												  switch_payload_t payload,
+ 												  uint32_t samples_per_interval,
+ 												  uint32_t ms_per_packet,
+-												  switch_rtp_flag_t flags[], char *timer_name, const char **err, switch_memory_pool_t *pool);
++												  switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID], char *timer_name, const char **err, switch_memory_pool_t *pool);
+ 
+ 
+ /*!
+@@ -260,7 +260,7 @@ SWITCH_DECLARE(switch_rtp_t *) switch_rt
+ 											  switch_payload_t payload,
+ 											  uint32_t samples_per_interval,
+ 											  uint32_t ms_per_packet,
+-											  switch_rtp_flag_t flags[], char *timer_name, const char **err, switch_memory_pool_t *pool, switch_port_t bundle_internal_ports, switch_port_t bundle_external_port);
++											  switch_rtp_flag_t flags[SWITCH_RTP_FLAG_INVALID], char *timer_name, const char **err, switch_memory_pool_t *pool, switch_port_t bundle_internal_ports, switch_port_t bundle_external_port);
+ 
+ 
+ /*!

--- a/net/freeswitch/patches/050-c++.patch
+++ b/net/freeswitch/patches/050-c++.patch
@@ -1,0 +1,35 @@
+From 8cf93d9c15b7138c69ffbaba2681b32bc18cf5b2 Mon Sep 17 00:00:00 2001
+From: Sebastian Kemper <sebastian_ml@gmx.net>
+Date: Sun, 1 Aug 2021 11:32:50 +0200
+Subject: [PATCH] [mod_gsmopen]: Address gsmlib gcc-11 compat issue
+
+With gcc-11 mod_gsmopen fails to compile:
+
+In file included from /home/sk/tmp/openwrt/staging_dir/target-mips_24kc_musl/usr/include/gsmlib/gsm_sms.h:18,
+                 from gsmopen_protocol.cpp:44:
+/home/sk/tmp/openwrt/staging_dir/target-mips_24kc_musl/usr/include/gsmlib/gsm_error.h:84:58: error: ISO C++17 does not allow dynamic exception specifications
+   84 |   extern std::string getMEErrorText(const int errorCode) throw(GsmException);
+      |                                                          ^~~~~
+/home/sk/tmp/openwrt/staging_dir/target-mips_24kc_musl/usr/include/gsmlib/gsm_error.h:165:59: error: ISO C++17 does not allow dynamic exception specifications
+  165 |   extern std::string getSMSErrorText(const int errorCode) throw(GsmException);
+      |                                                           ^~~~~
+
+gsmlib has seen no upstream activity in years, so as a workaround this
+commit adds "--std=c++11" to mod_gsmopen's CXXFLAGS.
+
+Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
+---
+ src/mod/endpoints/mod_gsmopen/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/mod/endpoints/mod_gsmopen/Makefile.am
++++ b/src/mod/endpoints/mod_gsmopen/Makefile.am
+@@ -3,7 +3,7 @@ MODNAME=mod_gsmopen
+ 
+ mod_LTLIBRARIES = mod_gsmopen.la
+ mod_gsmopen_la_SOURCES  = mod_gsmopen.cpp gsmopen_protocol.cpp 
+-mod_gsmopen_la_CXXFLAGS = $(SWITCH_AM_CXXFLAGS)
++mod_gsmopen_la_CXXFLAGS = $(SWITCH_AM_CXXFLAGS) --std=c++11
+ mod_gsmopen_la_CPPFLAGS = $(SPANDSP_CFLAGS) -I.
+ mod_gsmopen_la_LIBADD   = $(switch_builddir)/libfreeswitch.la $(SPANDSP_LIBS)
+ mod_gsmopen_la_LDFLAGS  = -avoid-version -module -no-undefined -lctb-0.16 -lgsmme


### PR DESCRIPTION
GCC 11 is more strict with declarations.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @micmac1 
Compile tested: ath79