### PR TITLE
coturn: improve reproducibility and fix build on macos

### DIFF
--- a/net/coturn/Makefile
+++ b/net/coturn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coturn
 PKG_VERSION:=4.5.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coturn/coturn/tar.gz/$(PKG_VERSION)?
@@ -129,6 +129,7 @@ CONFIGURE_ARGS+= \
 	--turndbdir=/etc/turnserver
 
 CONFIGURE_VARS+= \
+	ARCHIVERCMD="$(TARGET_AR) -r" \
 	LIBEV_OK=1 \
 	TURN_NO_PROMETHEUS=1 \
 	TURN_NO_SCTP=1 \

--- a/net/coturn/Makefile
+++ b/net/coturn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coturn
 PKG_VERSION:=4.5.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coturn/coturn/tar.gz/$(PKG_VERSION)?
@@ -129,6 +129,7 @@ CONFIGURE_ARGS+= \
 	--turndbdir=/etc/turnserver
 
 CONFIGURE_VARS+= \
+	LIBEV_OK=1 \
 	TURN_NO_PROMETHEUS=1 \
 	TURN_NO_SCTP=1 \
 	TURN_NO_SYSTEMD=1 \


### PR DESCRIPTION
This PR has two commits:
coturn: improve reproducibility (Ubuntu build host fix)
coturn: fix build on macos

Maintainer: @jslachta , Sebastian Kemper <sebastian_ml@gmx.net>
Compile tested: (armvirt/64, OpenWRT version b21bc3479d46e6a4c3cc6bf7c245d4b0ddccb7db)
Run tested: not really tested, but generated binaries are exactly the same as official binaries from https://downloads.openwrt.org/snapshots/packages/ . Now generated binaries are the same on Debian, Ubuntu and MacOS build hosts

CI status for first commit (reproducibility) is: https://github.com/svlobanov/telephony/runs/5024603191
CI status for both commits will be in this PR and by link: https://github.com/svlobanov/telephony/runs/5024839078
