### PR TITLE
siproxd: init problem with wireguard interface

### DIFF
--- a/net/siproxd/files/siproxd.init
+++ b/net/siproxd/files/siproxd.init
@@ -52,8 +52,8 @@ setup_networks() {
 	config_get _int_outbound "$sec" interface_outbound
 
 	. /lib/functions/network.sh
-	network_get_physdev _dev_inbound $_int_inbound
-	network_get_physdev _dev_outbound $_int_outbound
+	network_get_device _dev_inbound $_int_inbound
+	network_get_device _dev_outbound $_int_outbound
 
 	default_conf if_inbound $_dev_inbound
 	default_conf if_outbound $_dev_outbound


### PR DESCRIPTION
Function 'network_get_physdev' doesn't work with wireguard interfaces, fix this by changing the function to 'network_get_device'

Maintainer: @micmac1