### PR TITLE
libs/libsrtp: assign PKG_CPE_ID

### DIFF
--- a/libs/libsrtp/Makefile
+++ b/libs/libsrtp/Makefile
@@ -19,6 +19,7 @@ PKG_MIRROR_HASH:=7ee6ba7138e7e3c4b16dbb6aa1cd639dcca517f2aa3f7dafb2cf245d932e844
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:cisco:libsrtp
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
`cpe:/a:cisco:libsrtp` is the correct CPE ID for libsrtp: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:cisco:libsrtp

Maintainer:
Compile tested: Not needed
Run tested: Not needed
