### PR TITLE
[22.03] freeswitch: backport commit "allow building with OpenSSL 3.0"

### DIFF
--- a/net/freeswitch/Makefile
+++ b/net/freeswitch/Makefile
@@ -237,6 +237,9 @@ FS_PERL_FEED:=$(TOPDIR)/feeds/packages/lang/perl
 include $(TOPDIR)/feeds/packages/lang/python/python3-version.mk
 include $(FS_PERL_FEED)/perlver.mk
 
+# Allow compiling with OpenSSL 3.0
+TARGET_CFLAGS+=-Wno-error=deprecated-declarations
+
 PERL_SITELIB:=/usr/lib/perl$(PERL_MAJOR)/$(PERL_VERSION2)
 
 FS_PERL_LIBS:=$(shell grep "^libs=" \


### PR DESCRIPTION
Cherry pick commit 09ad78b6cce247f4e610be006d89dfe70003aa58 which should resolve build issue.

```
  CC       src/libfreeswitch_la-switch_hashtable.lo
src/switch_curl.c: In function 'switch_curl_process_form_post_params':
src/switch_curl.c:90:41: error: 'curl_formadd' is deprecated: since 7.56.0. Use curl_mime_init() [-Werror=deprecated-declarations]
   90 |                                         curl_formadd(&formpost,
      |                                         ^~~~~~~~~~~~
```

I'm guessing this is related to recent curl update in 22.03 branch.

Maintainer: me
Compile tested: N/A
Run tested: N/A

Description: backport build fix
