### PR TITLE
asterisk: add opus read and write support

### DIFF
--- a/net/asterisk-opus/Makefile
+++ b/net/asterisk-opus/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk-opus
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE_URL:=https://github.com/traud/asterisk-opus.git
-PKG_SOURCE_DATE:=2017-10-09
-PKG_SOURCE_VERSION:=83e1b458c77e0e287adeca494eeb79edb077b0ff
-PKG_MIRROR_HASH:=c71b859db7518cdafff1650e629c5901b290fe68f8af54ef1afd57bc9f15b122
+PKG_SOURCE_DATE:=2021-11-01
+PKG_SOURCE_VERSION:=20522fbcd3fdf6f0adb20602d096d14cd69055e8
+PKG_MIRROR_HASH:=e14dc42b0e5f4720e3f028e0b426f4e660bf315a103a015820ca3697e1fe9985
 PKG_SOURCE_PROTO:=git
 
 PKG_LICENSE:=GPL-2.0
@@ -23,7 +23,6 @@ PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 include $(INCLUDE_DIR)/package.mk
 
 TARGET_CFLAGS += \
-	-DAST_MODULE_SELF_SYM=__internal_codec_opus_open_source_self \
 	$(FPIC)
 
 define Package/asterisk-codec-opus

--- a/net/asterisk-opus/Makefile
+++ b/net/asterisk-opus/Makefile
@@ -25,13 +25,17 @@ include $(INCLUDE_DIR)/package.mk
 TARGET_CFLAGS += \
 	$(FPIC)
 
-define Package/asterisk-codec-opus
+define Package/asterisk-opus/Default
   SUBMENU:=Telephony
   SECTION:=net
   CATEGORY:=Network
-  TITLE:=Opus codec support
   URL:=https://github.com/traud/asterisk-opus
   DEPENDS:=asterisk +libopus
+endef
+
+define Package/asterisk-codec-opus
+$(call Package/asterisk-opus/Default)
+  TITLE:=Opus codec support
 endef
 
 define Package/asterisk-codec-opus/description
@@ -54,7 +58,24 @@ define Package/asterisk-codec-opus/install
 		$(1)/usr/lib/asterisk/modules
 endef
 
+define Package/asterisk-format-ogg-opus
+$(call Package/asterisk-opus/Default)
+  TITLE:=OGG/Opus audio support
+  DEPENDS+=+libopusfile +libopusenc
+endef
+
+define Package/asterisk-format-ogg-opus/description
+  Reading and writing audio files in the OGG/Opus format.
+endef
+
+define Package/asterisk-format-ogg-opus/install
+	$(INSTALL_DIR) $(1)/usr/lib/asterisk/modules
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/formats/format_ogg_opus_open_source.so \
+		$(1)/usr/lib/asterisk/modules
+endef
+
 define Build/Configure
 endef
 
 $(eval $(call BuildPackage,asterisk-codec-opus))
+$(eval $(call BuildPackage,asterisk-format-ogg-opus))

--- a/net/asterisk-opus/patches/01-Makefile.patch
+++ b/net/asterisk-opus/patches/01-Makefile.patch
@@ -1,18 +1,21 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -3,17 +3,17 @@ exec_prefix=$(prefix)
- libdir=$(exec_prefix)/lib
+@@ -5,18 +5,18 @@ libdir=$(exec_prefix)/lib
+ # build with `make OPUSENC=0` to disable rewrite support using libopusenc
+ OPUSENC?=1
  
- CC=gcc
--CFLAGS=-pthread -g3 -O3 -D_FORTIFY_SOURCE=2 -fPIC
-+CFLAGS+=-pthread
+-CFLAGS=-pthread -D_FORTIFY_SOURCE=2 -fPIC
+-DEBUG=-g3
+-OPTIMIZE=-O3
++CFLAGS+=-Wall -pthread
++DEBUG=
++OPTIMIZE=
  CPPFLAGS=
  DEFS=
  INSTALL=/usr/bin/install -c
--LDFLAGS=-shared -pthread -Wl,--warn-common
-+LDFLAGS+=-shared -pthread -Wl,--warn-common
+-LDFLAGS=-pthread -Wl,--warn-common
++LDFLAGS+=-pthread -Wl,--warn-common
  LIBS=
- MKDIR_P=/bin/mkdir -p
  SHELL=/bin/sh
  
  ASTMODDIR=$(libdir)/asterisk/modules

--- a/net/asterisk-opus/patches/01-Makefile.patch
+++ b/net/asterisk-opus/patches/01-Makefile.patch
@@ -20,7 +20,16 @@
  
  ASTMODDIR=$(libdir)/asterisk/modules
 -MODULES=codec_opus_open_source format_ogg_opus_open_source format_vp8 res_format_attr_opus
-+MODULES=codec_opus_open_source
++MODULES=codec_opus_open_source format_ogg_opus_open_source
  
  .SUFFIXES: .c .so
  
+@@ -38,7 +38,7 @@ codec_opus_open_source: DEFS+=-DAST_MODU
+ 	-DAST_MODULE_SELF_SYM=__internal_codec_opus_open_source_self
+ codec_opus_open_source: codecs/codec_opus_open_source.so
+ 
+-format_ogg_opus_open_source: CPATH+=-I/usr/include/opus
++format_ogg_opus_open_source: CPATH+=-I$(STAGING_DIR)/usr/include/opus
+ format_ogg_opus_open_source: LIBS+=-lopus -lopusfile
+ format_ogg_opus_open_source: DEFS+=-DAST_MODULE=\"format_ogg_opus_open_source\" \
+ 	-DAST_MODULE_SELF_SYM=__internal_format_ogg_opus_open_source_self


### PR DESCRIPTION
I've been using this for ~5 months now, works for me (tm).
In my case I store voicemail recording as .opus files and send those out via email.

There's currently no support to set the encoder properties using codecs.conf as I don't have a use case for it.
Noteworthy is that the encoding complexity is set to 4 (from the default of the max 10) on soft float devices, as they can't keep up encoding in realtime.

4 works for me on lantiq/xrx200, so a rather old and slow device.