### PR TITLE
siproxd: improve network device resolution

### DIFF
--- a/net/siproxd/Makefile
+++ b/net/siproxd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=siproxd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/hb9xar/siproxd.git
@@ -24,6 +24,7 @@ PKG_CONFIG_DEPENDS:=CONFIG_SIPROXD_MAX_CLIENTS
 
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
+PKG_MAINTAINER:=Tony Ambardar <itugrok@yahoo.com>
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/net/siproxd/files/siproxd.init
+++ b/net/siproxd/files/siproxd.init
@@ -39,6 +39,12 @@ append_conf() {
 	echo $* >> "$CONF_DIR/siproxd-$sec.conf"
 }
 
+# Resolve network device by layer 3 first, then layer 2
+
+siproxd_get_device() {
+	network_get_device $1 $2 || network_get_physdev $1 $2
+}
+
 # Use user-friendly network names (e.g. "wan", "lan") from options
 # 'interface_inbound' and 'interface_outbound', but use standard siproxd
 # parameters 'if_inbound' and 'if_outbound' if explicitly set.
@@ -51,9 +57,8 @@ setup_networks() {
 	config_get _int_inbound "$sec" interface_inbound
 	config_get _int_outbound "$sec" interface_outbound
 
-	. /lib/functions/network.sh
-	network_get_physdev _dev_inbound $_int_inbound
-	network_get_physdev _dev_outbound $_int_outbound
+	siproxd_get_device _dev_inbound $_int_inbound
+	siproxd_get_device _dev_outbound $_int_outbound
 
 	default_conf if_inbound $_dev_inbound
 	default_conf if_outbound $_dev_outbound
@@ -165,6 +170,7 @@ start_service() {
 	chmod 755 "$CONF_DIR" "$REG_DIR" "$PID_DIR"
 	chown "$SIPROXD_UID:$SIPROXD_GID" "$REG_DIR"
 
+	. /lib/functions/network.sh
 	siproxd_cb
 	config_load 'siproxd'
 }


### PR DESCRIPTION
**Maintainer**: @micmac1 @jslachta

**Description**:
Resolve network devices by first trying `network_get_device` (L3) and falling back to `network_get_physdev` (L2) on failure, which allows using Wireguard interfaces. Both are needed to avoid breaking existing usage for some interfaces (e.g. `wan`).

Also add myself as a maintainer.

This might help or fix #800, but I can't reproduce the error myself and don't have a VOIP-over-Wireguard setup at hand.

**Testing**:
Compile tested for ipq40xx, targeting EA6350v3 device on master.

Run tested on EA6350v3 with 23.05.2.
Checked problems with `network_get_device` and `network_get_physdev` from CLI, and confirmed siproxd config file `/var/etc/siproxd/siproxd-general.conf` contains correct `wg` interface after startup with this change.