### PR TITLE
libsrtp: use OpenSSL

### DIFF
--- a/libs/libsrtp/Makefile
+++ b/libs/libsrtp/Makefile
@@ -21,13 +21,15 @@ PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
 include $(INCLUDE_DIR)/package.mk
 
+CONFIGURE_ARGS+=--enable-openssl
+
 define Package/libsrtp2
   SUBMENU:=Telephony
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Secure RTP (SRTP) library, v$(PKG_VERSION)
   URL:=https://github.com/cisco/libsrtp
-  DEPENDS:=
+  DEPENDS:=+libopenssl
   ABI_VERSION:=1
 endef
 


### PR DESCRIPTION
Use OpenSSL instead of the internal crypto backend. Everything in
OpenWrt that links to libsrtp2 depends on OpenSSL anyway.

Upsides:

  - the libsrtp2 package size shrinks a bit (for example from 35 to 24
    KiB on ath79)
  - allows to use more cipher suites
  - may allow for hardware acceleration

Closes #763

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

-------------------------------

Maintainer: @jslachta 
Compile tested: 22.03-rc1 ath79
Run tested: 22.03-rc1 ath79, made some calls using SRTP (sdes)

Description:
Hi all,

PR to fix the recently opened issue.

Kind regards,
Seb