### PR TITLE
asterisk: add --without-libxslt to configure

### DIFF
--- a/net/asterisk/Makefile
+++ b/net/asterisk/Makefile
@@ -573,6 +573,7 @@ CONFIGURE_ARGS+= \
 	--without-pjproject-bundled \
 	--with-libedit="$(STAGING_DIR)/usr" \
 	--with-libxml2 \
+	--without-libxslt \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-res-snmp),--with-netsnmp="$(STAGING_DIR)/usr",--without-netsnmp) \
 	--without-newt \
 	--without-osptk \


### PR DESCRIPTION
Since upstream commit b40c4d59b1dd803cad79060fb5b5a48d249ba578
"--disable-xmldoc" does no longer prevent the linking to libxslt, if
available. If that's the case one is greeted with the following error:

Package asterisk is missing dependencies for the following libraries:
libxslt.so.1

This commit explicitly disables the use of libxslt, to avoid the
dependency.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: master sdk ath79
Run tested: N/A

Description: prevent use of libxslt if available in staging
