### PR TITLE
asterisk-chan-sccp: autoconf fixes

### DIFF
--- a/net/asterisk-chan-sccp/Makefile
+++ b/net/asterisk-chan-sccp/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk-chan-sccp
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 # Updated to v4.3.3 release
 PKG_SOURCE_URL:=https://github.com/chan-sccp/chan-sccp.git
@@ -25,6 +25,9 @@ PKG_LICENSE_FILES:=COPYING LICENSE
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
 PKG_INSTALL:=1
+
+# need iconv.m4, otherwise error during autoreconf
+PKG_BUILD_DEPENDS:=gettext-full
 
 include $(INCLUDE_DIR)/package.mk
 # chan-sccp needs iconv

--- a/net/asterisk-chan-sccp/patches/01-prevent-extra-optimization.patch
+++ b/net/asterisk-chan-sccp/patches/01-prevent-extra-optimization.patch
@@ -1,6 +1,6 @@
 --- a/autoconf/extra.m4
 +++ b/autoconf/extra.m4
-@@ -491,17 +491,6 @@ AC_DEFUN([CS_ENABLE_OPTIMIZATION], [
+@@ -516,17 +516,6 @@ AC_DEFUN([CS_ENABLE_OPTIMIZATION], [
  			], SUPPORTED_CFLAGS)
  		])
  		AC_SUBST([strip_binaries])
@@ -16,5 +16,5 @@
 -		esac
 -		CFLAGS_saved="${CFLAGS_saved} ${optimize_flag} "
  	])
- 
+ 	
  	AS_IF([test "X${enable_debug}" == "Xyes"], [

--- a/net/asterisk-chan-sccp/patches/02-autoconf-2.70.patch
+++ b/net/asterisk-chan-sccp/patches/02-autoconf-2.70.patch
@@ -1,0 +1,11 @@
+--- a/autoconf/acinclude.m4
++++ b/autoconf/acinclude.m4
+@@ -497,7 +497,7 @@ AC_DEFUN([CS_GET_VERSION], [
+   SCCP_REVISION="unknown"
+ 
+   CURRENT=`pwd`
+-  BASE=`dirname $ac_dir`
++  BASE=`dirname $ac_aux_dir`
+   cd $BASE >/dev/null
+   . ./tools/versioncheck silent
+   cd $CURRENT >/dev/null

--- a/net/asterisk-chan-sccp/patches/100-reproducible-builds.patch
+++ b/net/asterisk-chan-sccp/patches/100-reproducible-builds.patch
@@ -1,8 +1,6 @@
-Index: chan-sccp-v4.3.0-20171123/src/chan_sccp.c
-===================================================================
---- chan-sccp-v4.3.0-20171123.orig/src/chan_sccp.c
-+++ chan-sccp-v4.3.0-20171123/src/chan_sccp.c
-@@ -186,7 +186,7 @@ boolean_t sccp_postPBX_load(void)
+--- a/src/chan_sccp.c
++++ b/src/chan_sccp.c
+@@ -198,7 +198,7 @@ boolean_t sccp_postPBX_load(void)
  #else
  	snprintf(SCCP_REVISIONSTR, sizeof(SCCP_REVISIONSTR), "%s", SCCP_REVISION);
  #endif


### PR DESCRIPTION
Since OpenWrt updated autoconf to 2.71 configure fails, because "$ac_dir" is now empty when configure attempts to run "./tools/versioncheck". With previous autoconf "$ac_dir" contained "autoconf" at this point in the script.

As a workaround "$ac_dir" is replaced with "$ac_aux_dir", which incidentally contains "autoconf".

Also a build dependency is added for gettext-full, as it provides iconv.m4. Previously this was provided by libiconv, but not anymore. Without iconv.m4 autoreconf fails.

Some patches were refreshed to allow CI to pass.

Maintainer: @jslachta 
Compile tested: SDK master
Run tested: N/A, build fix
Description: Fix autoconf issues

FIY @dkgroot would be nice to have this upstream. Are you OK with the $ac_aux_dir approach? If yes happy to send pull request.
