### PR TITLE
asterisk-chan-lantiq: add user 'asterisk' to 'vmmc' group

### DIFF
--- a/net/asterisk-chan-lantiq/Makefile
+++ b/net/asterisk-chan-lantiq/Makefile
@@ -31,6 +31,7 @@ define Package/$(PKG_NAME)
   TITLE:=Lantiq channel driver
   URL:=https://github.com/kochstefan/asterisk_channel_lantiq
   DEPENDS:=+asterisk +kmod-ltq-vmmc
+  USERID:=asterisk=385::vmmc=386
 endef
 
 define Package/$(PKG_NAME)/description


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: lantiq/xrx200
Run tested: arcadyan,vgv7510kw22-nor

Description:
Make sure asterisk has permission to access /dev/vmmc* devices as it will segfault if started without.