### PR TITLE
rtpengine: add mqtt dep

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -45,6 +45,7 @@ ENGINE_DEPENDS := \
 	+libevent2-pthreads \
 	+libhiredis \
 	+libip4tc \
+	+libmosquitto \
 	+libopenssl \
 	+libpcap \
 	+libpcre \


### PR DESCRIPTION
rtpengine will use the lib if found, so add it.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: @jslachta / me
Compile tested: master ath79
Run tested: N/A

Description: add missing dep

Sorry Jiri, didn't see that yesterday :) I'll just wait for CI to complete and merge it after. Have a good weekend!