### PR TITLE
net/sngrep: assign PKG_CPE_ID

### DIFF
--- a/net/sngrep/Makefile
+++ b/net/sngrep/Makefile
@@ -15,6 +15,7 @@ PKG_RELEASE:=1
 PKG_MAINTAINER:=
 PKG_LICENSE:=GPL-3.0+
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:irontec:sngrep
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/irontec/sngrep/releases/download/v$(PKG_VERSION)


### PR DESCRIPTION
`cpe:/a:irontec:sngrep` is the correct CPE ID for sngrep: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:irontec:sngrep

Maintainer:
Compile tested: Not needed
Run tested: Not needed