### PR TITLE
kamailio: fix build on macos

### DIFF
--- a/net/kamailio/Makefile
+++ b/net/kamailio/Makefile
@@ -235,6 +235,7 @@ PKG_CONFIG_DEPENDS:= \
 
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/kernel.mk
 include $(TOPDIR)/feeds/packages/lang/python/python3-version.mk
 
 # Build reproducibly
@@ -412,6 +413,8 @@ CPU_MIPS2:=mips32 24kc 34kc 4kec 74kc
 endif
 
 MAKE_FLAGS += \
+	OS=linux \
+	OSREL=$(LINUX_UNAME_VERSION) \
 	$(if $(findstring $(call qstrip,$(CONFIG_CPU_TYPE)),$(CPU_MIPS2)),ARCH="mips2",ARCH="$(ARCH)") \
 	CC_EXTRA_OPTS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)" \
 	LD="$(TARGET_CC)" \


### PR DESCRIPTION
kamailio macos build fails due to kamailio Makefile checks OS
(`uname -s`) and OSREL (`uname -r`). If build host is not Linux,
then these checks will provide different results, but OpenWrt is
always Linux so target OS should be always Linux.

This patch explicitly specifies OS=linux and OSREL=$(LINUX_UNAME_VERSION)
to avoid using build host values for target build.

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

Maintainer: @jslachta 
Compile tested: (armvirt/64, OpenWRT 4d904524effc9eb0cc5094574c55d3a520803223)

Description: see above
