### PR TITLE
[22.03] asterisk: add upstream patch against iax2 crash

### DIFF
--- a/net/asterisk/Makefile
+++ b/net/asterisk/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk
 PKG_VERSION:=18.15.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases

--- a/net/asterisk/patches/180-chan_iax2.c-Avoid-crash-with-IAX2-switch-support.patch
+++ b/net/asterisk/patches/180-chan_iax2.c-Avoid-crash-with-IAX2-switch-support.patch
@@ -1,0 +1,25 @@
+From 39912b91384b4a6a4b4b34cdd338970c184fb096 Mon Sep 17 00:00:00 2001
+From: Sean Bright <sean@seanbright.com>
+Date: Fri, 7 Jul 2023 15:57:39 -0400
+Subject: [PATCH] chan_iax2.c: Avoid crash with IAX2 switch support.
+
+A change made in 82cebaa0 did not properly handle the case when a
+channel was not provided, triggering a crash. ast_check_hangup(...)
+does not protect against NULL pointers.
+
+Fixes #180
+---
+ channels/chan_iax2.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/channels/chan_iax2.c
++++ b/channels/chan_iax2.c
+@@ -14312,7 +14312,7 @@ static struct iax2_dpcache *find_cache(s
+ 			ast_log(LOG_WARNING, "Timeout waiting for %s exten %s\n", data, exten);
+ 		}
+ 
+-		if (ast_check_hangup(chan)) {
++		if (chan && ast_check_hangup(chan)) {
+ 			doabort = 1;
+ 		}
+ 


### PR DESCRIPTION
Reported by Sergio in issue #821. This adds upstream patch for the crash. See upstream issue [1] for details.

[1] https://github.com/asterisk/asterisk/issues/180

Maintainer: @jslachta 
Compile tested: sdk 22.03
Run tested: N/A

Description: Patch taken from asterisk "18" branch

Closes #821 
