### PR TITLE
freeswitch: don't start with explicit group

### DIFF
--- a/net/freeswitch/Makefile
+++ b/net/freeswitch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeswitch
 PKG_VERSION:=1.10.6
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=freeswitch-$(PKG_VERSION).-release.tar.xz

--- a/net/freeswitch/files/freeswitch.init
+++ b/net/freeswitch/files/freeswitch.init
@@ -83,7 +83,6 @@ start_service() {
     -cache "$dir_cache" \
     -conf "$dir_etc" \
     -db "$dir_db" \
-    -g "$NAME" \
     -log "$dir_log" \
     -recordings "$dir_recordings" \
     -run "$dir_run" \


### PR DESCRIPTION
Currently the freeswitch init script starts the service with the group
"freeswitch". Like this, even if the freeswitch user is part of other
groups, freeswitch will not be able to make use of them. So for instance
if you add the user to the group "dialout", freeswitch will run under
group "freeswitch", instead of "freeswitch" _and_ "dialout".

Not specifying the group gets rid of this limitation.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: N/A (init script change)
Run tested: 21.02 on ath79

Description:
Fixup the issue where the freeswitch user is added to different groups and the freeswitch software isn't able to make use of it.