### PR TITLE
libs/sofia-sip: assign PKG_CPE_ID

### DIFF
--- a/libs/sofia-sip/Makefile
+++ b/libs/sofia-sip/Makefile
@@ -26,6 +26,7 @@ PKG_INSTALL:=1
 
 PKG_LICENSE:=LGPL-2.1+
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:signalwire:sofia-sip
 PKG_MAINTAINER:=
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
`cpe:/a:signalwire:sofia-sip` is the correct CPE ID for sofia-sip: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:signalwire:sofia-sip

Maintainer:
Compile tested: Not needed
Run tested: Not needed
