### PR TITLE
pjproject: bump to 2.13.1

### DIFF
--- a/libs/pjproject/Makefile
+++ b/libs/pjproject/Makefile
@@ -10,14 +10,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pjproject
-PKG_VERSION:=2.13
+PKG_VERSION:=2.13.1
 PKG_RELEASE:=1
 
 # download "vX.Y.tar.gz" as "pjproject-vX.Y.tar.gz"
 PKG_SOURCE_URL_FILE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_URL_FILE)
-PKG_SOURCE_URL:=https://github.com/pjsip/$(PKG_NAME)/archive
-PKG_HASH:=4178bb9f586299111463fc16ea04e461adca4a73e646f8ddef61ea53dafa92d9
+PKG_SOURCE_URL:=https://github.com/pjsip/$(PKG_NAME)/archive/refs/tags
+PKG_HASH:=32a5ab5bfbb9752cb6a46627e4c410e61939c8dbbd833ac858473cfbd9fb9d7d
 PKG_INSTALL:=1
 
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
1. add "/refs/tags" to PKG_SOURCE_URL, otherwise the downloaded file is broken now
2. bump minor version, includes security related fixes, see [1], [2] and [3]

[1] https://github.com/pjsip/pjproject/security/advisories/GHSA-9pfh-r8x4-w26w
[2] https://github.com/pjsip/pjproject/security/advisories/GHSA-cxwq-5g9x-x7fr
[3] https://github.com/pjsip/pjproject/security/advisories/GHSA-q9cp-8wcq-7pfr

Maintainer: @jslachta 
Compile tested: master sdk ath79
Run tested: N/A

Description:
upstream security fixes