### PR TITLE
pcapsipdump: fix linking against libobsd

### DIFF
--- a/net/pcapsipdump/patches/01-use-libc-strlcpy-if-available-v2.patch
+++ b/net/pcapsipdump/patches/01-use-libc-strlcpy-if-available-v2.patch
@@ -1,49 +1,51 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -2,8 +2,12 @@ LIBS ?= -lpcap -lstdc++
+@@ -2,11 +2,14 @@ LIBS ?= -lpcap -lstdc++
  RELEASEFLAGS ?= -O3 -Wall
  #CXXFLAGS ?= --std=c++0x
  
+-# auto-detect if bsd/strings.h is available
+-ifeq ($(shell $(CXX) $(CXXFLAGS) $(LDFLAGS) $(DEFS) -E -o /dev/null \
+-    	make-checks/libbsd.cpp 2>/dev/null; echo $$?),0)
+-	BSDSTR_DEFS := -DUSE_BSD_STRING_H
+-	BSDSTR_LIBS := -lbsd
 +# check if libc provides BSD's strlcpy
 +ifeq ($(shell $(CXX) $(CXXFLAGS) -D_BSD_SOURCE $(LDFLAGS) $(DEFS) -o /dev/null \
 +	make-checks/strlcpy.cpp 2>/dev/null; echo $$?),0)
-+	BSDSTR_DEFS := -D_BSD_SOURCE -DUSE_LIBC_STRLCPY
- # auto-detect if bsd/strings.h is available
--ifeq ($(shell $(CXX) $(CXXFLAGS) $(LDFLAGS) $(DEFS) -E -o /dev/null \
-+else ifeq ($(shell $(CXX) $(CXXFLAGS) $(LDFLAGS) $(DEFS) -E -o /dev/null \
-     	make-checks/libbsd.cpp 2>/dev/null; echo $$?),0)
- 	BSDSTR_DEFS := -DUSE_BSD_STRING_H
- 	BSDSTR_LIBS := -lbsd
++	BSDSTR_DEFS := -D_BSD_SOURCE
++# use libbsd's strlcpy
++else
++	BSDSTR_DEFS != pkg-config --cflags libbsd-overlay
++	BSDSTR_LIBS != pkg-config --libs   libbsd-overlay
+ endif
+ 
+ # auto-detect rhel/fedora and debian/ubuntu
 --- a/pcapsipdump_lib.h
 +++ b/pcapsipdump_lib.h
-@@ -3,7 +3,7 @@
- #ifndef BSD
-   #ifdef USE_BSD_STRING_H
-     #include <bsd/string.h>
+@@ -1,13 +1,5 @@
+ #include <sys/stat.h>
+ 
+-#ifndef BSD
+-  #ifdef USE_BSD_STRING_H
+-    #include <bsd/string.h>
 -  #else
-+  #elif !defined(USE_LIBC_STRLCPY)
-     #define strlcpy strncpy
-   #endif
- #endif
+-    #define strlcpy strncpy
+-  #endif
+-#endif
+-
+ // equivalent of "mkdir -p"
+ int mkdir_p(const char *path, mode_t mode);
+ 
 --- a/make-checks/all.mk
 +++ b/make-checks/all.mk
 @@ -1,5 +1,5 @@
 -make-checks/all: make-checks/cxx make-checks/libpcap make-checks/libbsd
-+make-checks/all: make-checks/cxx make-checks/libpcap make-checks/strlcpy make-checks/libbsd
++make-checks/all: make-checks/cxx make-checks/libpcap make-checks/strlcpy
  	@touch make-checks/all
  
  make-checks/clean:
 -	rm -f make-checks/all make-checks/cxx make-checks/libpcap make-checks/libbsd
-+	rm -f make-checks/all make-checks/cxx make-checks/libpcap make-checks/strlcpy make-checks/libbsd
---- a/make-checks/libbsd.mk
-+++ b/make-checks/libbsd.mk
-@@ -2,5 +2,5 @@ CHECK_LIBBSD = $(CXX) $(CXXFLAGS) $(LDFL
- 
- make-checks/libbsd:
- 	@$(CHECK_LIBBSD) || (\
--	  echo "*** notice: recommended library not found: libbsd"; \
-+	  echo "*** notice: library not found: libbsd"; \
- 	  true)
++	rm -f make-checks/all make-checks/cxx make-checks/libpcap make-checks/strlcpy
 --- /dev/null
 +++ b/make-checks/strlcpy.cpp
 @@ -0,0 +1,6 @@


### PR DESCRIPTION
Maintainer: nobody
Compile tested: x64 glibc toolchain built from OpenWRT commit hash eb456aedfe24a076a4f53743ad3c090ae447329e with my PR at https://github.com/openwrt/openwrt/pull/9714 applied

Description:
```
This just makes it so libbsd is picked up through pkg-config. It adds
support for libobsd without breaking libbsd.
```
This is probably my first PR to OpenWRT that isn't fixing a bug while getting what I want done so I'm pinging @neheb as an interested party.

Signed-off-by: Guilherme Janczak <guilherme.janczak@yandex.com>