### PR TITLE
baresip: bump to 1.1.0 (re to 2.0.1 and rem to 1.0.0)

### DIFF
--- a/libs/re/Makefile
+++ b/libs/re/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=re
-PKG_VERSION:=1.0.0
-PKG_RELEASE:=1
+PKG_VERSION:=2.0.1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/baresip/re/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=bf0abfc511b7278462e7d54aaae39e7231b9f35423d5026c8210a322c7c8ef2f
+PKG_HASH:=43aa439b96aff75fe5768b9f9d49dea97042e42e7647df47b345465763e2f7ed
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=docs/COPYING
@@ -32,6 +32,7 @@ define Package/libre
   DEPENDS:=+libopenssl +zlib
   TITLE:=Generic library for real-time communications with async IO support
   URL:=https://github.com/baresip/re
+  ABI_VERSION:=1
 endef
 
 # re.mk is used for this and all related packages (rem, restund and baresip).
@@ -68,12 +69,12 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/re $(1)/usr/include
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libre.{a,so} $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libre.{a,so*} $(1)/usr/lib
 endef
 
 define Package/libre/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libre.so $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libre.so.$(ABI_VERSION)* $(1)/usr/lib
 endef
 
 $(eval $(call BuildPackage,libre))

--- a/libs/re/patches/001-extend-ninit-nclose-check.patch
+++ b/libs/re/patches/001-extend-ninit-nclose-check.patch
@@ -1,6 +1,6 @@
 --- a/src/dns/res.c
 +++ b/src/dns/res.c
-@@ -25,7 +25,7 @@ int get_resolv_dns(char *domain, size_t
+@@ -26,7 +26,7 @@ int get_resolv_dns(char *domain, size_t
  	uint32_t i;
  	int ret, err;
  
@@ -9,7 +9,7 @@
  	ret = res_init();
  	state = _res;
  #else
-@@ -56,7 +56,7 @@ int get_resolv_dns(char *domain, size_t
+@@ -76,7 +76,7 @@ int get_resolv_dns(char *domain, size_t
  	*n = i;
  
   out:

--- a/libs/re/patches/004-prevent-optimization-meddling.patch
+++ b/libs/re/patches/004-prevent-optimization-meddling.patch
@@ -1,10 +1,10 @@
 --- a/mk/re.mk
 +++ b/mk/re.mk
-@@ -43,7 +43,6 @@
+@@ -47,7 +47,6 @@
  
  ifneq ($(RELEASE),)
  CFLAGS  += -DRELEASE
 -OPT_SPEED=1
  endif
  
- 
+ ifneq ($(TRACE_ERR),)

--- a/libs/re/patches/005-fix-builds-for-mipsel-targets.patch
+++ b/libs/re/patches/005-fix-builds-for-mipsel-targets.patch
@@ -1,6 +1,6 @@
 --- a/mk/re.mk
 +++ b/mk/re.mk
-@@ -439,11 +439,6 @@ endif
+@@ -412,11 +412,6 @@ endif
  
  CFLAGS	+= -DARCH=\"$(ARCH)\"
  

--- a/libs/rem/Makefile
+++ b/libs/rem/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rem
-PKG_VERSION:=0.6.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.0
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.creytiv.com/pub
-PKG_HASH:=417620da3986461598aef327c782db87ec3dd02c534701e68f4c255e54e5272c
+PKG_SOURCE_URL:=https://codeload.github.com/baresip/rem/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=bcc91bb521fae183357fb422b00a3981477a22e99d3afe165c4ec50a6bbed9da
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=docs/COPYING
@@ -31,7 +31,7 @@ define Package/librem
   CATEGORY:=Libraries
   DEPENDS:=+libre
   TITLE:=Audio and video processing media library
-  URL:=http://www.creytiv.com
+  URL:=https://github.com/baresip/rem
 endef
 
 MAKE_FLAGS+= \

--- a/net/baresip/Makefile
+++ b/net/baresip/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=baresip
-PKG_VERSION:=1.0.0
-PKG_RELEASE:=1
+PKG_VERSION:=1.1.0
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/baresip/baresip/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=7b008c0a5b4fccfa0a4003f86dc4aaafeaabbdd259ece4757898e9cb5f04fdcf
+PKG_HASH:=f9230b27c4a62f31223847bc485c51f3d960f8a09f36998dedb73358e1784b4e
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=docs/COPYING
@@ -24,23 +24,35 @@ PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
 baresip-mods:= \
+	aac \
 	alsa \
+	amr \
 	avcodec \
+	avfilter \
 	avformat \
 	cons \
+	ctrl-dbus \
 	evdev \
 	g711 \
 	g722 \
 	g726 \
+	gst \
+	gst-video \
+	httpreq \
+	l16 \
+	mqtt \
 	opus \
+	opus_multistream \
 	oss \
 	plc \
 	portaudio \
 	pulse \
-	rtcpsummary \
+	snapshot \
 	sndfile \
+	speex-pp \
 	srtp \
 	stdio \
+	syslog \
 	v4l2 \
 	vp8 \
 	vp9
@@ -70,30 +82,42 @@ $(call Package/baresip/Default)
 	  /etc/baresip/contacts:baresip:baresip:0640
 endef
 
+baresip-mod-aac         := USE_AAC
 baresip-mod-alsa        := USE_ALSA
+baresip-mod-amr         := USE_AMR
 baresip-mod-avcodec     := USE_AVCODEC
+baresip-mod-avfilter    := USE_AVFILTER
 baresip-mod-avformat    := USE_AVFORMAT
 baresip-mod-cons        := USE_CONS
+baresip-mod-ctrl-dbus   := HAVE_GLIB USE_DBUS
 baresip-mod-evdev       := USE_EVDEV
 baresip-mod-g711        := USE_G711
 baresip-mod-g722        := USE_G722
 baresip-mod-g726        := USE_G726
+baresip-mod-gst         := USE_GST
+baresip-mod-gst-video   := USE_GST_VIDEO
+baresip-mod-httpreq     := USE_HTTPREQ
+baresip-mod-l16         := USE_L16
+baresip-mod-mqtt        := USE_MQTT
 baresip-mod-opus        := USE_OPUS
+baresip-mod-opus_multistream   := USE_OPUS_MS
 baresip-mod-oss         := USE_OSS
 baresip-mod-plc         := USE_PLC
 baresip-mod-portaudio   := USE_PORTAUDIO
 baresip-mod-pulse       := USE_PULSE
-baresip-mod-rtcpsummary := USE_RTCPSUMMARY
+baresip-mod-snapshot    := USE_SNAPSHOT
 baresip-mod-sndfile     := USE_SNDFILE
+baresip-mod-speex-pp    := USE_SPEEX_PP
 baresip-mod-srtp        := USE_SRTP
 baresip-mod-stdio       := USE_STDIO
+baresip-mod-syslog      := USE_SYSLOG
 baresip-mod-vp8         := USE_VPX
 baresip-mod-vp9         := USE_VPX
 baresip-mod-v4l2        := USE_V4L2
 
 BARESIP_MOD_OPTIONS:= \
 	MOD_AUTODETECT= \
-	$(foreach m,$(baresip-mods),$(baresip-mod-$(m))=$(if $(CONFIG_PACKAGE_baresip-mod-$(subst _,-,$(m))),1))
+	$(foreach m,$(baresip-mods),$(foreach v,$(baresip-mod-$(m)),$(v)=$(if $(CONFIG_PACKAGE_baresip-mod-$(subst _,-,$(m))),1)))
 
 MAKE_FLAGS+= \
 	CROSS_COMPILE="$(TARGET_CROSS)" \
@@ -168,26 +192,39 @@ endef
 
 $(eval $(call BuildPackage,baresip))
 
+$(eval $(call BuildPlugin,aac,MPEG-4 AAC Audio Codec,aac,+fdk-aac))
 $(eval $(call BuildPlugin,alsa,ALSA audio driver,alsa,+alsa-lib))
+$(eval $(call BuildPlugin,amr,Adaptive Multi-Rate [AMR] audio codec,amr,))
 $(eval $(call BuildPlugin,aubridge,Audio bridge module,aubridge,))
 $(eval $(call BuildPlugin,aufile,Audio module for using a WAV-file as audio input,aufile,))
+$(eval $(call BuildPlugin,ausine,Sine Audio Source,ausine,))
 $(eval $(call BuildPlugin,avcodec,Video codec using FFmpeg,avcodec,+libffmpeg-full))
 $(eval $(call BuildPlugin,avformat,Video source using FFmpeg,avformat,baresip-mod-avcodec))
 $(eval $(call BuildPlugin,b2bua,Back-to-Back User-Agent module,b2bua,))
 $(eval $(call BuildPlugin,cons,UDP/TCP console UI driver,cons,))
+$(eval $(call BuildPlugin,ctrl_dbus,DBus control interface,ctrl_dbus,+glib2))
 $(eval $(call BuildPlugin,ctrl_tcp,TCP control interface,ctrl_tcp,))
 $(eval $(call BuildPlugin,debug_cmd,Debug commands,debug_cmd,))
 $(eval $(call BuildPlugin,dtls_srtp,DTLS-SRTP end-to-end encryption,dtls_srtp,))
+$(eval $(call BuildPlugin,ebuacip,EBU ACIP [Audio Contribution over IP] Profile,ebuacip,))
 $(eval $(call BuildPlugin,echo,Echo server module,echo,))
 $(eval $(call BuildPlugin,evdev,Linux input driver,evdev,))
 $(eval $(call BuildPlugin,fakevideo,Fake video input/output driver,fakevideo,))
 $(eval $(call BuildPlugin,g711,G.711 audio codec,g711,))
 $(eval $(call BuildPlugin,g722,G.722 audio codec,g722,+libspandsp))
 $(eval $(call BuildPlugin,g726,G.726 audio codec,g726,+libspandsp))
+$(eval $(call BuildPlugin,gst,Gstreamer 1.0 playbin pipeline,gst,+glib2 +libgstreamer1))
+$(eval $(call BuildPlugin,gst_video,Video codecs using Gstreamer 1.0,gst_video,+glib2 +libgst1app +libgstreamer1))
 $(eval $(call BuildPlugin,httpd,HTTP webserver UI-module,httpd,))
+$(eval $(call BuildPlugin,httpreq,HTTP request module,httpreq,))
+$(eval $(call BuildPlugin,l16,16-bit linear codec,l16,))
+$(eval $(call BuildPlugin,mixausrc,Mixes another audio source into audio stream,mixausrc,))
+$(eval $(call BuildPlugin,mqtt,Message Queue Telemetry Transport [MQTT] client,mqtt,+libmosquitto))
+$(eval $(call BuildPlugin,multicast,Multicast support,multicast,))
 $(eval $(call BuildPlugin,mwi,Message Waiting Indication,mwi,))
 $(eval $(call BuildPlugin,natpmp,NAT Port Mapping Protocol module,natpmp,))
 $(eval $(call BuildPlugin,opus,OPUS Interactive audio codec,opus,+libopus))
+$(eval $(call BuildPlugin,opus_multistream,Opus Multistream Audio Codec,opus_multistream,+libopus))
 $(eval $(call BuildPlugin,oss,OSS audio driver,oss,))
 $(eval $(call BuildPlugin,plc,Packet Loss Concealment,plc,+libspandsp))
 $(eval $(call BuildPlugin,portaudio,Portaudio audio driver,portaudio,+portaudio))
@@ -195,13 +232,18 @@ $(eval $(call BuildPlugin,presence,Presence module,presence,))
 $(eval $(call BuildPlugin,pulse,Pulseaudio audio driver,pulse,PACKAGE_$(PKG_NAME)-mod-pulse:pulseaudio))
 $(eval $(call BuildPlugin,rtcpsummary,RTCP summary module,rtcpsummary,))
 $(eval $(call BuildPlugin,selfview,Video selfview module,selfview,))
+$(eval $(call BuildPlugin,serreg,Serial registration mode,serreg,))
+$(eval $(call BuildPlugin,snapshot,Snapshot video module,snapshot,+libpng))
 $(eval $(call BuildPlugin,sndfile,Audio dumper using libsndfile,sndfile,+libsndfile))
+$(eval $(call BuildPlugin,speex_pp,Speex Pre-processor,speex_pp,+libspeexdsp))
 $(eval $(call BuildPlugin,srtp,Secure RTP module using libre,srtp,))
 $(eval $(call BuildPlugin,stdio,Standard input/output UI driver,stdio,))
+$(eval $(call BuildPlugin,syslog,Syslog module,syslog,))
 $(eval $(call BuildPlugin,uuid,UUID generator and loader,uuid,))
 $(eval $(call BuildPlugin,v4l2,Video4Linux2 video source,v4l2,+libv4l))
 $(eval $(call BuildPlugin,v4l2_codec,Video4Linux2 video codec module,v4l2_codec,))
 $(eval $(call BuildPlugin,vidbridge,Video bridge module,vidbridge,))
+$(eval $(call BuildPlugin,vidinfo,Video-info filter,vidinfo,))
 $(eval $(call BuildPlugin,vidloop,Video-loop test module,vidloop,))
 $(eval $(call BuildPlugin,vumeter,Display audio levels in console,vumeter,))
 $(eval $(call BuildPlugin,vp8,VP8 video codec,vp8,+libvpx))

--- a/net/baresip/patches/002-fix-rem-include.patch
+++ b/net/baresip/patches/002-fix-rem-include.patch
@@ -1,53 +1,68 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -44,26 +44,15 @@ endif
- include $(LIBRE_MK)
- include mk/modules.mk
+@@ -45,63 +45,11 @@ SYSROOT_LOCAL := $(shell [ -d /usr/local
+ endif
+ endif
  
 -ifndef LIBREM_PATH
 -LIBREM_PATH	:= $(shell [ -d ../rem ] && echo "../rem")
 -endif
 -
+-ifeq ($(LIBREM_PATH),)
+-ifneq ($(SYSROOT_LOCAL),)
+-LIBREM_PATH	:= $(shell [ -f $(SYSROOT_LOCAL)/include/rem/rem.h ] && \
+-	echo "$(SYSROOT_LOCAL)")
+-endif
+-endif
 -
+-ifeq ($(LIBREM_PATH),)
+-LIBREM_PATH	:= $(shell [ -f $(SYSROOT)/include/rem/rem.h ] && \
+-	echo "$(SYSROOT)")
+-endif
+-
+ # Include path
+-LIBREM_INC := $(shell [ -f $(LIBREM_PATH)/include/rem.h ] && \
+-	echo "$(LIBREM_PATH)/include")
+-ifeq ($(LIBREM_INC),)
+-LIBREM_INC := $(shell [ -f $(LIBREM_PATH)/include/rem/rem.h ] && \
+-	echo "$(LIBREM_PATH)/include/rem")
+-endif
+-ifeq ($(LIBREM_INC),)
+-LIBREM_INC := $(shell [ -f /usr/local/include/rem/rem.h ] && \
+-	echo "/usr/local/include/rem")
+-endif
+-ifeq ($(LIBREM_INC),)
+-LIBREM_INC := $(shell [ -f /usr/include/rem/rem.h ] && echo "/usr/include/rem")
+-endif
++LIBREM_INC := $(SYSROOT_ALT)/include/rem
+ 
+ # Library path
+-ifeq ($(LIBREM_SO),)
+-LIBREM_SO  := $(shell [ -f $(LIBREM_PATH)/librem.a ] && \
+-	echo "$(LIBREM_PATH)")
+-endif
+-ifeq ($(LIBREM_SO),)
+-LIBREM_SO :=$(shell [ -f $(LIBREM_PATH)/librem$(LIB_SUFFIX) ] && \
+-	echo "$(LIBREM_PATH)")
+-endif
+-ifeq ($(LIBREM_SO),)
+-LIBREM_SO := $(shell [ -f $(LIBREM_PATH)/lib/librem$(LIB_SUFFIX) ] && \
+-	echo "$(LIBREM_PATH)/lib")
+-endif
+-ifeq ($(LIBREM_SO),)
+-LIBREM_SO  := $(shell [ -f /usr/local/lib/librem$(LIB_SUFFIX) ] \
+-	&& echo "/usr/local/lib")
+-endif
+-ifeq ($(LIBREM_SO),)
+-LIBREM_SO  := $(shell [ -f /usr/lib/librem$(LIB_SUFFIX) ] && \
+-	echo "/usr/lib")
+-endif
+-ifeq ($(LIBREM_SO),)
+-LIBREM_SO  := $(shell [ -f /usr/lib64/librem$(LIB_SUFFIX) ] && \
+-	echo "/usr/lib64")
+-endif
+-
++LIBREM_SO  := $(SYSROOT_ALT)/include/rem
+ 
  CFLAGS    += -I. -Iinclude -I$(LIBRE_INC)
--ifneq ($(LIBREM_PATH),)
--CFLAGS    += -I$(LIBREM_PATH)/include
--endif
--CFLAGS    += -I$(SYSROOT)/local/include/rem -I$(SYSROOT)/include/rem
-+CFLAGS    += -I$(SYSROOT_ALT)/include/rem
- ifneq ($(SYSROOT_LOCAL),)
- CFLAGS    += -I$(SYSROOT_LOCAL)/include/rem
- endif
- 
- 
- CXXFLAGS  += -I. -Iinclude -I$(LIBRE_INC)
--ifneq ($(LIBREM_PATH),)
--CXXFLAGS  += -I$(LIBREM_PATH)/include
--endif
--CXXFLAGS  += -I$(SYSROOT)/local/include/rem -I$(SYSROOT)/include/rem
-+CXXFLAGS  += -I$(SYSROOT_ALT)/include/rem
- ifneq ($(SYSROOT_LOCAL),)
- CXXFLAGS  += -I$(SYSROOT_LOCAL)/include/rem
- endif
-@@ -73,10 +62,6 @@ CXXFLAGS  += $(EXTRA_CXXFLAGS)
- # XXX: common for C/C++
- CPPFLAGS += -DHAVE_INTTYPES_H
- 
--ifneq ($(LIBREM_PATH),)
--CLANG_OPTIONS  += -I$(LIBREM_PATH)/include
--endif
--
- ifeq ($(OS),win32)
- STATIC    := yes
- endif
-@@ -144,10 +129,6 @@ LIB_OBJS  := $(OBJS) $(MOD_OBJS)
- TEST_OBJS := $(patsubst %.c,$(BUILD)/test/%.o,$(filter %.c,$(TEST_SRCS)))
- TEST_OBJS += $(patsubst %.cpp,$(BUILD)/test/%.o,$(filter %.cpp,$(TEST_SRCS)))
- 
--ifneq ($(LIBREM_PATH),)
--LIBS	+= -L$(LIBREM_PATH)
--endif
--
- # Static build: include module linker-flags in binary
- ifneq ($(STATIC),)
- LIBS      += $(MOD_LFLAGS)
+ CFLAGS    += -I$(LIBREM_INC)


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: 21.02
Run tested: 21.01

Description:
I don't use baresip myself, so a bit hard to run-test. But I got it to send me back a ringing with the b2bua module. It's not much, but that was as much time as I was willing to invest in this. It took me long enough getting the new version to build.

```
 Mon Dec  6 23:31:22 2021 daemon.err baresip[9292]: unhandeled request from 192.168.0.151:46932: REGISTER sip:192.168.0.1
Mon Dec  6 23:33:56 2021 daemon.err baresip[9292]: unhandeled request from 192.168.0.151:46598: REGISTER sip:192.168.0.1
Mon Dec  6 23:34:03 2021 daemon.info baresip[9292]: ua: sipsess connect via UDP 192.168.0.151:46598 --> 192.168.0.1:5080
Mon Dec  6 23:34:03 2021 daemon.info baresip[9292]: b2bua-inbound@192.168.0.1: use catch-all account for 6001
Mon Dec  6 23:34:03 2021 daemon.info baresip[9292]: ua: using AF from sdp offer: af=AF_INET
Mon Dec  6 23:34:03 2021 daemon.info baresip[9292]: call: alloc with params laddr=192.168.1.2, af=AF_INET, use_rtp=1
```

Kind regards,
Seb