### PR TITLE
baresip: add uci config section for accounts

### DIFF
--- a/net/baresip/Makefile
+++ b/net/baresip/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=baresip
 PKG_VERSION:=3.16.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/baresip/baresip/tar.gz/v$(PKG_VERSION)?
@@ -142,7 +142,6 @@ define Package/baresip/install
 endef
 
 define Package/baresip/conffiles
-/etc/baresip/accounts
 /etc/baresip/config
 /etc/baresip/contacts
 endef

--- a/net/baresip/files/baresip.defaults
+++ b/net/baresip/files/baresip.defaults
@@ -5,6 +5,23 @@ if [ ! -f "$CFGFILE" ]; then
 config baresip main
 	option enable 0
 	option options ''
+
+config account
+	option user '+49123456789'
+	option password ''
+	option server 'tel.t-online.de'
+	option transport 'tls'
+	option mediaenc 'srtp'
+	option ignore 1
+
+config account
+	option user '12'
+	option password '7282ce22eee6d91193a1d5014398356x'
+	option server '172.27.0.97'
+	option transport 'udp'
+	option mediaenc ''
+	option append 'answerdelay=0;rwait=90;mwi=no'
+	option ignore 1
 EOF
 fi
 

--- a/net/baresip/files/baresip.init
+++ b/net/baresip/files/baresip.init
@@ -4,6 +4,31 @@
 START=92
 USE_PROCD=1
 PROG=/usr/bin/baresip
+ACCOUNTS=
+
+add_account()
+{
+	local user password server transport append ignore mediaenc
+	local acc
+
+	uci_validate_section baresip account "${1}" \
+		'ignore:bool:0' \
+		'user:string' \
+		'password:string' \
+		'server:string' \
+		'transport:string:udp' \
+		'mediaenc:string' \
+		'append:string'
+
+	[ "$ignore" = "0" ] || return
+
+	acc="<sip:${user}@${server};transport=${transport}>"
+	[ -n "$mediaenc" ] && acc="${acc};mediaenc=${mediaenc}"
+	[ -n "$password" ] && acc="${acc};auth_pass=${password}"
+	[ -n "$append" ] && acc="${acc};${append}"
+
+	ACCOUNTS="${ACCOUNTS}${acc}\n"
+}
 
 start_service()
 {
@@ -15,6 +40,10 @@ start_service()
 
 	[ "$enable" = "0" ] && return
 
+	config_load baresip
+	config_foreach add_account account
+	printf "$ACCOUNTS" > /etc/baresip/accounts
+
 	procd_open_instance
 	procd_set_param command $PROG -f /etc/baresip $options
 	procd_set_param user baresip
@@ -25,4 +54,9 @@ start_service()
 service_triggers()
 {
 	procd_add_reload_trigger baresip
+}
+
+reload_service()
+{
+	/etc/init.d/baresip restart
 }


### PR DESCRIPTION
Adds a new UCI config section that allows the user to define accounts from which the init script will create the /etc/baresip/accounts file.

Using UCI has the big benefit, that changes in the config can be recognized by reload_config which will restart baresip automatically.

Example /etc/config/baresip:
--
config baresip main
	option enable 1
	option options ''

config account
	option user '+49123456789'
	option password ''
	option server 'tel.t-online.de'
	option transport 'tls'
	option mediaenc 'srtp'

config account
	option user '12'
	option password '7282ce22eee6d91193a1d5014398356x'
	option server '172.27.0.97'
	option transport 'udp'
	option append 'answerdelay=0;rwait=90;mwi=no'
	option ignore 1
--

The basic account options user,password,server,mediaenc and tansport can be set directly. All other custom baresip account options can be append to the account string using the 'append' option.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
