### PR TITLE
net/kamailio: assign PKG_CPE_ID

### DIFF
--- a/net/kamailio/Makefile
+++ b/net/kamailio/Makefile
@@ -19,6 +19,7 @@ PKG_BUILD_FLAGS:=no-mips16
 
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:kamailio:kamailio
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
 PKG_INSTALL:=1


### PR DESCRIPTION
`cpe:/a:kamailio:kamailio` is the correct CPE ID for kamailio: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:kamailio:kamailio

Maintainer:
Compile tested: Not needed
Run tested: Not needed