### PR TITLE
asterisk-chan-lantiq: import patches improving log output

### DIFF
--- a/net/asterisk-chan-lantiq/Makefile
+++ b/net/asterisk-chan-lantiq/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk-chan-lantiq
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://github.com/kochstefan/asterisk_channel_lantiq.git
 PKG_SOURCE_VERSION:=2f029ec8778420538c8151c6aceba0f7b44b07c9

--- a/net/asterisk-chan-lantiq/patches/0003-use-channel_state-enum.patch
+++ b/net/asterisk-chan-lantiq/patches/0003-use-channel_state-enum.patch
@@ -1,0 +1,32 @@
+From 1fded33e58cb57a6c67195bd7cd822a25c0c073d Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sat, 29 Jun 2024 01:05:51 +0100
+Subject: [PATCH 1/2] use channel_state enum
+
+Make compiler aware of finite states listed in enum.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ src/channels/chan_lantiq.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/src/channels/chan_lantiq.c
++++ b/src/channels/chan_lantiq.c
+@@ -141,7 +141,7 @@ enum channel_state {
+ static struct lantiq_pvt {
+ 	struct ast_channel *owner;       /* Channel we belong to, possibly NULL   */
+ 	int port_id;                     /* Port number of this object, 0..n      */
+-	int channel_state;
++	enum channel_state channel_state;/* Current state of the channel          */
+ 	char context[AST_MAX_CONTEXT];   /* this port's dialplan context          */
+ 	int dial_timer;                  /* timer handle for autodial timeout     */
+ 	char dtmfbuf[AST_MAX_EXTENSION]; /* buffer holding dialed digits          */
+@@ -1401,6 +1401,8 @@ static int lantiq_dev_event_hook(int c,
+ 			case INCALL:
+ 				ret = lantiq_end_call(c);
+ 				break;
++			default:
++				break;
+ 		}
+ 
+ 		iflist[c].channel_state = ONHOOK;

--- a/net/asterisk-chan-lantiq/patches/0004-report-state-in-lantiq_dev_event_digit.patch
+++ b/net/asterisk-chan-lantiq/patches/0004-report-state-in-lantiq_dev_event_digit.patch
@@ -1,0 +1,24 @@
+From c1af296bac46a828f16c616f0f470b0d525e7860 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sat, 29 Jun 2024 01:12:47 +0100
+Subject: [PATCH 2/2] report state in lantiq_dev_event_digit
+
+Inform user about channel state in case of unhandled digit.
+As it is not really an error, use NOTICE log level instead of ERROR.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ src/channels/chan_lantiq.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/channels/chan_lantiq.c
++++ b/src/channels/chan_lantiq.c
+@@ -1574,7 +1574,7 @@ static void lantiq_dev_event_digit(int c
+ 			}
+ 			break;
+ 		default:
+-			ast_log(LOG_ERROR, "don't know what to do in unhandled state\n");
++			ast_log(LOG_NOTICE, "don't know what to do in unhandled state %s\n", state_string(pvt->channel_state));
+ 			break;
+ 	}
+ 

--- a/net/asterisk-chan-lantiq/patches/0005-inform-requester-about-busy-channel.patch
+++ b/net/asterisk-chan-lantiq/patches/0005-inform-requester-about-busy-channel.patch
@@ -1,0 +1,23 @@
+From cdc77d6f9388c42bd6e21666b8a4d5789e93d05e Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sat, 29 Jun 2024 01:20:16 +0100
+Subject: [PATCH] inform requester about busy channel
+
+Set cause to AST_CAUSE_USER_BUSY if requesting the channel failed
+due to being offhook already.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ src/channels/chan_lantiq.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/src/channels/chan_lantiq.c
++++ b/src/channels/chan_lantiq.c
+@@ -1283,6 +1283,7 @@ static struct ast_channel *ast_lantiq_re
+ 	/* Bail out if channel is already in use */
+ 	struct lantiq_pvt *pvt = &iflist[port_id];
+ 	if (! pvt->channel_state == ONHOOK) {
++		*cause = AST_CAUSE_USER_BUSY;
+ 		ast_debug(1, "TAPI channel %i alread in use.\n", port_id+1);
+ 	} else {
+ 		chan = lantiq_channel(AST_STATE_DOWN, port_id, NULL, NULL, cap, assigned_ids, requestor);


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: lantiq/xrx200 (mips_24kc)
Run tested: arcadyan,vgv7510kw22-nor
Description:

Output channel state in log message if a digit ends up not being handled. Report USER_BUSY as cause in case a phone is not on hook while being called.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>
(cherry picked from commit d1123a245b5a21f3520e2c3d4ad1bfab82a52a9a)
