### PR TITLE
rtpengine: use perl/host when building

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -29,7 +29,7 @@ PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 # errors.
 PKG_BUILD_PARALLEL:=0
 
-PKG_BUILD_DEPENDS:=gperf/host
+PKG_BUILD_DEPENDS:=gperf/host perl/host
 
 # With below variable set, $(PKG_SYMVERS_DIR)/rtpengine.symvers gets generated
 # from kernel-module/Module.symvers.
@@ -242,7 +242,9 @@ ifeq ($(QUILT),)
 	cd "$(PKG_BUILD_DIR)" && \
 		$(FIND) . -maxdepth 2 -name "*Makefile" | \
 		xargs  -I{} $(SED) \
-		'/shell which dpkg-/s/dpkg/OpenWrt-has-no-dpkg/' {}
+		'/shell which dpkg-/s/dpkg/OpenWrt-has-no-dpkg/' {} && \
+		$(SED) 's|#!/usr/bin/perl|#!$(STAGING_DIR_HOSTPKG)/usr/bin/perl|' \
+		utils/const_str_hash
 endif
 endef
 


### PR DESCRIPTION
utils/const_str_hash is called by rtpengine build system. The Perl
script uses shebang "#!/usr/bin/perl" and depends on perl-IPC-Cmd. If
this is missing the build will fail:

../utils/const_str_hash < "control_ng.c" > "control_ng.strhash.c"
Can't locate IPC/Cmd.pm in @INC (you may need to install the IPC::Cmd module) (@INC contains: /usr/local/lib64/perl5/5.34 /usr/local/share/perl5/5.34 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ../utils/const_str_hash line 6.
BEGIN failed--compilation aborted at ../utils/const_str_hash line 6.
make[4]: *** [../lib/common.Makefile:46: control_ng.strhash.c] Error 2

OpenWrt does not depend on perl-IPC-Cmd being available, so this commit
makes rtpengine build depend on perl/host, which provides this Perl
module.

Closes #748

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: me
Compile tested: sdk ath79 master
Run tested: N/A, build fix

Description:
Make the build use perl/host to make sure necessary Perl module is available.