### PR TITLE
[21.02] restund: fix CVE-2021-21382

### DIFF
--- a/net/restund/Makefile
+++ b/net/restund/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=restund
 PKG_VERSION:=0.4.12
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.creytiv.com/pub

--- a/net/restund/patches/200-turn-block-forwarding-to-loopback-any.patch
+++ b/net/restund/patches/200-turn-block-forwarding-to-loopback-any.patch
@@ -1,0 +1,69 @@
+From ffa2d56cac3d37715fe1381df81802774240da92 Mon Sep 17 00:00:00 2001
+From: Dusan Stevanovic <dule@wire.com>
+Date: Thu, 11 Mar 2021 10:58:32 +0100
+Subject: [PATCH] turn: block forwarding to loopback/any
+
+---
+ modules/turn/turn.c | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
+
+--- a/modules/turn/turn.c
++++ b/modules/turn/turn.c
+@@ -153,6 +153,7 @@ static bool indication_handler(struct re
+ 	struct stun_attr *data, *peer;
+ 	struct allocation *al;
+ 	struct perm *perm;
++	const struct sa *psa;
+ 	int err;
+ 	(void)sock;
+ 	(void)ctx;
+@@ -173,13 +174,17 @@ static bool indication_handler(struct re
+ 	if (!peer || !data)
+ 		return true;
+ 
+-	perm = perm_find(al->perms, &peer->v.xor_peer_addr);
++	psa = &peer->v.xor_peer_addr;
++	perm = perm_find(al->perms, psa);
+ 	if (!perm) {
+ 		++al->dropc_tx;
+ 		return true;
+ 	}
+ 
+-	err = udp_send(al->rel_us, &peer->v.xor_peer_addr, &data->v.data);
++	if (sa_is_loopback(psa) || sa_is_any(psa))
++		err = EPERM;
++	else
++		err = udp_send(al->rel_us, psa, &data->v.data);
+ 	if (err)
+ 		turnd.errc_tx++;
+ 	else {
+@@ -200,6 +205,7 @@ static bool raw_handler(int proto, const
+ 	uint16_t numb, len;
+ 	struct perm *perm;
+ 	struct chan *chan;
++	const struct sa *psa;
+ 	int err;
+ 
+ 	al = allocation_find(proto, src, dst);
+@@ -219,7 +225,8 @@ static bool raw_handler(int proto, const
+ 	if (!chan)
+ 		return false;
+ 
+-	perm = perm_find(al->perms, chan_peer(chan));
++	psa = chan_peer(chan);
++	perm = perm_find(al->perms, psa);
+ 	if (!perm) {
+ 		++al->dropc_tx;
+ 		return false;
+@@ -227,7 +234,10 @@ static bool raw_handler(int proto, const
+ 
+ 	mb->end = mb->pos + len;
+ 
+-	err = udp_send(al->rel_us, chan_peer(chan), mb);
++	if (sa_is_loopback(psa) || sa_is_any(psa))
++		err = EPERM;
++	else
++		err = udp_send(al->rel_us, psa, mb);
+ 	if (err)
+ 		turnd.errc_tx++;
+ 	else {

--- a/net/restund/patches/201-turn-also-don-t-forward-linklocal-addresses.patch
+++ b/net/restund/patches/201-turn-also-don-t-forward-linklocal-addresses.patch
@@ -1,0 +1,29 @@
+From e2f4094e23c73d4563a55f0de72244f34bb5b702 Mon Sep 17 00:00:00 2001
+From: Dusan Stevanovic <dule@wire.com>
+Date: Thu, 11 Mar 2021 11:53:50 +0100
+Subject: [PATCH] turn: also don't forward linklocal addresses
+
+---
+ modules/turn/turn.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/modules/turn/turn.c
++++ b/modules/turn/turn.c
+@@ -181,7 +181,7 @@ static bool indication_handler(struct re
+ 		return true;
+ 	}
+ 
+-	if (sa_is_loopback(psa) || sa_is_any(psa))
++	if (sa_is_loopback(psa) || sa_is_any(psa) || sa_is_linklocal(psa))
+ 		err = EPERM;
+ 	else
+ 		err = udp_send(al->rel_us, psa, &data->v.data);
+@@ -234,7 +234,7 @@ static bool raw_handler(int proto, const
+ 
+ 	mb->end = mb->pos + len;
+ 
+-	if (sa_is_loopback(psa) || sa_is_any(psa))
++	if (sa_is_loopback(psa) || sa_is_any(psa) || sa_is_linklocal(psa))
+ 		err = EPERM;
+ 	else
+ 		err = udp_send(al->rel_us, psa, mb);

--- a/net/restund/patches/202-turn-block-whole-loopback-range-also-block-broadcast.patch
+++ b/net/restund/patches/202-turn-block-whole-loopback-range-also-block-broadcast.patch
@@ -1,0 +1,52 @@
+From 955064fc220b5739010a2e207a8561ea44f974d3 Mon Sep 17 00:00:00 2001
+From: Dusan Stevanovic <dule@wire.com>
+Date: Thu, 11 Mar 2021 13:15:27 +0100
+Subject: [PATCH] turn: block whole loopback range, also block broadcast
+
+---
+ modules/turn/turn.c | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+--- a/modules/turn/turn.c
++++ b/modules/turn/turn.c
+@@ -144,6 +144,22 @@ static bool request_handler(struct restu
+ 	return true;
+ }
+ 
++static inline bool is_loopback(const struct sa *sa)
++{
++	return (ntohl(sa->u.in.sin_addr.s_addr) & 0xffffff00) == 0x7f000000;
++}
++
++static inline bool is_broadcast(const struct sa *sa)
++{
++	return ntohl(sa->u.in.sin_addr.s_addr) == 0xffffffff;
++}
++
++static inline bool is_blocked(const struct sa *sa)
++{
++	return is_loopback(sa) || is_broadcast(sa)
++		|| sa_is_any(sa) || sa_is_linklocal(sa);
++	
++}
+ 
+ static bool indication_handler(struct restund_msgctx *ctx, int proto,
+ 			       void *sock, const struct sa *src,
+@@ -181,7 +197,7 @@ static bool indication_handler(struct re
+ 		return true;
+ 	}
+ 
+-	if (sa_is_loopback(psa) || sa_is_any(psa) || sa_is_linklocal(psa))
++	if (is_blocked(psa))
+ 		err = EPERM;
+ 	else
+ 		err = udp_send(al->rel_us, psa, &data->v.data);
+@@ -234,7 +250,7 @@ static bool raw_handler(int proto, const
+ 
+ 	mb->end = mb->pos + len;
+ 
+-	if (sa_is_loopback(psa) || sa_is_any(psa) || sa_is_linklocal(psa))
++	if (is_blocked(psa))
+ 		err = EPERM;
+ 	else
+ 		err = udp_send(al->rel_us, psa, mb);


### PR DESCRIPTION
Patches taken from [1].

[1] https://github.com/wireapp/restund/pull/7

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: 21.02
Run tested: 21.02

Description: Without the patches I was able to follow [this tutorial](https://gist.github.com/cameronelliott/be1e581cb7b28f748e04bcabc249e6b6) and test restund on localhost. With the patches applied the negotiation is still fine, but no Turn packets are sent for bindings to localhost by restund anymore. So the patches seem to work as far as I can tell.
