### PR TITLE
dahdi-inux: Rename MAX definition to avoid macro naming conflict

### DIFF
--- a/libs/dahdi-linux/Makefile
+++ b/libs/dahdi-linux/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=dahdi-linux
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/asterisk/dahdi-linux.git

--- a/libs/dahdi-linux/patches/011-rename-max-definition.patch
+++ b/libs/dahdi-linux/patches/011-rename-max-definition.patch
@@ -1,0 +1,107 @@
+commit b821026c73588e927ae882f904642c2103781395
+Author: InterLinked1 <24227567+InterLinked1@users.noreply.github.com>
+Date:   Sun Sep 22 16:34:05 2024 -0400
+
+    drivers: Rename MAX definition to avoid macro naming conflict.
+    
+    MAX can already be defined by the kernel headers and cause
+    compilation failure due to the redefinition, so use
+    MAX_ATTEMPTS to a more descriptive and non-conflicting name.
+    
+    Resolves: #61
+
+--- a/drivers/dahdi/opvxa1200/base.c
++++ b/drivers/dahdi/opvxa1200/base.c
+@@ -868,12 +868,12 @@ static int __wait_access(struct wctdm *w
+     long origjiffies;
+     int count = 0;
+ 
+-    #define MAX 6000 /* attempts */
++    #define MAX_ATTEMPTS 6000 /* attempts */
+ 
+ 
+     origjiffies = jiffies;
+     /* Wait for indirect access */
+-    while (count++ < MAX)
++    while (count++ < MAX_ATTEMPTS)
+ 	 {
+ 		data = __wctdm_getreg(wc, card, I_STATUS);
+ 
+@@ -882,7 +882,7 @@ static int __wait_access(struct wctdm *w
+ 
+ 	 }
+ 
+-    if(count > (MAX-1)) printk(KERN_NOTICE " ##### Loop error (%02x) #####\n", data);
++    if(count > (MAX_ATTEMPTS-1)) printk(KERN_NOTICE " ##### Loop error (%02x) #####\n", data);
+ 
+ 	return 0;
+ }
+--- a/drivers/dahdi/wcaxx-base.c
++++ b/drivers/dahdi/wcaxx-base.c
+@@ -1066,16 +1066,16 @@ static int wait_access(struct wcaxx *wc,
+ 	unsigned char data = 0;
+ 	int count = 0;
+ 
+-	#define MAX 10 /* attempts */
++	#define MAX_ATTEMPTS 10 /* attempts */
+ 
+ 	/* Wait for indirect access */
+-	while (count++ < MAX) {
++	while (count++ < MAX_ATTEMPTS) {
+ 		data = wcaxx_getreg(wc, mod, I_STATUS);
+ 		if (!data)
+ 			return 0;
+ 	}
+ 
+-	if (count > (MAX-1)) {
++	if (count > (MAX_ATTEMPTS-1)) {
+ 		dev_notice(&wc->xb.pdev->dev,
+ 			   " ##### Loop error (%02x) #####\n", data);
+ 	}
+--- a/drivers/dahdi/wctdm.c
++++ b/drivers/dahdi/wctdm.c
+@@ -623,11 +623,11 @@ static int __wait_access(struct wctdm *w
+     unsigned char data = 0;
+     int count = 0;
+ 
+-    #define MAX 6000 /* attempts */
++    #define MAX_ATTEMPTS 6000 /* attempts */
+ 
+ 
+     /* Wait for indirect access */
+-    while (count++ < MAX)
++    while (count++ < MAX_ATTEMPTS)
+ 	 {
+ 		data = __wctdm_getreg(wc, card, I_STATUS);
+ 
+@@ -636,7 +636,7 @@ static int __wait_access(struct wctdm *w
+ 
+ 	 }
+ 
+-    if(count > (MAX-1)) printk(KERN_NOTICE " ##### Loop error (%02x) #####\n", data);
++    if(count > (MAX_ATTEMPTS-1)) printk(KERN_NOTICE " ##### Loop error (%02x) #####\n", data);
+ 
+ 	return 0;
+ }
+--- a/drivers/dahdi/wctdm24xxp/base.c
++++ b/drivers/dahdi/wctdm24xxp/base.c
+@@ -1516,16 +1516,16 @@ static int wait_access(struct wctdm *wc,
+ 	unsigned char data = 0;
+ 	int count = 0;
+ 
+-	#define MAX 10 /* attempts */
++	#define MAX_ATTEMPTS 10 /* attempts */
+ 
+ 	/* Wait for indirect access */
+-	while (count++ < MAX) {
++	while (count++ < MAX_ATTEMPTS) {
+ 		data = wctdm_getreg(wc, mod, I_STATUS);
+ 		if (!data)
+ 			return 0;
+ 	}
+ 
+-	if (count > (MAX-1)) {
++	if (count > (MAX_ATTEMPTS-1)) {
+ 		dev_notice(&wc->vb.pdev->dev,
+ 			   " ##### Loop error (%02x) #####\n", data);
+ 	}


### PR DESCRIPTION
backport from master

Fixes https://github.com/openwrt/telephony/issues/921

Maintainer: @dangowrt 
Compile tested: rockchip/armv8, openwrt 24.10.4
Run tested: none

Description:
Before fix:
```
  CC [M]  /mnt/data/build/istoreos-build/24.10/rk3xxx/openwrt/build_dir/target-aarch64_generic_musl/linux-rockchip_armv8/dahdi-linux-2024.04.12~83d89b64/drivers/dahdi/wctdm24xxp/base.o
../dahdi-linux-2024.04.12~83d89b64/drivers/dahdi/wctdm24xxp/base.c: In function 'wait_access':
../dahdi-linux-2024.04.12~83d89b64/drivers/dahdi/wctdm24xxp/base.c:1519: error: "MAX" redefined [-Werror]
 1519 |         #define MAX 10 /* attempts */
      | 
In file included from ./include/linux/kernel.h:27,
                 from ../dahdi-linux-2024.04.12~83d89b64/drivers/dahdi/wctdm24xxp/base.c:41:
./include/linux/minmax.h:315: note: this is the location of the previous definition
  315 | #define MAX(a, b) __cmp(max, a, b)
      | 
cc1: all warnings being treated as errors
make[7]: *** [scripts/Makefile.build:243: /mnt/data/build/istoreos-build/24.10/rk3xxx/openwrt/build_dir/target-aarch64_generic_musl/linux-rockchip_armv8/dahdi-linux-2024.04.12~83d89b64/drivers/dahdi/wctdm24xxp/base.o] Error 1
make[6]: *** [scripts/Makefile.build:480: /mnt/data/build/istoreos-build/24.10/rk3xxx/openwrt/build_dir/target-aarch64_generic_musl/linux-rockchip_armv8/dahdi-linux-2024.04.12~83d89b64/drivers/dahdi/wctdm24xxp] Error 2

```