### PR TITLE
rtpengine: update to 9.5.2.1

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=rtpengine
-PKG_VERSION:=9.5.1.3
+PKG_VERSION:=9.5.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-mr$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sipwise/rtpengine/tar.gz/mr$(PKG_VERSION)?
-PKG_HASH:=c9b07f120703429351abc120da71e4e72d4d9b8d72ec689a3cd61ab3030545c6
+PKG_HASH:=c7f08783e6d085b0fb1e2499a87a1e82f70aeb57f00f74ba56c5b2a2452c8fba
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-mr$(PKG_VERSION)
 


### PR DESCRIPTION
Fixes compilation with glib 2.70.

Added new dependency.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Maintainer: @micmac1 
Compile tested: ath79