### PR TITLE
asterisk-chan-quectel:Add asterisk support for Quectel EC25 modem

### DIFF
--- a/net/asterisk-chan-quectel/Makefile
+++ b/net/asterisk-chan-quectel/Makefile
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2017 - 2018 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=asterisk-chan-quectel
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/t4rd15/asterisk-chan-quectel.git
+PKG_SOURCE_VERSION:=ad17cff6d9a1f690c8102e3965e4399c98aea894
+PKG_SOURCE_DATE=2020-05-28
+PKG_RELEASE:=1
+PKG_MIRROR_HASH:=skip
+
+PKG_FIXUP:=autoreconf
+
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYRIGHT.txt LICENSE.txt
+PKG_MAINTAINER:=spacedream <spacedream@tutamail.com>
+
+MODULES_DIR:=/usr/lib/asterisk/modules
+
+include $(INCLUDE_DIR)/package.mk
+# asterisk-chan-quectel needs iconv
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/asterisk-chan-quectel
+  SUBMENU:=Telephony
+  SECTION:=net
+  CATEGORY:=Network
+  URL:=https://github.com/t4rd15/asterisk-chan-quectel
+  DEPENDS:=asterisk $(ICONV_DEPENDS) +libsqlite3
+  TITLE:=Quectel EC25 modem support
+endef
+
+define Package/asterisk-chan-quectel/description
+ Asterisk channel driver for Quectel EC25 modem.
+endef
+
+CONFIGURE_ARGS+= \
+	--with-asterisk=$(STAGING_DIR)/usr/include \
+	--with-astversion=18 \
+	--with-iconv=$(ICONV_PREFIX)/include
+
+MAKE_FLAGS+=LD="$(TARGET_CC)"
+
+CONFIGURE_VARS += \
+	DESTDIR="$(MODULES_DIR)" \
+	ac_cv_type_size_t=yes \
+	ac_cv_type_ssize_t=yes
+
+define Package/asterisk-chan-quectel/conffiles
+/etc/asterisk/quectel.conf
+endef
+
+define Package/asterisk-chan-quectel/install
+	$(INSTALL_DIR) $(1)/etc/asterisk
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/etc/quectel.conf $(1)/etc/asterisk
+	$(INSTALL_DIR) $(1)$(MODULES_DIR)
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/chan_quectel.so $(1)$(MODULES_DIR)
+endef
+
+$(eval $(call BuildPackage,asterisk-chan-quectel))

--- a/net/asterisk-chan-quectel/patches/200-fix-iconv-detection.patch
+++ b/net/asterisk-chan-quectel/patches/200-fix-iconv-detection.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -83,7 +83,7 @@ fi
+ 
+ dnl Checks for libraries.
+ dnl AC_CHECK_LIB([pthread], [pthread_create])  # should use ast_pthread_join everywhere?
+-AC_SEARCH_LIBS([iconv], [c iconv],,AC_MSG_ERROR([iconv library missing]))
++AC_SEARCH_LIBS([libiconv], [iconv],,AC_MSG_ERROR([iconv library missing]))
+ AC_CHECK_LIB([sqlite3], [sqlite3_open],,AC_MSG_ERROR([sqlite3 library missing]))
+ 
+ dnl Checks for header files.

--- a/net/asterisk-chan-quectel/patches/300-use-openwrt-flags.patch
+++ b/net/asterisk-chan-quectel/patches/300-use-openwrt-flags.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -224,8 +224,6 @@ dnl Apply options to defines
+ if test "x$enable_debug" = "xyes" ; then
+   CFLAGS="$CFLAGS -O0 -g"
+   AC_DEFINE([__DEBUG__], [1], [Build with debugging])
+-else
+-  CFLAGS="$CFLAGS -O6"
+ fi
+ 
+ dnl Asterisk header files use lots of old style declarations, ignore those.


### PR DESCRIPTION
Quectel EC25 modem support for asterisk.

Signed-off-by: Matej Peric <peric.matej1@gmail.com>