### PR TITLE
rtpengine: bump to 10.5.2.6

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=rtpengine
-PKG_VERSION:=9.5.3.2
+PKG_VERSION:=10.5.2.6
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-mr$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sipwise/rtpengine/tar.gz/mr$(PKG_VERSION)?
-PKG_HASH:=03d8da1b5efcaa17ef88f306046f49e30ca87b3998c26a13bd96df922f8e729f
+PKG_HASH:=6f6d5cc2ebf27b6361ed2bd2f86a0ca74103503fd1a14af69ed423dba8340bc4
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-mr$(PKG_VERSION)
 
@@ -122,7 +122,7 @@ define Package/rtpengine/install
 	$(INSTALL_CONF) ./files/rtpengine.conf $(1)/etc/config/rtpengine
 
 	$(INSTALL_DIR) $(1)/etc/rtpengine
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/etc/rtpengine.sample.conf \
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/etc/rtpengine.conf \
 				$(1)/etc/rtpengine/rtpengine.conf
 
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
@@ -183,7 +183,7 @@ define Package/rtpengine-recording/install
 		$(1)/etc/config/rtpengine-recording
 
 	$(INSTALL_DIR) $(1)/etc/rtpengine
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/etc/rtpengine-recording.sample.conf \
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/etc/rtpengine-recording.conf \
 				$(1)/etc/rtpengine/rtpengine-recording.conf
 endef
 

--- a/net/rtpengine/patches/05-use-spandsp3.patch
+++ b/net/rtpengine/patches/05-use-spandsp3.patch
@@ -9,7 +9,7 @@
  CFLAGS+=	-DWITH_TRANSCODING
  CFLAGS+=        $(shell mysql_config --cflags)
  else
-@@ -68,7 +68,7 @@ LDLIBS+=	$(shell pkg-config --libs libav
+@@ -65,7 +65,7 @@ LDLIBS+=	$(shell pkg-config --libs libav
  LDLIBS+=	$(shell pkg-config --libs libavutil)
  LDLIBS+=	$(shell pkg-config --libs libswresample)
  LDLIBS+=	$(shell pkg-config --libs libavfilter)


### PR DESCRIPTION
Maintainer: @jslachta / me 
Compile tested: master/22.03 ath79
Run tested: 22.03 ath79

```
# rtpengine -v
Version: 10.5.2.6
# logread |grep rtpe
Sat Oct 15 00:43:32 2022 user.err rtpengine: service not enabled
Sat Oct 15 00:43:32 2022 user.err rtpengine: edit /etc/config/rtpengine
Sat Oct 15 00:44:57 2022 user.notice rtpengine: instance instance1 has started
Sat Oct 15 00:44:58 2022 daemon.info rtpengine[14078]: INFO: [crypto] Generating new DTLS certificate
Sat Oct 15 00:44:58 2022 daemon.err rtpengine[14078]: ERR: [core] FAILED TO CREATE KERNEL TABLE 0 (No such file or directory), KERNEL FORWARDING DISABLED
Sat Oct 15 00:44:58 2022 daemon.err rtpengine[14078]: [1665787498.373282] ERR: [core] FAILED TO CREATE KERNEL TABLE 0 (No such file or directory), KERNEL FORWARDING DISABLED
Sat Oct 15 00:44:58 2022 daemon.info rtpengine[14078]: INFO: [core] Startup complete, version 10.5.2.6
Sat Oct 15 00:44:58 2022 daemon.info rtpengine[14078]: INFO: [http] Websocket listener thread running
Sat Oct 15 00:48:20 2022 daemon.info rtpengine[14078]: INFO: [core] Version 10.5.2.6 shutting down

```
Description:
Updates package to new LTS version.