### PR TITLE
coturn: add libintl dependency when enabled full language support

### DIFF
--- a/net/coturn/Makefile
+++ b/net/coturn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coturn
 PKG_VERSION:=4.5.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coturn/coturn/tar.gz/$(PKG_VERSION)?

--- a/net/coturn/patches/100-configure-dont-link-libintl.patch
+++ b/net/coturn/patches/100-configure-dont-link-libintl.patch
@@ -1,0 +1,22 @@
+From 2132a1a8eecb3460b8c2e4a7201e3254dc420179 Mon Sep 17 00:00:00 2001
+From: Sebastian Kemper <sebastian_ml@gmx.net>
+Date: Sun, 26 Dec 2021 15:47:41 +0100
+Subject: [PATCH] configure: don't link in libintl
+
+libintl isn't used, so there is no need to link coturn to it.
+
+Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
+---
+ configure | 1 -
+ 1 file changed, 1 deletion(-)
+
+--- a/configure
++++ b/configure
+@@ -699,7 +699,6 @@ if ! [ ${ER} -eq 0 ] ; then
+     echo "CYGWIN ?"
+ fi
+ testlib wldap64
+-testlib intl
+ testlib nsl
+ testlib resolv
+ 


### PR DESCRIPTION
Maintainers: @jslachta and @micmac1 
Issue reproduced on these two routers:
- Turris MOX, mvebu, (cortex-a53), OpenWrt master
- Turris Omnia, mvebu (cortex-a9), OpenWrt master
and on the later one, I was able to reproduce this issue locally and fix it as well. I didn't had the build environment for the first one, yet. Thus proposing this fix.

If there is enabled CONFIG_BUILD_NLS, coturn can not be compiled.
It fails with the following error:

Package coturn is missing dependencies for the following libraries:
libintl.so.8