### PR TITLE
Add CPE ID for asterisk and pjproject

### DIFF
--- a/libs/pjproject/Makefile
+++ b/libs/pjproject/Makefile
@@ -12,6 +12,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=pjproject
 PKG_VERSION:=2.13.1
 PKG_RELEASE:=1
+PKG_CPE_ID:=cpe:/a:pjsip:pjsip
 
 # download "vX.Y.tar.gz" as "pjproject-vX.Y.tar.gz"
 PKG_SOURCE_URL_FILE:=$(PKG_VERSION).tar.gz

--- a/net/asterisk/Makefile
+++ b/net/asterisk/Makefile
@@ -10,6 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=asterisk
 PKG_VERSION:=20.3.0
 PKG_RELEASE:=2
+PKG_CPE_ID:=cpe:/a:digium:asterisk
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases


### PR DESCRIPTION
Maintainer: @micmac1 
Compile tested: x86 / 64 / master
Run tested: no run tests done, given the nature of the change it should be alright

Description:
Add CPE IDs for Asterisk and pjproject
