### PR TITLE
gsmlib: use += for PKG_BUILD_DEPENDS

### DIFF
--- a/libs/gsmlib/Makefile
+++ b/libs/gsmlib/Makefile
@@ -21,7 +21,7 @@ PKG_MIRROR_HASH:=bc24d7ddcb5f4b5f9160351d9f38cf6f35f3feef969f675f883b32d04c8c80f
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 # Need Makefile.in.in from gettext-full/host and po.m4 from gettext-full
-PKG_BUILD_DEPENDS:=gettext-full/host gettext-full
+PKG_BUILD_DEPENDS += gettext-full/host gettext-full
 
 PKG_FIXUP:=autoreconf
 
@@ -32,6 +32,7 @@ PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/$(PKG_NAME)/Default
   SUBMENU:=Telephony


### PR DESCRIPTION
It might be getting set elsewhere.

Signed-off-by: Rosen Penev <rosenp@gmail.com>