### PR TITLE
net/rtpproxy: assign PKG_CPE_ID

### DIFF
--- a/net/rtpproxy/Makefile
+++ b/net/rtpproxy/Makefile
@@ -24,6 +24,7 @@ PKG_FIXUP:=autoreconf
 
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:rtpproxy:rtpproxy
 PKG_MAINTAINER:=Jiri Slachta <jiri@slachta.eu>
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
`cpe:/a:rtpproxy:rtpproxy` is the correct CPE ID for rtpproxy: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:rtpproxy:rtpproxy

Maintainer:
Compile tested: Not needed
Run tested: Not needed
