### PR TITLE
asterisk: update to version 20.14.1

### DIFF
--- a/net/asterisk/Makefile
+++ b/net/asterisk/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk
-PKG_VERSION:=20.14.0
+PKG_VERSION:=20.14.1
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:digium:asterisk
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases
-PKG_HASH:=f9152e87467d5b57a898e3bc69bcded87b8525db21e5bf06ea361120af838ce6
+PKG_HASH:=fa0f953740eed079d5aaadf88f7f7131a053c61e4bc961faed0f30ba77f52ac9
 
 PKG_BUILD_DEPENDS:=libxml2/host
 


### PR DESCRIPTION
Maintainer: @jslachta 
Compile tested: mips_24kc
Run tested: lantiq/xrx200 (incl. asterisk-chan-lantiq)

Description:
Changes since 20.14.0:

asterisk.c: Add option to restrict shell access from remote consoles.

Author: George Joseph Date: 2025-05-19

UserNote: A new asterisk.conf option 'disable_remote_console_shell' has been added that, when set, will prevent remote consoles from executing shell commands using the '!' prefix.

Resolves: #GHSA-c7p6-7mvq-8jq2

res_pjsip_messaging.c: Mask control characters in received From display name

Author: George Joseph Date: 2025-03-24

Incoming SIP MESSAGEs will now have their From header's display name sanitized by replacing any characters < 32 (space) with a space.

Resolves: #GHSA-2grh-7mhv-fcfw
