### PR TITLE
asterisk: don't send stdout to syslog by default

### DIFF
--- a/net/asterisk/files/asterisk.conf
+++ b/net/asterisk/files/asterisk.conf
@@ -12,5 +12,5 @@
 config asterisk 'general'
 	option enabled '0'
 	option log_stderr '1'
-	option log_stdout '1'
+	option log_stdout '0'
 	option options ''

--- a/net/asterisk/files/asterisk.init
+++ b/net/asterisk/files/asterisk.init
@@ -30,7 +30,7 @@ start_service() {
   fi
 
   config_get_bool log_stderr general log_stderr 1
-  config_get_bool log_stdout general log_stdout 1
+  config_get_bool log_stdout general log_stdout 0
 
   config_get options general options
 


### PR DESCRIPTION
Maintainer: @jslachta
Compile tested: x86_64, generic, HEAD (236c3ea730)
Run tested: same, installed & running on production PBX

Description:

Don't duplicate console tracing into `/var/log/messages`.