### PR TITLE
Treewide: Use return in init scripts instead of exit

### DIFF
--- a/net/asterisk/files/asterisk.init
+++ b/net/asterisk/files/asterisk.init
@@ -26,7 +26,7 @@ start_service() {
   config_get_bool enabled general enabled 0
   if [ $enabled -eq 0 ]; then
     $LOGGER service not enabled in /etc/config/$NAME
-    exit 1
+    return 1
   fi
 
   config_get_bool log_stderr general log_stderr 1

--- a/net/baresip/files/baresip.init
+++ b/net/baresip/files/baresip.init
@@ -21,7 +21,7 @@ start_service() {
   if [ "$ENABLE_BARESIP" != yes ]; then
     $LOGGER User configuration incomplete - not starting $DAEMON
     $LOGGER Check ENABLE_BARESIP in $DEFAULT
-    exit 1
+    return 1
   fi
 
   procd_open_instance

--- a/net/coturn/Makefile
+++ b/net/coturn/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coturn
 PKG_VERSION:=4.5.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/coturn/coturn/tar.gz/$(PKG_VERSION)?

--- a/net/coturn/files/turnserver.init
+++ b/net/coturn/files/turnserver.init
@@ -20,7 +20,7 @@ start_service() {
   config_get_bool enabled general enabled 0
   if [ $enabled -eq 0 ]; then
     $LOG_ERR service not enabled in /etc/config/$NAME
-    exit 1
+    return 1
   fi
 
   config_get_bool log_stderr general log_stderr 1

--- a/net/freeswitch/files/freeswitch.init
+++ b/net/freeswitch/files/freeswitch.init
@@ -26,7 +26,7 @@ start_service() {
   config_get_bool enabled general enabled 0
   if [ $enabled -eq 0 ]; then
     $LOG_ERR service not enabled in /etc/config/$NAME
-    exit 1
+    return 1
   fi
 
   config_get_bool log_stderr general log_stderr 1
@@ -46,7 +46,7 @@ start_service() {
     $LOG_INFO using procd\'s default term_timeout
   elif ! [ 0 -lt "$term_timeout" ] 2>/dev/null; then
     $LOG_ERR invalid term_timeout in /etc/config/$NAME
-    exit 1
+    return 1
   fi
 
   for i in "$dir_localstate" "$dir_run"; do

--- a/net/kamailio/files/kamailio.init
+++ b/net/kamailio/files/kamailio.init
@@ -26,7 +26,7 @@ check_listen() {
 
   [ -z "$value" ] && {
     $LOG_ERR empty $type entry
-    exit 1
+    return 1
   }
 
   # IPv6 addresses need to be enclosed in square brackets. If there are
@@ -39,7 +39,7 @@ check_listen() {
   # Bail if more than 2 colons.
   [ $(echo "$value" | awk -F ":" '{print NF-1}') -gt 2 ] && {
     $LOG_ERR init script does not understand $type entry \""$value"\"
-    exit 1
+    return 1
   }
 
   IFS=":" read one two three << EOF
@@ -93,7 +93,7 @@ start_service() {
 
   if [ $enabled -eq 0 ]; then
     $LOG_ERR service not enabled in /etc/config/$NAME
-    exit 1
+    return 1
   fi
 
   config_get user       general user       $NAME

--- a/net/rtpproxy/files/rtpproxy.init
+++ b/net/rtpproxy/files/rtpproxy.init
@@ -48,13 +48,13 @@ check_ipaddr() {
 
 	[ -z "$value" ] && {
 		$LOG_ERR empty $type entry
-		exit 1
+		return 1
 	}
 
 	# Bail if more than 1 slash.
 	[ $(echo "$value" | awk -F "/" '{print NF-1}') -gt 1 ] && {
 		$LOG_ERR init script does not understand $type entry \""$value"\"
-		exit 1
+		return 1
 	}
 
 	IFS="/" read one two << EOF


### PR DESCRIPTION
Maintainer: @jslachta & me
Compile tested: master ath79
Run tested: 22.03 ath79

Description: Hi all,

I saw the commit [1] in packages. It fixed a bunch of init scripts to use return instead of exit in shell functions. I think we should do the same.

Usually we use "exit 1" in "start_service()" in our procd init scripts. Changing this to return is the right thing to do. There is a difference, though. If we run into "exit 1" we exit everything and the return value of the init script is "1". When converted to "return 1" the init script returns "0". So you could be in for a surprise if anything checked that return value. But in the files we provide we don't do that (e.g. freeswitch hotplug script calls init script but doesn't check return value).

Also, in rtpproxy and kamailio we use "exit 1" in helper functions. That way if the called helper is not happy and does "exit 1" the whole init script stops with exit status 1. Replace "exit 1" with "return 1" and and this doesn't happen, the init script continues, the programs are initialized, but without some extra (but ill-formatted) configuration. So again, slight change in behavior. Although the user still gets an error message (e.g. "init script does not understand $type entry").

This could be adapted, but I don't think we'd want that added complexity. Anyway, up for discussion.

[1] https://github.com/openwrt/packages/commit/b1651c5d5444b990b58180a26d6e76779cbb88a9
