### PR TITLE
rtpengine: fix compilation with iptables 1.8.8

### DIFF
--- a/net/rtpengine/patches/06-fix-compilation-with-iptables-1-8-8.patch
+++ b/net/rtpengine/patches/06-fix-compilation-with-iptables-1-8-8.patch
@@ -1,0 +1,30 @@
+From 2a6d5cd2cbb58c1cab271a65a76decfdbc11dcd7 Mon Sep 17 00:00:00 2001
+From: Nick Hainke <vincent@systemli.org>
+Date: Wed, 8 Jun 2022 09:30:44 +0200
+Subject: [PATCH] fix compilation with iptables 1.8.8
+
+The extension handling changed [0,1]. Fix compilation with iptables
+1.8.8 [2].
+
+[0] - https://git.netfilter.org/iptables/commit/?id=ef108943f69a6e20533d58823740d3f0534ea8ec
+[1] - https://git.netfilter.org/iptables/commit/?id=6c689b639cf8e2aeced8685eca2915892d76ad86
+[2] - openwrt/openwrt#9886
+
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+---
+ iptables-extension/libxt_RTPENGINE.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/iptables-extension/libxt_RTPENGINE.c
++++ b/iptables-extension/libxt_RTPENGINE.c
+@@ -5,6 +5,10 @@
+ #include <netinet/in.h>
+ #include <arpa/inet.h>
+ 
++#ifndef _init
++#define _init __attribute__((constructor)) _INIT
++#endif
++
+ #if defined(__ipt)
+ #include <iptables.h>
+ #elif defined(__ip6t)


### PR DESCRIPTION
The extension handling changed [0,1]. Fix compilation with iptables
1.8.8 [2].

[0] - https://git.netfilter.org/iptables/commit/?id=ef108943f69a6e20533d58823740d3f0534ea8ec
[1] - https://git.netfilter.org/iptables/commit/?id=6c689b639cf8e2aeced8685eca2915892d76ad86
[2] - https://github.com/openwrt/openwrt/pull/9886

