### PR TITLE
[22.03] rtpengine: update libwebsockets dependency

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -48,7 +48,7 @@ ENGINE_DEPENDS := \
 	+libopenssl \
 	+libpcap \
 	+libpcre \
-	+libwebsockets \
+	+libwebsockets-openssl \
 	+xmlrpc-c-client \
 	+zlib
 


### PR DESCRIPTION
The rtpengine daemon requires lws_get_ssl(). This function is not available in libwebsockets-mbedtls. This commit updates the dependency to libwebsockets-openssl.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Maintainer: me & @jslachta 
Compile tested: 22.03 ath79 sdk
Run tested: 22.03 with libwebsockets-full, but that should be the same as libwebsockets-openssl as far as lws_get_ssl() is concerned.

Description:
Update dependency as per #796