### PR TITLE
[21.02] sofia-sip: update to 1.13.7

### DIFF
--- a/libs/sofia-sip/Makefile
+++ b/libs/sofia-sip/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sofia-sip
 
-PKG_VERSION:=1.13.6
-PKG_RELEASE:=1
+PKG_VERSION:=1.13.7
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/freeswitch/$(PKG_NAME)/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=6f3cb48a35929abd3454087b32ad4c75fa5fe50fab8a9cc6f98559e6fd1bd64b
+PKG_HASH:=3bdcbe80a066c9cafa8d947d51512b86ed56bf2cdbb25dbe9b8eef6a8bab6a25
 
 # sofia-sip adds a version to include path
 # need to update this when the version changes


### PR DESCRIPTION
Contains DOS fix, see [1].

Converted to AUTORELEASE.

[1] https://github.com/signalwire/freeswitch/issues/1518

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
(cherry picked from commit f04a5a23830ced20e0bd298f41fb9fd93c8353a0)

-------------------------------

Maintainer: me
Compile tested: sdk ath79 master
Run tested: 19.07 ath79

Description: version bump
