### PR TITLE
sofia-sip: removed "--disable-stun"

### DIFF
--- a/libs/sofia-sip/Makefile
+++ b/libs/sofia-sip/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=sofia-sip
 
 PKG_VERSION:=1.13.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/freeswitch/$(PKG_NAME)/tar.gz/v${PKG_VERSION}?
@@ -60,7 +60,6 @@ licensed under the LGPL.
 endef
 
 CONFIGURE_ARGS+= \
-	--disable-stun \
 	--without-doxygen \
 	--without-glib
 


### PR DESCRIPTION
Maintainer: @micmac1 
Run tested: (mips, Astoria Networks ARV7518PW,  OpenWrt 23.05.4 r24012-d8dd03c46f , sip registration and made a test sip call)

Description:

I'm trying to update my [svd package](https://github.com/olivluca/danube-voip) for OpenWrt 23.05.4. To compile it I need stun enabled. ~~I'm working on a test repository [here](https://github.com/olivluca/danube-voip-test) where~~  In my repository I adopted this version of the Makefile.
