### PR TITLE
[22.03] rtpengine: security bump to 9.5.8.2

### DIFF
--- a/net/rtpengine/Makefile
+++ b/net/rtpengine/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=rtpengine
-PKG_VERSION:=9.5.3.2
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_VERSION:=9.5.8.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-mr$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/sipwise/rtpengine/tar.gz/mr$(PKG_VERSION)?
-PKG_HASH:=03d8da1b5efcaa17ef88f306046f49e30ca87b3998c26a13bd96df922f8e729f
+PKG_HASH:=9125506f86741159fa6e09eba426fb66bc052cfdbec8897596eeee4c41b2172e
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-mr$(PKG_VERSION)
 


### PR DESCRIPTION
Fixes "RTPEngine susceptible to Denial of Service via DTLS Hello packets during call initiation", see [1].

[1] https://www.openwall.com/lists/oss-security/2023/12/15/8

Maintainer: @jslachta & me
Compile tested: sdk 22.03
Run tested: N/A

Description:
