### PR TITLE
siproxd: init requires that interface_inbound and interface_outbound …

### DIFF
--- a/net/siproxd/files/siproxd.init
+++ b/net/siproxd/files/siproxd.init
@@ -51,24 +51,28 @@ append_conf() {
 
 setup_networks() {
 	local sec="$1"
-	local _int_inbound _int_outbound
-	local _dev_inbound _dev_outbound
+	local _int _dev _up
 
-	config_get _int_inbound "$sec" interface_inbound
-	[ -z $_int_inbound ] && die 1 "$sec.interface_inbound not defined"
-	config_get _int_outbound "$sec" interface_outbound
-	[ -z $_int_outbound ] && die 1 "$sec.interface_outbound not defined"
+	for _role in inbound outbound; do
+		config_get _int "$sec" interface_$_role
+		[ -z $_int ] && die 1 "$sec.interface_$_role not defined"
 
-	. /lib/functions/network.sh
-	ubus -t 30 wait_for network.interface.$_int_inbound 2>/dev/null
-	network_get_device _dev_inbound $_int_inbound
-	[ -z $_dev_inbound ] && die 1 "$sec.interface_inbound, $_int_inbound isn't a valid interface"
-	ubus -t 30 wait_for network.interface.$_int_outbound 2>/dev/null
-	network_get_device _dev_outbound $_int_outbound
-	[ -z $_dev_outbound ] && die 1 "$sec.interface_outbound, $_int_outbound isn't a valid interface"
+		ubus -t 30 wait_for network.interface.$_int 2> /dev/null || die 1 "$sec.interface_$_role - $_int isn't a valid interface"
 
-	default_conf if_inbound $_dev_inbound
-	default_conf if_outbound $_dev_outbound
+		for i in `seq 30`; do
+			if [ -z $_dev ]; then
+				_dev=`ifstatus $_int | jsonfilter -qe '$.l3_device'`
+			else
+				_up=`ifstatus $_int | jsonfilter -qe '$.up'`
+				[ $_up = true ] && break
+			fi
+
+			[ $i -eq 30 ] && die 1 "$sec.interface_$_role - $_int timeout, interface not up"
+			sleep 1
+		done
+
+		default_conf if_$_role $_dev
+	done
 }
 
 # Apply default values to key options if unset in user's UCI config.


### PR DESCRIPTION
…be set

siproxd will not work without if_inbound and if_outbound defined in the config file. Tell meaningful error about interface_inbound and interface_outbound

Maintainer: @micmac1 

Signed-off-by: Azureit azurite@mailfence.com