### PR TITLE
coturn: add /etc/turnserver to conffiles

### DIFF
--- a/net/coturn/Makefile
+++ b/net/coturn/Makefile
@@ -59,6 +59,7 @@ define Package/coturn/conffiles
 /etc/config/turnserver
 /etc/init.d/turnserver
 /etc/turnserver.conf
+/etc/turnserver
 endef
 
 define Package/coturn/config


### PR DESCRIPTION
If turndb it created in this folder it should be saved during
sysupgrade.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me / @jslachta 
Compile tested: NA
Run tested: NA

Description:
