### PR TITLE
[openwrt-22.03] sofia-sip: bump to 1.13.8

### DIFF
--- a/libs/sofia-sip/Makefile
+++ b/libs/sofia-sip/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sofia-sip
 
-PKG_VERSION:=1.13.7
+PKG_VERSION:=1.13.8
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/freeswitch/$(PKG_NAME)/tar.gz/v${PKG_VERSION}?
-PKG_HASH:=3bdcbe80a066c9cafa8d947d51512b86ed56bf2cdbb25dbe9b8eef6a8bab6a25
+PKG_HASH:=792b99eb35e50d7abeb42e91a5dceaf28afc5be1a85ffb01995855792a747fec
 
 # sofia-sip adds a version to include path
 # need to update this when the version changes


### PR DESCRIPTION
Some security issues were fixed. Upstream labelled them as follows:

GHSA-79jq-hh82-cv9g: Fix Out-of-bound read in sip_method_d
GHSA-g3x6-p824-x6hm: Fix Out-of-bound read in url_canonize2 and
                     url_canonize3
GHSA-8w5j-6g2j-pxcp: Fix Heap-buffer-overflow in parse_descs and
                     parse_message

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
(cherry picked from commit 1efc4f3f98ed46b8bef2e29710d04131cda8ad44)

-------------------------------

Maintainer: me 
Compile tested: 
Run tested: 

Description:
Cherry-pick to address security issues in sofia-sip.