### PR TITLE
baresip: fix compilation with NLS

### DIFF
--- a/net/baresip/Makefile
+++ b/net/baresip/Makefile
@@ -61,6 +61,7 @@ PKG_CONFIG_DEPENDS:= \
 	$(patsubst %,CONFIG_PACKAGE_baresip-mod-%,$(subst _,-,$(baresip-mods)))
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/baresip/Default
   SECTION:=net


### PR DESCRIPTION
Maintainer: @jslachta
Compile tested: Turris Omnia, mvebu (cortex-a9), OpenWrt master
Run tested: N/A

Fixes issue:

```
ccache_cc -L//master/build/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/lib -fPIC -L//master/build/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-11.2.0_musl_eabi/usr/lib -L//master/build/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-11.2.0_musl_eabi/lib -DPIC -fpic -specs=//master/build/include/hardened-ld-pie.specs -znow -zrelro -shared  \
	build-arm/modules/opus/decode.o build-arm/modules/opus/encode.o build-arm/modules/opus/opus.o build-arm/modules/opus/sdp.o \
	-lopus -lm -L//master/build/staging_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/usr/lib -lre -o opus.so
//master/build/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-11.2.0_musl_eabi/lib/gcc/arm-openwrt-linux-muslgnueabi/11.2.0/../../../../arm-openwrt-linux-muslgnueabi/bin/ld: cannot find -lintl
collect2: error: ld returned 1 exit status
make[3]: *** [mk/mod.mk:41: ctrl_dbus.so] Error 1
make[3]: *** Waiting for unfinished jobs....
collect2: error: ld returned 1 exit status
make[3]: *** [mk/mod.mk:41: gst.so] Error 1
//master/build/staging_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-11.2.0_musl_eabi/lib/gcc/arm-openwrt-linux-muslgnueabi/11.2.0/../../../../arm-openwrt-linux-muslgnueabi/bin/ld: cannot find -lintl
collect2: error: ld returned 1 exit status
make[3]: *** [mk/mod.mk:41: gst_video.so] Error 1
make[3]: Leaving directory '//master/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/baresip-1.1.0'
make[2]: *** [Makefile:197: //master/build/build_dir/target-arm_cortex-a9+vfpv3-d16_musl_eabi/baresip-1.1.0/.built] Error 2
make[2]: Leaving directory '//master/build/feeds/telephony/net/baresip'
time: package/feeds/telephony/baresip/compile#0.91#0.31#0.57
    ERROR: package/feeds/telephony/baresip failed to build.
make[1]: *** [package/Makefile:116: package/feeds/telephony/baresip/compile] Error 1
make[1]: Leaving directory '//master/build'
make: *** [//master/build/include/toplevel.mk:230: package/baresip/compile] Error 2
```