### PR TITLE
siproxd/libosip2: update to latest

### DIFF
--- a/libs/libosip2/Makefile
+++ b/libs/libosip2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libosip2
-PKG_VERSION:=5.1.2
-PKG_RELEASE:=1
+PKG_VERSION:=5.3.0
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/osip
-PKG_HASH:=2bc0400f21a64cf4f2cbc9827bf8bdbb05a9b52ecc8e791b4ec0f1f9410c1291
+PKG_HASH:=f4725916c22cf514969efb15c3c207233d64739383f7d42956038b78f6cae8c8
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -30,7 +30,7 @@ define Package/libosip2
   CATEGORY:=Libraries
   TITLE:=GNU oSIP library
   URL:=http://www.gnu.org/software/osip/
-  ABI_VERSION:=13
+  ABI_VERSION:=15
   DEPENDS:=+librt
 endef
 

--- a/net/siproxd/Makefile
+++ b/net/siproxd/Makefile
@@ -8,12 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=siproxd
-PKG_VERSION:=0.8.3
-PKG_RELEASE:=4
+PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SF/siproxd
-PKG_HASH:=9a6d7a6bb6fff162775b1e1fb7018de9c69642cbf8626185dc6ffceeeba07736
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/hb9xar/siproxd.git
+PKG_SOURCE_DATE:=2022-02-18
+PKG_SOURCE_VERSION:=4750bea4ffedb4543a404dafc979c2b16b53e523
+PKG_MIRROR_HASH:=e6c4266b9eba43792908cf7c4ee73c32eee7b3a227ee671a5381cc335295fc05
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
@@ -59,6 +60,7 @@ define Package/siproxd/config
 endef
 
 CONFIGURE_ARGS+= \
+	--enable-reproducible-build \
 	--with-libosip-prefix="$(STAGING_DIR)/usr" \
 	--without-included-ltdl \
 	--disable-doc


### PR DESCRIPTION
Maintainer: @jslachta @guidosarducci 
Compile tested: master ath79 SDK
Run tested: N/A

Description:
This bumps libosip2 to latest release and siproxd to latest upstream git commit. siproxd update contains fixes related to time64 and also allows for a reproducible build.

Closes #613
Closes #742
