### PR TITLE
kamailio: Kamailio 6.0.1 uci config and init script fixes

### DIFF
--- a/net/kamailio/Makefile
+++ b/net/kamailio/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kamailio
 PKG_VERSION:=6.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/kamailio/kamailio/archive/refs/tags/
 PKG_SOURCE:=$(PKG_VERSION).tar.gz
@@ -263,6 +263,8 @@ endef
 define Package/kamailio
 $(call Package/kamailio/Default)
   TITLE:=Mature and flexible open source SIP server, v$(PKG_VERSION)
+  USER:=kamailio
+  GROUP:=kamailio
   USERID:=kamailio=380:kamailio=380
   MENU:=1
 endef
@@ -300,6 +302,7 @@ endef
 
 define Package/kamailio/postinst
 #!/bin/sh
+chown "$(USER)":"$(GROUP)" "/etc/kamailio" -R
 if [ -z "$${IPKG_INSTROOT}" ]; then
   echo
   echo "o-------------------------------------------------------------------o"
@@ -412,7 +415,7 @@ MAKE_FLAGS += \
 	LIBDIR=lib \
 	PREFIX=/usr \
 	cfg_prefix="$(PKG_INSTALL_DIR)" \
-	cfg_target=/etc/kamailio \
+	cfg_target=/etc/kamailio/ \
 	group_include="standard" \
 	include_modules="$$(INCL_MODULES) $(EXTRA_MODULES)" \
 	quiet=verbose \

--- a/net/kamailio/files/kamailio.conf
+++ b/net/kamailio/files/kamailio.conf
@@ -1,22 +1,25 @@
 
 config kamailio 'general'
-	option enabled 0
-	option user kamailio
-	option group kamailio
+	option enabled '0'
+	option user 'kamailio'
+	option group 'kamailio'
 	# Amount of shared and private memory to allocate in MByte:
-	option shm_memory 8
-	option pkg_memory 2
+	option shm_memory '8'
+	option pkg_memory '3'
 	option cfg_file /etc/kamailio/kamailio.cfg
-	# The lists "listen" and "listen6" basically have the same
-	# effect - each list entry will be added to the Kamailio command
-	# line ("-l address"). However, the init script will try to
+	option stderr '0'
+	option debug_level '0'
+	# list listen(6) have the same effect - each list entry is added to the
+	# Kamailio command line ("-l address"). The init script will try to
 	# resolve any interface specifier into an IPv4 ("listen") or
-	# IPv6 ("listen6") address before starting Kamailio. These lists
+	# IPv6 ("listen6") address before starting Kamailio. These list listen(6)
 	# may be helpful when using dynamic IPs.
-	#list listen udp:wan:5060
-	#list listen udp:192.168.1.1:5060
-	#list listen6 udp:wan:5060
-	# Any other option can be put between the quotes below:
+	# Examples:
+	# list listen 'udp:wan:5060'
+	# list listen 'udp:192.168.1.1:5060'
+	# list listen6 'udp:wan:5060'
+	# list listen6 'udp:[::1]:5060'
+	# Any other Kamailio start parameter can be put in the options quotes below:
 	#option options ""
 
 config kamailio 'hotplug'

--- a/net/kamailio/files/kamailio.init
+++ b/net/kamailio/files/kamailio.init
@@ -16,116 +16,136 @@ USE_PROCD=1
 #PROCD_DEBUG=1
 
 check_listen() {
-  local value="$1"
-  local type="$2"
+	local value="$1"
+	local type="$2"
 
-  local address
-  local has_proto=0
-  local one two three
-  local tmp
+	local proto host port address result
 
-  [ -z "$value" ] && {
-    $LOG_ERR empty $type entry
-    return 1
-  }
+	[ -z "$value" ] && {
+		$LOG_ERR empty $type entry
+		return 1
+	}
 
-  # IPv6 addresses need to be enclosed in square brackets. If there are
-  # square brackets in the listen entry, just copy it.
-  echo "$value" | grep "\[[0-9:A-Fa-f]*\]" &> /dev/null && {
-    options=$options" -l $value"
-    return
-  }
+	# [IPv6] - pass through as-is
+	case "$value" in
+		*\[*\]*)
+			options="$options -l $value"
+			return
+			;;
+	esac
 
-  # Bail if more than 2 colons.
-  [ $(echo "$value" | awk -F ":" '{print NF-1}') -gt 2 ] && {
-    $LOG_ERR init script does not understand $type entry \""$value"\"
-    return 1
-  }
+	# Count colons. More than 2 means malformed
+	# Format: proto:host:port
+	if [ "$(echo "$value" | awk -F: '{print NF-1}')" -gt 2 ]; then
+		$LOG_ERR init script does not understand $type entry \""$value"\"
+		return 1
+	fi
 
-  IFS=":" read one two three << EOF
-$value
-EOF
+	# Parse proto (if present)
+	case "$value" in
+		udp:*|tcp:*|tls:*|sctp:*)
+			proto="${value%%:*}"
+			value="${value#*:}"
+			;;
+	esac
 
-  case "$one" in
-    udp|tcp|tls|sctp)
-      tmp="$two"
-      has_proto=1
-      ;;
-    *)
-      tmp="$one"
-      ;;
-  esac
+	# Parse port (if present)
+	case "$value" in
+		*:* )
+			host="${value%%:*}"
+			port="${value#*:}"
+			;;
+		*)
+			host="$value"
+			port=""
+			;;
+	esac
 
-  if [ "$type" = "listen" ]; then
-    network_get_ipaddr address "$tmp" || address="$tmp"
-  else
-    network_get_ipaddr6 address "$tmp" && address="[$address]" || \
-                                                     address="$tmp"
-  fi
+	# Resolve host to IP or interface
+	if [ "$type" = "listen" ]; then
+		network_get_ipaddr address "$host" || address="$host"
+	else
+		network_get_ipaddr6 address "$host" && address="[$address]" || address="$host"
+	fi
 
-  if [ -n "$three" ]; then
-    tmp="$one:$address:$three"
-  elif [ -n "$two" ]; then
-    if [ $has_proto = 1 ]; then
-      tmp="$one:$address"
-    else
-      tmp="$address:$two"
-    fi
-  else
-    tmp="$address"
-  fi
+	# Reconstruct result
+	if [ -n "$proto" ]; then
+		if [ -n "$port" ]; then
+			result="$proto:$address:$port"
+		else
+			result="$proto:$address"
+		fi
+	else
+		if [ -n "$port" ]; then
+			result="$address:$port"
+		else
+			result="$address"
+		fi
+	fi
 
-  options=$options" -l $tmp"
+	options="$options -l $result"
 }
 
 start_service() {
-  local enabled
-  local user
-  local group
-  local shm_memory
-  local pkg_memory
-  local cfg_file
-  local options
+	local enabled
+	local user
+	local group
+	local shm_memory
+	local pkg_memory
+	local cfg_file
+	local options
 
-  config_load $NAME
+	config_load $NAME
 
-  config_get_bool enabled general enabled 0
+	config_get_bool enabled general enabled 0
 
-  if [ $enabled -eq 0 ]; then
-    $LOG_ERR service not enabled in /etc/config/$NAME
-    return 1
-  fi
+	if [ $enabled -eq 0 ]; then
+		$LOG_ERR service not enabled in /etc/config/$NAME
+		return 1
+	fi
 
-  config_get user       general user       $NAME
-  config_get group      general group      $NAME
-  config_get shm_memory general shm_memory 8
-  config_get pkg_memory general pkg_memory 2
-  config_get cfg_file   general cfg_file   /etc/$NAME/$NAME.cfg
-  config_get options    general options
+	config_get user        general user       $NAME
+	config_get group       general group      $NAME
+	config_get shm_memory  general shm_memory 8
+	config_get pkg_memory  general pkg_memory 3
+	config_get cfg_file    general cfg_file   /etc/$NAME/$NAME.cfg
+	config_get options     general options
+	config_get_bool stderr general stderr 0
+	config_get debug_level general debug_level 0
 
-  . /lib/functions/network.sh
+	. /lib/functions/network.sh
 
-  config_list_foreach general listen  check_listen listen
-  config_list_foreach general listen6 check_listen listen6
+	config_list_foreach general listen  check_listen listen
+	config_list_foreach general listen6 check_listen listen6
 
-  if [ ! -d $RUNDIR ]; then
-    mkdir -p $RUNDIR
-    chown "$user":"$group" $RUNDIR
-  fi
+	if [ ! -d "$RUNDIR" ]; then
+		mkdir -p "$RUNDIR"
+		chown "$user":"$group" "$RUNDIR"
+	fi
 
-  procd_open_instance
-  procd_set_param command $COMMAND
-  procd_append_param command \
-    -P $PIDFILE \
-    -f "$cfg_file" \
-    -m "$shm_memory" \
-    -M "$pkg_memory" \
-    $options \
-    -u "$user" \
-    -g "$group" \
-    -DD -E
-  # forward stderr to logd
-  procd_set_param stderr 1
-  procd_close_instance
+	if [ -d "/etc/kamailio" ]; then
+		chown "$user":"$group" /etc/kamailio/ -R
+	fi
+
+	procd_open_instance
+	procd_set_param command $COMMAND
+	procd_append_param command \
+		-P $PIDFILE \
+		-f "$cfg_file" \
+		-m "$shm_memory" \
+		-M "$pkg_memory" \
+		$options \
+		-u "$user" \
+		-g "$group" \
+		-DDD
+	# If log_stderror=no (default) global parameter and -E is not provided, then it writes to syslog daemon
+	[ "$stderr" -eq '1' ] && procd_append_param command -E
+	procd_append_param command --debug $debug_level
+
+	# silence stderr (useful only for debug)
+	procd_set_param stderr 0
+	# forward stdout to logd
+	procd_set_param stdout 1
+	procd_close_instance
 }
 


### PR DESCRIPTION
bump pkg_memory 2MiB -> 3MiB.
space -> tab convert kamailio.init file
refactor kamailio.init check_listen() for clarity
cfg_target: append /
quote uci config values
chown kamailio:kamailio -R /etc/kamailio/*
debug_level 0
stderr 0
