### PR TITLE
libpri: fix build on macos

### DIFF
--- a/libs/libpri/Makefile
+++ b/libs/libpri/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpri
 PKG_VERSION:=1.6.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/libpri/releases
@@ -34,6 +34,10 @@ define Package/libpri/description
 	May 12, 2001, it has been tested work with NI-2, Nortel DMS-100, and
 	Lucent 5E Custom protocols on switches from Nortel and Lucent.
 endef
+
+MAKE_FLAGS += \
+	OSARCH=Linux \
+	LDCONFIG=ldconfig
 
 define Build/Configure
 endef

--- a/libs/libpri/patches/001-fix-include-signal-h-warning.patch
+++ b/libs/libpri/patches/001-fix-include-signal-h-warning.patch
@@ -1,7 +1,5 @@
-Index: libpri-1.4.15/pritest.c
-===================================================================
---- libpri-1.4.15.orig/pritest.c
-+++ libpri-1.4.15/pritest.c
+--- a/pritest.c
++++ b/pritest.c
 @@ -41,7 +41,7 @@
  #include <sys/ioctl.h>
  #include <stdlib.h>
@@ -11,10 +9,8 @@ Index: libpri-1.4.15/pritest.c
  #include <sys/select.h>
  #include <sys/wait.h>
  #include <sys/resource.h>
-Index: libpri-1.4.15/testprilib.c
-===================================================================
---- libpri-1.4.15.orig/testprilib.c
-+++ libpri-1.4.15/testprilib.c
+--- a/testprilib.c
++++ b/testprilib.c
 @@ -41,7 +41,7 @@
  #include <sys/ioctl.h>
  #include <stdlib.h>

--- a/libs/libpri/patches/100_add-an-ability-to-build-libpri-on-MacOS-for-Linux-ta.patch
+++ b/libs/libpri/patches/100_add-an-ability-to-build-libpri-on-MacOS-for-Linux-ta.patch
@@ -1,0 +1,39 @@
+Upstream issue: https://issues.asterisk.org/jira/browse/PRI-188
+
+From ec1d6589c6e4eb6550cb92d5e0f214f7b31e8d5f Mon Sep 17 00:00:00 2001
+From: "Sergey V. Lobanov" <sergey@lobanov.in>
+Date: Sun, 30 Jan 2022 13:25:17 +0300
+Subject: [PATCH] Add an ability to build libpri on MacOS for Linux target
+
+This patch allows to rededine ar and ranlib tool using AR and
+RANLIB make flags.
+
+Fixes: PRI-188
+
+Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>
+---
+ Makefile | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+--- a/Makefile
++++ b/Makefile
+@@ -27,6 +27,8 @@
+ CC=gcc
+ GREP=grep
+ AWK=awk
++AR=ar
++RANLIB=ranlib
+ 
+ OSARCH=$(shell uname -s)
+ PROC?=$(shell uname -m)
+@@ -193,8 +195,8 @@ MAKE_DEPS= -MD -MT $@ -MF .$(subst /,_,$
+ 	$(CC) $(CFLAGS) $(MAKE_DEPS) -c -o $@ $<
+ 
+ $(STATIC_LIBRARY): $(STATIC_OBJS)
+-	ar rcs $(STATIC_LIBRARY) $(STATIC_OBJS)
+-	ranlib $(STATIC_LIBRARY)
++	$(AR) rcs $(STATIC_LIBRARY) $(STATIC_OBJS)
++	$(RANLIB) $(STATIC_LIBRARY)
+ 
+ $(DYNAMIC_LIBRARY): $(DYNAMIC_OBJS)
+ 	$(CC) $(SOFLAGS) -o $@ $(DYNAMIC_OBJS)


### PR DESCRIPTION
libpri can not be built on macos for OpenWrt Linux target due to:
1. Makefile uses `ar` and `ranlib` (without using make variables).
   MacOS system ar and ranlib are not compatible with the objects
   generated by OpenWrt GCC toolchain. This commit adds patch to
   add an ability to redefine `ar` and `ranlib` tools.
   Upstream issue: https://issues.asterisk.org/jira/browse/PRI-188
2. Makefile detects Darwin using `uname -s` and changes build logic
   but it is not need for cross-platfrom build. This commit
   redefines OSARCH=Linux in OpenWrt Makefile
3. After redefining OSARCH=Linux, libpri Makefile uses /sbin/ldconfig
   that does not exist on MacOS. This commit redefines LDCONFIG=ldconfig
   in OpenWrt Makefile to use ldconfig provided by OpenWrt.

Patch '001-fix-include-signal-h-warning.patch' was refreshed to pass
CI checks. The payload of this patch was not changed.

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @dangowrt 
Compile tested: (armvirt/64, OpenWRT trunk)

Description: see above
Additional info: related PR to openwrt core (ldconfig symlink issue on macos): https://github.com/openwrt/openwrt/pull/5015