### PR TITLE
asterisk: update AST_EXT_TOOL_CHECK for OpenWrt

### DIFF
--- a/net/asterisk/patches/160-AST_EXT_TOOL_CHECK.patch
+++ b/net/asterisk/patches/160-AST_EXT_TOOL_CHECK.patch
@@ -1,0 +1,22 @@
+--- a/autoconf/ast_ext_tool_check.m4
++++ b/autoconf/ast_ext_tool_check.m4
+@@ -8,13 +8,16 @@ AC_DEFUN([AST_EXT_TOOL_CHECK],
+ 	AC_REQUIRE([AST_PROG_SED])dnl
+ 	if test "x${PBX_$1}" != "x1" -a "${USE_$1}" != "no"; then
+ 		PBX_$1=0
+-		AC_PATH_TOOL(CONFIG_$1, $2, No, [${$1_DIR}/bin:$PATH])
++		if test "x${$1_DIR}" != "x"; then
++			AC_PATH_TOOL(CONFIG_$1, $2, No, [${$1_DIR}/bin:$PATH])
++		else
++			AC_PATH_TOOL(CONFIG_$1, $2, No, [$PATH])
++		fi
+ 		if test ! "x${CONFIG_$1}" = xNo; then
+ 			$1_INCLUDE=$(${CONFIG_$1} m4_default([$3],[--cflags]))
+-			$1_INCLUDE=$(echo ${$1_INCLUDE} | $SED -e "s|-I|-I${$1_DIR}|g" -e "s|-std=c99||g")
++			$1_INCLUDE=$(echo ${$1_INCLUDE} | $SED -e "s|-std=c99||g")
+ 
+ 			$1_LIB=$(${CONFIG_$1} m4_default([$4],[--libs]))
+-			$1_LIB=$(echo ${$1_LIB} | $SED -e "s|-L|-L${$1_DIR}|g")
+ 
+ 			m4_ifval([$5], [
+ 				saved_cppflags="${CPPFLAGS}"


### PR DESCRIPTION
Issue #672 shows that the current macro has some pitfalls, at least when
running within OpenWrt's buildroot.

The macro is used to detect these tools:

  1. xml2-config
  2. mysql_config
  3. neon-config
  4. net-snmp-config
  5. sdl-config (we're not using SDL)

The macro also adds configure arguments that allow to specify a path
like so:

  --with-mysqlclient=PATH

Macro problems:

  1. If no PATH is specified, it adds "/bin" to the search path.
     Obviously this is a bad thing when cross-compiling.
  2. If a PATH is specified, it adds it to the start of every include
     and library path it encounters. These paths are then broken.

This commit makes problem 1 go away by making the addition of
"${$1_DIR}/bin" to the PATH dependent on there being a PATH handed to
the macro. An alternative would be to remove the PATH addition
altogether, but then the macro wouldn't behave as expected.

It also removes the path filtering of the include and lib dirs to
address problem 2.

Closes #672

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: 21.03 SDK
Run tested: Not tested, this is a build fix

Description:
Hi Jiri,

Hope you have good summer days!

Small macro amendment included. If you don't like the way I did it let me know, of course :)

No runtime change, so I didn't revbump.

Kind regards,
Seb