### PR TITLE
[19.07] asterisk-chan-sccp: fix mwi header issue

### DIFF
--- a/net/asterisk-chan-sccp/Makefile
+++ b/net/asterisk-chan-sccp/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=chan-sccp
 PKG_VERSION:=v4.3.2-20190411
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/chan-sccp/chan-sccp.git

--- a/net/asterisk-chan-sccp/patches/01-prevent-extra-optimization.patch
+++ b/net/asterisk-chan-sccp/patches/01-prevent-extra-optimization.patch
@@ -1,6 +1,6 @@
 --- a/autoconf/extra.m4
 +++ b/autoconf/extra.m4
-@@ -491,17 +491,6 @@ AC_DEFUN([CS_ENABLE_OPTIMIZATION], [
+@@ -493,17 +493,6 @@ AC_DEFUN([CS_ENABLE_OPTIMIZATION], [
  			], SUPPORTED_CFLAGS)
  		])
  		AC_SUBST([strip_binaries])
@@ -16,5 +16,5 @@
 -		esac
 -		CFLAGS_saved="${CFLAGS_saved} ${optimize_flag} "
  	])
- 
+ 	
  	AS_IF([test "X${enable_debug}" == "Xyes"], [

--- a/net/asterisk-chan-sccp/patches/100-reproducible-builds.patch
+++ b/net/asterisk-chan-sccp/patches/100-reproducible-builds.patch
@@ -1,7 +1,5 @@
-Index: chan-sccp-v4.3.0-20171123/src/chan_sccp.c
-===================================================================
---- chan-sccp-v4.3.0-20171123.orig/src/chan_sccp.c
-+++ chan-sccp-v4.3.0-20171123/src/chan_sccp.c
+--- a/src/chan_sccp.c
++++ b/src/chan_sccp.c
 @@ -186,7 +186,7 @@ boolean_t sccp_postPBX_load(void)
  #else
  	snprintf(SCCP_REVISIONSTR, sizeof(SCCP_REVISIONSTR), "%s", SCCP_REVISION);

--- a/net/asterisk-chan-sccp/patches/110-fix-compile-with-gcc8.patch
+++ b/net/asterisk-chan-sccp/patches/110-fix-compile-with-gcc8.patch
@@ -24,8 +24,6 @@ Date:   Mon May 6 21:07:48 2019 +0200
     
     Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
 
-diff --git a/src/sccp_utils.c b/src/sccp_utils.c
-index df043d1a..f917c0c9 100644
 --- a/src/sccp_utils.c
 +++ b/src/sccp_utils.c
 @@ -10,6 +10,7 @@

--- a/net/asterisk-chan-sccp/patches/120-Add-support-for-new-asterisk-mwi.h-header-file.patch
+++ b/net/asterisk-chan-sccp/patches/120-Add-support-for-new-asterisk-mwi.h-header-file.patch
@@ -1,0 +1,77 @@
+From 9684efb7709c1be23c99f555f61b5a3ad15b0675 Mon Sep 17 00:00:00 2001
+From: Diederik de Groot <dkgroot@talon.nl>
+Date: Thu, 16 May 2019 17:48:55 +0200
+Subject: [PATCH] Add support for new asterisk mwi.h header file
+
+---
+ autoconf/asterisk.m4 |  6 ++++++
+ configure            | 13 +++++++++++++
+ src/config.h.in      |  3 +++
+ src/sccp_mwi.c       |  4 ++++
+ 4 files changed, 26 insertions(+)
+
+--- a/autoconf/asterisk.m4
++++ b/autoconf/asterisk.m4
+@@ -1112,6 +1112,12 @@ dnl 	CFLAGS="${CFLAGS_saved} -Werror=imp
+ 		],,[ 
+ 			$HEADER_INCLUDE
+ 		])
++		AC_CHECK_HEADER([asterisk/mwi.h],
++		[
++			AC_DEFINE([HAVE_PBX_MWI_H],1,[Found 'asterisk/mwi.h'])
++		],,[ 
++			$HEADER_INCLUDE
++		])
+ 		AC_CHECK_HEADER([asterisk/utils.h],
+ 		[
+ 			AC_DEFINE([HAVE_PBX_UTILS_H],1,[Found 'asterisk/utils.h'])
+--- a/configure
++++ b/configure
+@@ -28793,6 +28793,19 @@ $as_echo "#define HAVE_PBX_MESSAGE_H 1"
+ fi
+ 
+ 
++		ac_fn_c_check_header_compile "$LINENO" "asterisk/mwi.h" "ac_cv_header_asterisk_mwi_h" "
++			$HEADER_INCLUDE
++
++"
++if test "x$ac_cv_header_asterisk_mwi_h" = xyes; then :
++
++
++$as_echo "#define HAVE_PBX_MWI_H 1" >>confdefs.h
++
++
++fi
++
++
+ 		ac_fn_c_check_header_compile "$LINENO" "asterisk/utils.h" "ac_cv_header_asterisk_utils_h" "
+ 			$HEADER_INCLUDE
+ 
+--- a/src/config.h.in
++++ b/src/config.h.in
+@@ -571,6 +571,9 @@
+ /* Found 'asterisk/message.h' */
+ #undef HAVE_PBX_MESSAGE_H
+ 
++/* Found 'asterisk/mwi.h' */
++#undef HAVE_PBX_MWI_H
++
+ /* Found 'asterisk/pbx.h' */
+ #undef HAVE_PBX_PBX_H
+ 
+--- a/src/sccp_mwi.c
++++ b/src/sccp_mwi.c
+@@ -25,9 +25,13 @@ SCCP_FILE_VERSION(__FILE__, "");
+ #elif HAVE_PBX_STASIS_H
+ #include <asterisk/stasis.h>
+ #endif
++#ifdef HAVE_PBX_MWI_H				// ast_mwi_state_type
++#include <asterisk/mwi.h>
++#else
+ #ifdef HAVE_PBX_APP_H				// ast_mwi_state_type
+ #include <asterisk/app.h>
+ #endif
++#endif
+ #include <asterisk/cli.h>
+ 
+ pbx_mutex_t subscriptions_lock;


### PR DESCRIPTION
Asterisk, somewhere between release 16.3.0 and 16.22.0, added a new
header "mwi.h". This causes compile failure, because the chan-sccp
snapshot is not aware.

This adds a patch from upstream to resolve.

All patches refreshed.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @jslachta 
Compile tested: 19.07 sdk ath79
Run tested: No, build fix

Description: build fix
