### PR TITLE
rtpengine: update libwebsockets dependency

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=rtpengine
 PKG_VERSION:=10.5.2.6
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-mr$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sipwise/rtpengine/tar.gz/mr$(PKG_VERSION)?
@@ -49,7 +49,7 @@ ENGINE_DEPENDS := \
 	+libopenssl \
 	+libpcap \
 	+libpcre \
-	+libwebsockets \
+	+libwebsockets-openssl \
 	+xmlrpc-c-client \
 	+zlib
 


### PR DESCRIPTION
The rtpengine daemon requires lws_get_ssl(). This function is not available in libwebsockets-mbedtls. This commit updates the dependency to libwebsockets-openssl.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me & @jslachta 
Compile tested: sdk ath79
Run tested: 22.03 with libwebsockets-full, but that should be the same as libwebsockets-openssl as far as lws_get_ssl() is concerned.

Description:
Update dependency as per #796 