### PR TITLE
freeswitch: set stop level

### DIFF
--- a/net/freeswitch/Makefile
+++ b/net/freeswitch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeswitch
 PKG_VERSION:=1.10.6
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=freeswitch-$(PKG_VERSION).-release.tar.xz

--- a/net/freeswitch/files/freeswitch.init
+++ b/net/freeswitch/files/freeswitch.init
@@ -2,6 +2,7 @@
 # Copyright (C) 2017 - 2018 OpenWrt.org
 
 START=90
+STOP=10
 
 USE_PROCD=1
 


### PR DESCRIPTION
This sets STOP to 10 to allow for a
graceful shutdown. Users may additionally need to set "term_timeout" in
/etc/config/freeswitch to a sensible value.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: N/A
Run tested: 21.02 ath79

Description:
Update init script a bit after seeing some commits from stintel in "packages" repo. Makes sense to give FS a chance to clean up during shutdown.