### PR TITLE
gsmlib: set C++ standard to 11

### DIFF
--- a/libs/gsmlib/Makefile
+++ b/libs/gsmlib/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gsmlib
 PKG_VERSION:=1.10-20140304
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/vbouchaud/gsmlib.git
@@ -61,6 +61,8 @@ endef
 define Package/gsm-utils/description
 Some simple command line programs to access GSM mobile phones via GSM modems.
 endef
+
+TARGET_CXXFLAGS += -std=c++11
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/$(PKG_NAME)


### PR DESCRIPTION
throw() was removed in C++17, which GCC11 defaults to.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @micmac1 
Compile tested: ath79