### PR TITLE
rtpengine: bump to 11.5.1.18

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=rtpengine
-PKG_VERSION:=11.5.1.12
+PKG_VERSION:=11.5.1.18
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-mr$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sipwise/rtpengine/tar.gz/mr$(PKG_VERSION)?
-PKG_HASH:=76a16d00926838cdb16b0004043c2476115b8481f85eff454d5134204c780d47
+PKG_HASH:=d5b0288ec02164b13730c14976425160d9a0b42b1c74796f8d9e59649e705fa6
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-mr$(PKG_VERSION)
 
@@ -51,6 +51,7 @@ ENGINE_DEPENDS := \
 	+libpcre2 \
 	+libwebsockets-openssl \
 	+libopus \
+	+xmlrpc-c \
 	+xmlrpc-c-client \
 	+zlib
 


### PR DESCRIPTION
Add missing xmlrpc-c dependency.

Maintainer: Jiri + me
Compile tested: master ath79
Run tested: N/A

Description: this should fix compile issues we're having currently in master
