### PR TITLE
Fix compilation on kernel >6.12

### DIFF
--- a/net/rtpengine/patches/101-fix-kernel-6.12-builds.patch
+++ b/net/rtpengine/patches/101-fix-kernel-6.12-builds.patch
@@ -1,0 +1,14 @@
+--- a/kernel-module/xt_RTPENGINE.c
++++ b/kernel-module/xt_RTPENGINE.c
+@@ -4010,7 +4010,11 @@
+ 	if (!net)
+ 		goto drop;
+ 
++#if(LINUX_VERSION_CODE < KERNEL_VERSION(6,10,3))
+ 	rt = ip_route_output(net, dst->u.ipv4, src->u.ipv4, tos, 0);
++#else
++       rt = ip_route_output(net, dst->u.ipv4, src->u.ipv4, tos, 0, 0);
++#endif
+ 	if (IS_ERR(rt))
+ 		goto drop;
+ 	skb_dst_drop(skb);


### PR DESCRIPTION
Tested on: WRT1900ACS v2, mvebu, openwrt built from [master#440b85f5b1025d26b3a40d6b55b34b17cb6520c8](https://github.com/openwrt/openwrt/commit/440b85f5b1025d26b3a40d6b55b34b17cb6520c8)

see reference: https://github.com/sipwise/rtpengine/commit/e8af2017782be9b51605993bdf9ce2af4cfd64f1