### PR TITLE
[22.03] baresip: fix init script and parallel build

### DIFF
--- a/net/baresip/Makefile
+++ b/net/baresip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=baresip
 PKG_VERSION:=1.1.0
-PKG_RELEASE:=$(AUTORELEASE)
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/baresip/baresip/tar.gz/v$(PKG_VERSION)?

--- a/net/baresip/files/baresip.init
+++ b/net/baresip/files/baresip.init
@@ -21,7 +21,7 @@ start_service() {
   if [ "$ENABLE_BARESIP" != yes ]; then
     $LOGGER User configuration incomplete - not starting $DAEMON
     $LOGGER Check ENABLE_BARESIP in $DEFAULT
-    exit 1
+    return 1
   fi
 
   procd_open_instance

--- a/net/baresip/patches/010-fix-parallel-build.patch
+++ b/net/baresip/patches/010-fix-parallel-build.patch
@@ -1,0 +1,23 @@
+From d7aeb9393876af3746dacdbacd70c4a5d6dfcf39 Mon Sep 17 00:00:00 2001
+From: Christian Spielberger <c.spielberger@commend.com>
+Date: Sun, 23 May 2021 10:01:04 +0200
+Subject: [PATCH] ctrl_dbus: add dependency to baresipbus.h (#1447) (#1457)
+
+---
+ modules/ctrl_dbus/module.mk | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/modules/ctrl_dbus/module.mk
++++ b/modules/ctrl_dbus/module.mk
+@@ -16,7 +16,10 @@ $(MOD)_CFLAGS	+= -Wno-unused-parameter -
+ 
+ $(MOD)_CCHECK_OPT	= -e baresipbus.h -e baresipbus.c
+ 
+-modules/ctrl_dbus/baresipbus.h modules/ctrl_dbus/baresipbus.c: \
++modules/$(MOD)/baresipbus.o :	modules/$(MOD)/baresipbus.h
++modules/$(MOD)/ctrl_dbus.o :	modules/$(MOD)/baresipbus.h
++
++modules/$(MOD)/baresipbus.h modules/$(MOD)/baresipbus.c: \
+ 	modules/ctrl_dbus/com.github.Baresip.xml
+ 	@cd $(dir $@) && ./gen.sh
+ 


### PR DESCRIPTION
Maintainer: @micmac1
Compile tested: mvebu, Turris Omnia, Turris OS 7 = OpenWrt 22.03
Run tested: mvebu, Turris Omnia, Turris OS 7 = OpenWrt 22.03

Description:
The build of the baresip package sometimes fails for us with the error mentioned in the commit message. After rebase to this patch everything works.
