### PR TITLE
kamailio: prevent arm -march overrides

### DIFF
--- a/net/kamailio/Makefile
+++ b/net/kamailio/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio
 PKG_VERSION:=5.5.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://www.kamailio.org/pub/kamailio/$(PKG_VERSION)/src
 PKG_SOURCE:=kamailio-$(PKG_VERSION)_src.tar.gz

--- a/net/kamailio/patches/070-dont-override-arm-march.patch
+++ b/net/kamailio/patches/070-dont-override-arm-march.patch
@@ -1,0 +1,29 @@
+--- a/src/Makefile.defs
++++ b/src/Makefile.defs
+@@ -1260,7 +1260,7 @@ ifeq	($(ARCH), arm)
+ ifeq		($(CC_NAME), gcc)
+ 				C_DEFS+=-DCC_GCC_LIKE_ASM
+ 				#common stuff
+-				CFLAGS=-marm -march=armv5t $(CC_OPT) -fsigned-char $(PROFILE)
++				CFLAGS=-marm $(CC_OPT) -fsigned-char $(PROFILE)
+ 			#if gcc 4.5+ or 4.2+
+ ifeq (,$(strip $(filter-out 4.2+ 4.5+ 5.0+ 6.0+ 7.0+ 8.0+ 9.0+,$(CC_SHORTVER))))
+ 					CFLAGS+= -ftree-vectorize -fno-strict-overflow
+@@ -1308,7 +1308,7 @@ ifeq	($(ARCH), arm6)
+ ifeq		($(CC_NAME), gcc)
+ 				C_DEFS+=-DCC_GCC_LIKE_ASM
+ 				#common stuff
+-				CFLAGS=-march=armv6 $(CC_OPT) -fsigned-char \
++				CFLAGS=$(CC_OPT) -fsigned-char \
+ 						$(PROFILE)
+ 			#if gcc 7.0+, 6.0+, 5.0+, 4.5+ or 4.2+
+ ifeq (,$(strip $(filter-out 4.2+ 4.5+ 5.0+ 6.0+ 7.0+ 8.0+ 9.0+,$(CC_SHORTVER))))
+@@ -1355,7 +1355,7 @@ ifeq	($(ARCH), arm7)
+ ifeq		($(CC_NAME), gcc)
+ 				C_DEFS+=-DCC_GCC_LIKE_ASM
+ 				#common stuff, use armv7-a as lowest common architecture
+-				CFLAGS=-march=armv7-a $(CC_OPT) -fsigned-char \
++				CFLAGS=$(CC_OPT) -fsigned-char \
+ 						$(PROFILE)
+ 			#if gcc 7.0+, 6.0+, 5.0+, 4.5+ or 4.2+
+ ifeq (,$(strip $(filter-out 4.2+ 4.5+ 5.0+ 6.0+ 7.0+ 8.0+ 9.0+,$(CC_SHORTVER))))


### PR DESCRIPTION
src/Makefile.defs adds "-march=..." to target flags for ARM targets.
This can clash with the OpenWrt target flags in
CONFIG_TARGET_OPTIMIZATION. If for example the latter is set to
"-mcpu=cortex-a9" the following warning is issued:

cc1: warning: switch '-mcpu=cortex-a9' conflicts with '-march=armv5t' switch

This commit removes these flags. The addition is unwanted when
cross-compiling.

An issue was raised for this recently, see [1].

[1] https://github.com/openwrt/packages/issues/16135

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: CI
Run tested: No

Description:
Hello @ByteEnable

Please try this and provide feedback. Thanks.

Regards,
Seb