### PR TITLE
[23.05] freeswitch: add patches for CVEs in bundled libvpx

### DIFF
--- a/net/freeswitch/Makefile
+++ b/net/freeswitch/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freeswitch
 PKG_VERSION:=1.10.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=Sebastian Kemper <sebastian_ml@gmx.net>
 
 PKG_SOURCE:=freeswitch-$(PKG_VERSION).-release.tar.xz

--- a/net/freeswitch/patches/500-libvpx-VP8-disallow-thread-count-changes.patch
+++ b/net/freeswitch/patches/500-libvpx-VP8-disallow-thread-count-changes.patch
@@ -1,0 +1,23 @@
+From 6f9e72c585265d8def8a613b36cd4f524c201980 Mon Sep 17 00:00:00 2001
+From: Andrey Volk <andywolk@gmail.com>
+Date: Wed, 4 Oct 2023 00:47:39 +0300
+Subject: [PATCH] [libvpx] VP8: disallow thread count changes
+
+---
+ libs/libvpx/vp8/encoder/onyx_if.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/libs/libvpx/vp8/encoder/onyx_if.c
++++ b/libs/libvpx/vp8/encoder/onyx_if.c
+@@ -1447,6 +1447,11 @@ void vp8_change_config(VP8_COMP *cpi, VP
+   last_h = cpi->oxcf.Height;
+   prev_number_of_layers = cpi->oxcf.number_of_layers;
+ 
++  if (cpi->initial_width) {
++      // TODO(https://crbug.com/1486441): Allow changing thread counts; the
++      // allocation is done once in vp8_create_compressor().
++      oxcf->multi_threaded = cpi->oxcf.multi_threaded;
++  }
+   cpi->oxcf = *oxcf;
+ 
+   switch (cpi->oxcf.Mode) {

--- a/net/freeswitch/patches/501-libvpx-Fix-bug-with-smaller-width-bigger-size.patch
+++ b/net/freeswitch/patches/501-libvpx-Fix-bug-with-smaller-width-bigger-size.patch
@@ -1,0 +1,88 @@
+From 2ab7a3d323984a4df969ea19dadf86213308a361 Mon Sep 17 00:00:00 2001
+From: Andrey Volk <andywolk@gmail.com>
+Date: Fri, 6 Oct 2023 00:42:10 +0300
+Subject: [PATCH] [libvpx] Fix bug with smaller width bigger size
+
+---
+ libs/libvpx/vp9/common/vp9_alloccommon.c | 12 +++++------
+ libs/libvpx/vp9/encoder/vp9_encoder.c    | 27 ++++++++++++++++++++++--
+ 2 files changed, 31 insertions(+), 8 deletions(-)
+
+--- a/libs/libvpx/vp9/common/vp9_alloccommon.c
++++ b/libs/libvpx/vp9/common/vp9_alloccommon.c
+@@ -123,12 +123,6 @@ int vp9_alloc_context_buffers(VP9_COMMON
+     if (cm->alloc_mi(cm, new_mi_size)) goto fail;
+   }
+ 
+-  if (cm->seg_map_alloc_size < cm->mi_rows * cm->mi_cols) {
+-    // Create the segmentation map structure and set to 0.
+-    free_seg_map(cm);
+-    if (alloc_seg_map(cm, cm->mi_rows * cm->mi_cols)) goto fail;
+-  }
+-
+   if (cm->above_context_alloc_cols < cm->mi_cols) {
+     vpx_free(cm->above_context);
+     cm->above_context = (ENTROPY_CONTEXT *)vpx_calloc(
+@@ -143,6 +137,12 @@ int vp9_alloc_context_buffers(VP9_COMMON
+     cm->above_context_alloc_cols = cm->mi_cols;
+   }
+ 
++  if (cm->seg_map_alloc_size < cm->mi_rows * cm->mi_cols) {
++    // Create the segmentation map structure and set to 0.
++    free_seg_map(cm);
++    if (alloc_seg_map(cm, cm->mi_rows * cm->mi_cols)) goto fail;
++  }
++
+   if (vp9_alloc_loop_filter(cm)) goto fail;
+ 
+   return 0;
+--- a/libs/libvpx/vp9/encoder/vp9_encoder.c
++++ b/libs/libvpx/vp9/encoder/vp9_encoder.c
+@@ -1915,6 +1915,17 @@ static void alloc_copy_partition_data(VP
+   }
+ }
+ 
++static void free_copy_partition_data(VP9_COMP *cpi) {
++  vpx_free(cpi->prev_partition);
++  cpi->prev_partition = NULL;
++  vpx_free(cpi->prev_segment_id);
++  cpi->prev_segment_id = NULL;
++  vpx_free(cpi->prev_variance_low);
++  cpi->prev_variance_low = NULL;
++  vpx_free(cpi->copied_frame_cnt);
++  cpi->copied_frame_cnt = NULL;
++}
++
+ void vp9_change_config(struct VP9_COMP *cpi, const VP9EncoderConfig *oxcf) {
+   VP9_COMMON *const cm = &cpi->common;
+   RATE_CONTROL *const rc = &cpi->rc;
+@@ -1999,6 +2010,8 @@ void vp9_change_config(struct VP9_COMP *
+     new_mi_size = cm->mi_stride * calc_mi_size(cm->mi_rows);
+     if (cm->mi_alloc_size < new_mi_size) {
+       vp9_free_context_buffers(cm);
++      vp9_free_pc_tree(&cpi->td);
++      vpx_free(cpi->mbmi_ext_base);
+       alloc_compressor_data(cpi);
+       realloc_segmentation_maps(cpi);
+       cpi->initial_width = cpi->initial_height = 0;
+@@ -2014,8 +2027,18 @@ void vp9_change_config(struct VP9_COMP *
+     update_frame_size(cpi);
+ 
+   if (last_w != cpi->oxcf.width || last_h != cpi->oxcf.height) {
+-    memset(cpi->consec_zero_mv, 0,
+-           cm->mi_rows * cm->mi_cols * sizeof(*cpi->consec_zero_mv));
++    vpx_free(cpi->consec_zero_mv);
++    CHECK_MEM_ERROR(
++        cm, cpi->consec_zero_mv,
++        vpx_calloc(cm->mi_rows * cm->mi_cols, sizeof(*cpi->consec_zero_mv)));
++
++    vpx_free(cpi->skin_map);
++    CHECK_MEM_ERROR(
++        cm, cpi->skin_map,
++        vpx_calloc(cm->mi_rows * cm->mi_cols, sizeof(cpi->skin_map[0])));
++
++    free_copy_partition_data(cpi);
++    alloc_copy_partition_data(cpi);
+     if (cpi->oxcf.aq_mode == CYCLIC_REFRESH_AQ)
+       vp9_cyclic_refresh_reset_resize(cpi);
+     rc->rc_1_frame = 0;


### PR DESCRIPTION
CVE-2023-5217
CVE-2023-44488

Patches are for bundled libvpx, see [1].

[1] https://github.com/signalwire/freeswitch/issues/2258

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>
(cherry picked from commit 26e09b2914af221e477a65f1ec92db48b9a9979a)

Maintainer: me
Compile tested: master
Run tested: N/A
Description:
