### PR TITLE
yate: Update yate script to use an nftables set

### DIFF
--- a/net/yate/Makefile
+++ b/net/yate/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yate
 PKG_VERSION:=6.4.0-1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://yate.null.ro/tarballs/yate6/


### PR DESCRIPTION
Maintainer: @jslachta
Compile tested: -
Run tested: Netgear R6220, 23.05.0-rc3

By using an nftables set in this script it's easier to install and use this script now that OpenWrt uses nftables by default.
