### PR TITLE
yate: disable parallel builds

### DIFF
--- a/net/yate/Makefile
+++ b/net/yate/Makefile
@@ -21,7 +21,8 @@ PKG_LICENSE_FILES:=COPYING
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
 PKG_FIXUP:=autoreconf
-PKG_BUILD_PARALLEL:=1
+# Sporadic build failures on the build bots
+PKG_BUILD_PARALLEL:=0
 PKG_INSTALL:=1
 
 # Yate currently does not compile with FORTIFY_SOURCE enabled


### PR DESCRIPTION
Sporadic build failures are visible on the build bots.

```
libyate.so: undefined reference to `TelEngine::ClientLogic::initStaticData()'
libyate.so: undefined reference to `TelEngine::DefaultLogic::DefaultLogic(char const*, int)'
collect2: error: ld returned 1 exit status
```

Turning off parallel builds should (hopefully) work around this.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: N/A
Run tested: N/A

Description:
This should hopefully take care of issue #688 