### PR TITLE
freeswitch: remove "+=" operator for portability

### DIFF
--- a/net/freeswitch/patches/230-mod_radius_cdr.patch
+++ b/net/freeswitch/patches/230-mod_radius_cdr.patch
@@ -5,7 +5,7 @@
  $(RADCLIENT_BUILDDIR)/Makefile: $(RADCLIENT_DIR)
  	mkdir -p $(RADCLIENT_BUILDDIR)
 -	cd $(RADCLIENT_BUILDDIR) && $(DEFAULT_VARS) $(RADCLIENT_DIR)/configure $(DEFAULT_ARGS) --srcdir=$(RADCLIENT_DIR)
-+	cd $(RADCLIENT_BUILDDIR) && patch -p1 < ../../src/mod/event_handlers/mod_radius_cdr/freeradius-client-1.1.6-configure-in.diff && autoreconf -v -f -i -s && $(DEFAULT_VARS) CFLAGS+="-Wno-cpp" $(RADCLIENT_DIR)/configure $(DEFAULT_ARGS) --srcdir=$(RADCLIENT_DIR)
++	cd $(RADCLIENT_BUILDDIR) && patch -p1 < ../../src/mod/event_handlers/mod_radius_cdr/freeradius-client-1.1.6-configure-in.diff && autoreconf -v -f -i -s && $(DEFAULT_VARS) CFLAGS="${CFLAGS} -Wno-cpp" $(RADCLIENT_DIR)/configure $(DEFAULT_ARGS) --srcdir=$(RADCLIENT_DIR)
  	$(TOUCH_TARGET)
  
  $(RADCLIENT_LA): $(RADCLIENT_BUILDDIR)/Makefile


### PR DESCRIPTION
POSIX shells don't support "+=" operators. This commit replaces it with
something portable.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: ath79 master
Run tested: no, build fix

Description:
Hi @neheb,

This fixes it, right? Any more of these issues or is this it?

Kind regards,
Seb