### PR TITLE
kamailio: add patches for app_python3

### DIFF
--- a/net/kamailio/Makefile
+++ b/net/kamailio/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio
 PKG_VERSION:=5.6.2
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://www.kamailio.org/pub/kamailio/$(PKG_VERSION)/src
 PKG_SOURCE:=kamailio-$(PKG_VERSION)_src.tar.gz

--- a/net/kamailio/patches/170-app_python3-use-new-Python-3.10-API-functions-for-tr.patch
+++ b/net/kamailio/patches/170-app_python3-use-new-Python-3.10-API-functions-for-tr.patch
@@ -1,0 +1,60 @@
+From b8bf86eb11a17c853450e5c7f81d2446cf719fbc Mon Sep 17 00:00:00 2001
+From: Daniel-Constantin Mierla <miconda@gmail.com>
+Date: Thu, 21 Jul 2022 20:15:29 +0200
+Subject: [PATCH] app_python3: use new Python 3.10+ API functions for tracking
+ execution
+
+- GH #3187
+---
+ src/modules/app_python3/apy_kemi.c | 23 ++++++++++++++++++++++-
+ 1 file changed, 22 insertions(+), 1 deletion(-)
+
+--- a/src/modules/app_python3/apy_kemi.c
++++ b/src/modules/app_python3/apy_kemi.c
+@@ -1810,6 +1810,9 @@ PyObject *sr_apy_kemi_exec_func(PyObject
+ 	PyObject *ret = NULL;
+ 	PyThreadState *pstate = NULL;
+ 	PyFrameObject *pframe = NULL;
++#if PY_VERSION_HEX >= 0x03100000
++	PyCodeObject *pcode = NULL;
++#endif
+ 	struct timeval tvb = {0}, tve = {0};
+ 	struct timezone tz;
+ 	unsigned int tdiff;
+@@ -1832,10 +1835,27 @@ PyObject *sr_apy_kemi_exec_func(PyObject
+ 				   + (tve.tv_usec - tvb.tv_usec);
+ 		if(tdiff >= cfg_get(core, core_cfg, latency_limit_action)) {
+ 			pstate = PyThreadState_GET();
+-			if (pstate != NULL && pstate->frame != NULL) {
++			if (pstate != NULL) {
++#if PY_VERSION_HEX >= 0x03100000
++				pframe = PyThreadState_GetFrame(pstate);
++				if(pframe != NULL) {
++					pcode = PyFrame_GetCode(pframe);
++				}
++#else
+ 				pframe = pstate->frame;
++#endif
+ 			}
+ 
++#if PY_VERSION_HEX >= 0x03100000
++			LOG(cfg_get(core, core_cfg, latency_log),
++					"alert - action KSR.%s%s%s(...)"
++					" took too long [%u ms] (file:%s func:%s line:%d)\n",
++					(ket->mname.len>0)?ket->mname.s:"",
++					(ket->mname.len>0)?".":"", ket->fname.s, tdiff,
++					(pcode)?PyBytes_AsString(pcode->co_filename):"",
++					(pcode)?PyBytes_AsString(pcode->co_name):"",
++					(pframe)?PyFrame_GetLineNumber(pframe):0);
++#else
+ 			LOG(cfg_get(core, core_cfg, latency_log),
+ 					"alert - action KSR.%s%s%s(...)"
+ 					" took too long [%u ms] (file:%s func:%s line:%d)\n",
+@@ -1844,6 +1864,7 @@ PyObject *sr_apy_kemi_exec_func(PyObject
+ 					(pframe && pframe->f_code)?PyBytes_AsString(pframe->f_code->co_filename):"",
+ 					(pframe && pframe->f_code)?PyBytes_AsString(pframe->f_code->co_name):"",
+ 					(pframe && pframe->f_code)?PyCode_Addr2Line(pframe->f_code, pframe->f_lasti):0);
++#endif
+ 		}
+ 	}
+ 

--- a/net/kamailio/patches/171-app_python3-proper-check-of-PY_VERSION_HEX-for-pytho.patch
+++ b/net/kamailio/patches/171-app_python3-proper-check-of-PY_VERSION_HEX-for-pytho.patch
@@ -1,0 +1,38 @@
+From 8546fb87e3277b675bd47eba9435f739cf3bb69d Mon Sep 17 00:00:00 2001
+From: Daniel-Constantin Mierla <miconda@gmail.com>
+Date: Fri, 13 Jan 2023 12:33:20 +0100
+Subject: [PATCH] app_python3: proper check of PY_VERSION_HEX for python 3.11
+
+---
+ src/modules/app_python3/apy_kemi.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/src/modules/app_python3/apy_kemi.c
++++ b/src/modules/app_python3/apy_kemi.c
+@@ -1810,7 +1810,7 @@ PyObject *sr_apy_kemi_exec_func(PyObject
+ 	PyObject *ret = NULL;
+ 	PyThreadState *pstate = NULL;
+ 	PyFrameObject *pframe = NULL;
+-#if PY_VERSION_HEX >= 0x03100000
++#if PY_VERSION_HEX >= 0x030B0000
+ 	PyCodeObject *pcode = NULL;
+ #endif
+ 	struct timeval tvb = {0}, tve = {0};
+@@ -1836,7 +1836,7 @@ PyObject *sr_apy_kemi_exec_func(PyObject
+ 		if(tdiff >= cfg_get(core, core_cfg, latency_limit_action)) {
+ 			pstate = PyThreadState_GET();
+ 			if (pstate != NULL) {
+-#if PY_VERSION_HEX >= 0x03100000
++#if PY_VERSION_HEX >= 0x030B0000
+ 				pframe = PyThreadState_GetFrame(pstate);
+ 				if(pframe != NULL) {
+ 					pcode = PyFrame_GetCode(pframe);
+@@ -1846,7 +1846,7 @@ PyObject *sr_apy_kemi_exec_func(PyObject
+ #endif
+ 			}
+ 
+-#if PY_VERSION_HEX >= 0x03100000
++#if PY_VERSION_HEX >= 0x030B0000
+ 			LOG(cfg_get(core, core_cfg, latency_log),
+ 					"alert - action KSR.%s%s%s(...)"
+ 					" took too long [%u ms] (file:%s func:%s line:%d)\n",

--- a/net/kamailio/patches/172-app_python3-use-Py_SET_TYPE-from-python-3.9.patch
+++ b/net/kamailio/patches/172-app_python3-use-Py_SET_TYPE-from-python-3.9.patch
@@ -1,0 +1,23 @@
+From fc75b4c3f8f9bdba320f74ddf942686c09316b56 Mon Sep 17 00:00:00 2001
+From: Daniel-Constantin Mierla <miconda@gmail.com>
+Date: Fri, 13 Jan 2023 12:41:12 +0100
+Subject: [PATCH] app_python3: use Py_SET_TYPE() from python 3.9
+
+---
+ src/modules/app_python3/python_msgobj.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/src/modules/app_python3/python_msgobj.c
++++ b/src/modules/app_python3/python_msgobj.c
+@@ -507,7 +507,11 @@ static PyTypeObject MSGtype = {
+ 
+ int python_msgobj_init(void)
+ {
++#if PY_VERSION_HEX >= 0x03090000
++	Py_SET_TYPE(&MSGtype, &PyType_Type);
++#else
+ 	Py_TYPE(&MSGtype) = &PyType_Type;
++#endif
+ 	if (PyType_Ready(&MSGtype) < 0)
+ 		return -1;
+ 	return 0;


### PR DESCRIPTION
Python was updated to 3.11 and app_python3 doesn't compile anymore. This commit adds three upstream patches to resolve this.

Maintainer: @jslachta (I'll merge this once CI is done)
Compile tested: ath79 sdk
Run tested: N/A

Description:
