### PR TITLE
[21.02] gsmlib: disable NLS

### DIFF
--- a/libs/gsmlib/Makefile
+++ b/libs/gsmlib/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gsmlib
 PKG_VERSION:=1.10-20140304
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/vbouchaud/gsmlib.git
@@ -62,6 +62,8 @@ endef
 define Package/gsm-utils/description
 Some simple command line programs to access GSM mobile phones via GSM modems.
 endef
+
+CONFIGURE_ARGS += --disable-nls
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/$(PKG_NAME)

--- a/libs/gsmlib/patches/01-update-autotools.patch
+++ b/libs/gsmlib/patches/01-update-autotools.patch
@@ -19,6 +19,15 @@ Description: Update autotools-related stuff.
  dnl comment out this line to get extensive debugging output and asserts
  dnl CXXFLAGS="-DNDEBUG $CXXFLAGS"
  
+@@ -108,7 +111,7 @@ AC_SUBST(GSM_VERSION)
+ dnl national language support (NLS)
+ LINGUAS="de"
+ ALL_LINGUAS=$LINGUAS
+-AM_GNU_GETTEXT
++AM_GNU_GETTEXT([external])
+ dnl AM_GLIB_GNU_GETTEXT
+ 
+ dnl set locale dir (FIXME there must be a better way)
 --- /dev/null
 +++ b/po/Makevars
 @@ -0,0 +1,5 @@
@@ -29,7 +38,7 @@ Description: Update autotools-related stuff.
 +
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -11,6 +11,8 @@
+@@ -11,14 +11,12 @@
  # * Created: 21.5.1999
  # *************************************************************************
  
@@ -38,3 +47,11 @@ Description: Update autotools-related stuff.
  SUBDIRS_ =	po gsmlib apps tests doc scripts win32 ext
  
  EXTRA_DIST =	gsmlib.spec
+ 
+-if COMPILE_INTL
+-SUBDIRS =	intl $(SUBDIRS_) # po - make automake happy
+-else
+ SUBDIRS =	$(SUBDIRS_) # po intl - make automake happy
+-endif
+ 
+ all:


### PR DESCRIPTION
It's not wanted, so add "--disable-nls" to override user selecting CONFIG_BUILD_NLS.

This also updates 01-update-autotools.patch to make these disappear:

ERROR: Use of AM_GNU_GETTEXT without [external] argument is no longer supported.

Makefile.am:21: warning: 'intl' should not be in SUBDIRS when AM_GNU_GETTEXT([external]) is used

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
(cherry picked from commit b86cf0cdc66d056be13ae49563d9bf5aadf28e78)

Maintainer: me
Compile tested: 21.02 SDK ath79
Run tested: N/A

Description: backport to 21.02 as requested by Josef in #674 
