### PR TITLE
asterisk: bring up to current - bump from 20.14.1 to 22.2.7->23.1.0

### DIFF
--- a/libs/pjproject/Makefile
+++ b/libs/pjproject/Makefile
@@ -10,7 +10,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pjproject
-PKG_VERSION:=2.14.1
+PKG_VERSION:=2.15.1
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:pjsip:pjsip
 
@@ -18,7 +18,7 @@ PKG_CPE_ID:=cpe:/a:pjsip:pjsip
 PKG_SOURCE_URL_FILE:=$(PKG_VERSION).tar.gz
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_URL_FILE)
 PKG_SOURCE_URL:=https://github.com/pjsip/$(PKG_NAME)/archive/refs/tags
-PKG_HASH:=6140f7a97e318caa89c17e8d5468599671c6eed12d64a7c160dac879ba004c68
+PKG_HASH:=8f3bd99caf003f96ed8038b8a36031eb9d8cd9eaea1eaff7e01c2eef6bd55706
 PKG_INSTALL:=1
 
 PKG_LICENSE:=GPL-2.0

--- a/libs/pjproject/patches/0004-config_site.patch
+++ b/libs/pjproject/patches/0004-config_site.patch
@@ -77,9 +77,9 @@
 +#define PJ_ICE_MAX_CHECKS (PJ_ICE_MAX_CAND * PJ_ICE_MAX_CAND)
 +
 +/* Increase limits to allow more formats */
-+#define	PJMEDIA_MAX_SDP_FMT   64
++#define	PJMEDIA_MAX_SDP_FMT   72
 +#define	PJMEDIA_MAX_SDP_BANDW   4
-+#define	PJMEDIA_MAX_SDP_ATTR   (PJMEDIA_MAX_SDP_FMT*3 + 4)
++#define	PJMEDIA_MAX_SDP_ATTR   (PJMEDIA_MAX_SDP_FMT*6 + 4)
 +#define	PJMEDIA_MAX_SDP_MEDIA   16
 +
 +/*
@@ -92,7 +92,7 @@
 +
 +#define PJSIP_TSX_UAS_CONTINUE_ON_TP_ERROR 0
 +#define PJ_SSL_SOCK_OSSL_USE_THREAD_CB 0
-+#define PJSIP_AUTH_ALLOW_MULTIPLE_AUTH_HEADER 1
++#define PJSIP_AUTH_ALLOW_MULTIPLE_AUTH_HEADER 0
 +
 +/*
 + * The default is 32 with 8 being used by pjproject itself.

--- a/libs/pjproject/patches/0006-fix-pkg_config-file.patch
+++ b/libs/pjproject/patches/0006-fix-pkg_config-file.patch
@@ -13,7 +13,7 @@
  Description: Multimedia communication library
 --- a/build.mak.in
 +++ b/build.mak.in
-@@ -351,6 +351,6 @@ export PJ_LIBXX_FILES := $(APP_LIBXX_FIL
+@@ -352,6 +352,6 @@ export PJ_LIBXX_FILES := $(APP_LIBXX_FIL
  export PJ_INSTALL_DIR := @prefix@
  export PJ_INSTALL_INC_DIR := @includedir@
  export PJ_INSTALL_LIB_DIR := @libdir@

--- a/libs/pjproject/patches/0010-Avoid_deadlock_between_transport_and_transaction.patch
+++ b/libs/pjproject/patches/0010-Avoid_deadlock_between_transport_and_transaction.patch
@@ -1,0 +1,154 @@
+From edde06f261ac807a89a6086b7f03460867675f95 Mon Sep 17 00:00:00 2001
+From: Nanang Izzuddin <nanang@teluu.com>
+Date: Tue, 1 Jul 2025 15:13:36 +0700
+Subject: [PATCH] Avoid deadlock between transport and transaction (#4453)
+
+---
+ pjsip/include/pjsip/sip_transaction.h |   1 +
+ pjsip/src/pjsip/sip_transaction.c     | 101 ++++++++++++++++++++++----
+ 2 files changed, 88 insertions(+), 14 deletions(-)
+
+--- a/pjsip/include/pjsip/sip_transaction.h
++++ b/pjsip/include/pjsip/sip_transaction.h
+@@ -141,6 +141,7 @@ struct pjsip_transaction
+     int                         retransmit_count;/**< Retransmission count. */
+     pj_timer_entry              retransmit_timer;/**< Retransmit timer.     */
+     pj_timer_entry              timeout_timer;  /**< Timeout timer.         */
++    pj_timer_entry              misc_timer;     /**< Miscellaneous timer.   */
+ 
+     /** Module specific data. */
+     void                       *mod_data[PJSIP_MAX_MODULE];
+--- a/pjsip/src/pjsip/sip_transaction.c
++++ b/pjsip/src/pjsip/sip_transaction.c
+@@ -140,6 +140,7 @@ static int max_retrans_count = -1;
+ #define TRANSPORT_ERR_TIMER     3
+ #define TRANSPORT_DISC_TIMER    4
+ #define TERMINATE_TIMER         5
++#define TRANSPORT_CB_TIMER      6
+ 
+ /* Flags for tsx_set_state() */
+ enum
+@@ -2265,23 +2266,21 @@ static void send_msg_callback( pjsip_sen
+ }
+ 
+ 
+-/* Transport callback. */
+-static void transport_callback(void *token, pjsip_tx_data *tdata,
+-                               pj_ssize_t sent)
+-{
+-    pjsip_transaction *tsx = (pjsip_transaction*) token;
++/* Transport callback parameter. */
++struct tp_cb_param {
++    pjsip_transaction* tsx;
++    pjsip_tx_data* tdata;
++    pj_ssize_t sent;
++};
+ 
+-    /* Check if the transaction layer has been shutdown. */
+-    if (mod_tsx_layer.mod.id < 0)
+-        return;
+ 
+-    /* In other circumstances, locking tsx->grp_lock AFTER transport mutex
+-     * will introduce deadlock if another thread is currently sending a
+-     * SIP message to the transport. But this should be safe as there should
+-     * be no way this callback could be called while another thread is
+-     * sending a message.
+-     */
++/* Transport callback actual implementation. */
++static void transport_callback_impl(pjsip_transaction *tsx,
++                                    pjsip_tx_data* tdata,
++                                    pj_ssize_t sent)
++{
+     pj_grp_lock_acquire(tsx->grp_lock);
++
+     tsx->transport_flag &= ~(TSX_HAS_PENDING_TRANSPORT);
+ 
+     if (sent > 0 || tsx->role == PJSIP_ROLE_UAS) {
+@@ -2299,6 +2298,7 @@ static void transport_callback(void *tok
+             tsx_set_state( tsx, PJSIP_TSX_STATE_DESTROYED,
+                            PJSIP_EVENT_UNKNOWN, NULL, 0 );
+             pj_grp_lock_release(tsx->grp_lock);
++            pj_grp_lock_dec_ref(tsx->grp_lock);
+             return;
+         }
+ 
+@@ -2354,6 +2354,79 @@ static void transport_callback(void *tok
+ }
+ 
+ 
++/* Timer callback for transport callback.
++ * This is currently only used to avoid deadlock due to inversed locking order
++ * between transport and transaction.
++ */
++static void tsx_misc_timer_callback(pj_timer_heap_t *theap,
++                                    pj_timer_entry *entry)
++{
++    PJ_UNUSED_ARG(theap);
++
++    if (entry->id == TRANSPORT_CB_TIMER) {
++        struct tp_cb_param* param = (struct tp_cb_param*)entry->user_data;
++
++        /* Check if the transaction layer has been shutdown. */
++        if (mod_tsx_layer.mod.id >= 0) {
++            /* Call transport callback implementation */
++            transport_callback_impl(param->tsx, param->tdata, param->sent);
++        }
++
++        /* Release tdata */
++        pjsip_tx_data_dec_ref(param->tdata);
++    }
++}
++
++
++/* Transport callback. */
++static void transport_callback(void *token, pjsip_tx_data *tdata,
++                               pj_ssize_t sent)
++{
++    pjsip_transaction *tsx = (pjsip_transaction*) token;
++    pj_status_t status;
++
++    /* Check if the transaction layer has been shutdown. */
++    if (mod_tsx_layer.mod.id < 0)
++        return;
++
++    /* In other circumstances, locking tsx->grp_lock AFTER transport mutex
++     * will introduce deadlock if another thread is currently sending a
++     * SIP message to the transport. But this should be safe as there should
++     * be no way this callback could be called while another thread is
++     * sending a message.
++     */
++    // Deadlock does happen, see #4453.
++    // So now, to avoid deadlock, we'll try to acquire the group lock first,
++    // and if it fails, we'll schedule the processing via timer.
++    status = pj_grp_lock_tryacquire(tsx->grp_lock);
++    if (status != PJ_SUCCESS) {
++        pj_time_val delay = { 0, 0 };
++        struct tp_cb_param *param = NULL;
++
++        lock_timer(tsx);
++        tsx_cancel_timer(tsx, &tsx->misc_timer);
++
++        /* Increment tdata ref count to avoid premature destruction.
++         * Note that tsx ref count is already handled by tsx_schedule_timer().
++         */
++        pjsip_tx_data_add_ref(tdata);
++
++        param = PJ_POOL_ZALLOC_T(tsx->pool, struct tp_cb_param);
++        param->sent = sent;
++        param->tdata = tdata;
++        param->tsx = tsx;
++        pj_timer_entry_init(&tsx->misc_timer, TIMER_INACTIVE, param,
++                            &tsx_misc_timer_callback);
++        tsx_schedule_timer(tsx, &tsx->misc_timer, &delay, TRANSPORT_CB_TIMER);
++        unlock_timer(tsx);
++        return;
++    }
++
++    transport_callback_impl(tsx, tdata, sent);
++    pj_grp_lock_release(tsx->grp_lock);
++}
++
++
+ /*
+  * Callback when transport state changes.
+  */

--- a/net/asterisk/Makefile
+++ b/net/asterisk/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk
-PKG_VERSION:=20.14.1
+PKG_VERSION:=22.7.0
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:digium:asterisk
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases
-PKG_HASH:=fa0f953740eed079d5aaadf88f7f7131a053c61e4bc961faed0f30ba77f52ac9
+PKG_HASH:=5b0e5d276aeb014bf8a08a94d1055a9e97b9dce3375846eea70da5221bf9efe7
 
 PKG_BUILD_DEPENDS:=libxml2/host
 
@@ -125,19 +125,15 @@ MODULES_AVAILABLE:= \
 	cel-custom \
 	cel-manager \
 	cel-sqlite3-custom \
-	chan-alsa \
 	chan-audiosocket \
 	chan-bridge-media \
 	chan-console \
 	chan-dahdi \
 	chan-iax2 \
-	chan-mgcp \
 	chan-mobile \
 	chan-motif \
 	chan-ooh323 \
 	chan-rtp \
-	chan-sip \
-	chan-skinny \
 	chan-unistim \
 	codec-a-mu \
 	codec-adpcm \
@@ -280,7 +276,6 @@ MODULES_AVAILABLE:= \
 	res-limit \
 	res-manager-devicestate \
 	res-manager-presencestate \
-	res-monitor \
 	res-musiconhold \
 	res-mutestream \
 	res-mwi-devstate \
@@ -294,7 +289,6 @@ MODULES_AVAILABLE:= \
 	res-pjsip-rfc3329 \
 	res-pjsip-stir-shaken \
 	res-pjproject \
-	res-pktccops \
 	res-prometheus \
 	res-realtime \
 	res-remb-modifier \
@@ -321,7 +315,9 @@ MODULES_AVAILABLE:= \
 	res-stun-monitor \
 	res-timing-dahdi \
 	res-timing-pthread \
+	res-timing-timerfd \
 	res-tonedetect \
+	res-websocket-client \
 	res-xmpp
 
 UTILS_AVAILABLE:= \
@@ -482,6 +478,7 @@ endef
 define Package/$(PKG_NAME)/conffiles
 /etc/asterisk/asterisk.conf
 /etc/asterisk/acl.conf
+/etc/asterisk/cdr.conf
 /etc/asterisk/cel.conf
 /etc/asterisk/ccss.conf
 /etc/asterisk/cli.conf
@@ -500,20 +497,19 @@ define Package/$(PKG_NAME)/conffiles
 /etc/asterisk/res_config_sqlite3.conf
 /etc/asterisk/stasis.conf
 /etc/asterisk/udptl.conf
-/etc/asterisk/users.conf
 /etc/config/asterisk
 /etc/init.d/asterisk
 endef
 
 AST_CFG_FILES:= \
-	asterisk.conf acl.conf cel.conf ccss.conf cli.conf \
+	asterisk.conf acl.conf cdr.conf cel.conf ccss.conf cli.conf \
 	cli_permissions.conf codecs.conf dnsmgr.conf dsp.conf extconfig.conf \
 	extensions.conf features.conf http.conf indications.conf \
 	logger.conf manager.conf modules.conf stasis.conf udptl.conf \
-	users.conf res_config_sqlite3.conf
+	res_config_sqlite3.conf
 
 AST_EMB_MODULES:=\
-	app_dial app_echo app_macro app_playback \
+	app_dial app_echo app_stack app_playback \
 	func_callerid func_logic func_strings func_timeout \
 	pbx_config res_crypto res_timing_timerfd
 
@@ -567,13 +563,12 @@ else
 	--without-tonezone
 endif
 
-# Pass CPPFLAGS in the CFLAGS as otherwise the build system will
+# Pass CPPFLAGS in the CFLAGS as otherwise the build system will
 # ignore them.
 TARGET_CFLAGS+=$(TARGET_CPPFLAGS)
 
 CONFIGURE_ARGS+= \
 	--disable-xmldoc \
-	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-chan-alsa),--with-asound="$(STAGING_DIR)/usr",--without-asound) \
 	--without-execinfo \
 	$(if $(CONFIG_PACKAGE_$(PKG_NAME)-chan-mobile),--with-bluetooth="$(STAGING_DIR)/usr",--without-bluetooth) \
 	--with-cap="$(STAGING_DIR)/usr" \
@@ -862,23 +857,19 @@ $(eval $(call BuildAsteriskModule,bridge-simple,Simple two channel bridging modu
 $(eval $(call BuildAsteriskModule,bridge-softmix,Multi-party software based channel mixing,Multi-party software based channel mixing.,,,bridge_softmix,,))
 $(eval $(call BuildAsteriskModule,cdr,Provides CDR,Call Detail Records.,,cdr.conf cdr_custom.conf cdr_manager.conf,app_cdr app_forkcdr cdr_custom cdr_manager func_cdr,,))
 $(eval $(call BuildAsteriskModule,cdr-csv,Provides CDR CSV,Comma Separated Values CDR backend.,,,cdr_csv,,))
-$(eval $(call BuildAsteriskModule,cdr-sqlite3,Provides CDR SQLITE3,SQLite3 CDR backend.,libsqlite3,,cdr_sqlite3_custom,,))
+$(eval $(call BuildAsteriskModule,cdr-sqlite3,Provides CDR SQLITE3,SQLite3 CDR backend.,libsqlite3,cdr_sqlite3_custom.conf,cdr_sqlite3_custom,,))
 $(eval $(call BuildAsteriskModule,cel-custom,Customizable CSV CEL backend,Customizable Comma Separated Values CEL backend.,,cel_custom.conf,cel_custom,,))
 $(eval $(call BuildAsteriskModule,cel-manager,AMI CEL backend,Asterisk Manager Interface CEL backend.,,,cel_manager,,))
 $(eval $(call BuildAsteriskModule,cel-sqlite3-custom,SQLite3 custom CEL,SQLite3 custom CEL module.,,cel_sqlite3_custom.conf,cel_sqlite3_custom,,))
-$(eval $(call BuildAsteriskModule,chan-alsa,ALSA channel,ALSA console channel driver.,+alsa-lib,alsa.conf,chan_alsa,,))
 $(eval $(call BuildAsteriskModule,chan-audiosocket,Audiosocket channel,Audiosocket channel.,+$(PKG_NAME)-res-audiosocket,,chan_audiosocket,,))
 $(eval $(call BuildAsteriskModule,chan-bridge-media,Bridge media channel driver,Bridge media channel driver.,,,chan_bridge_media,,))
 $(eval $(call BuildAsteriskModule,chan-console,Console channel driver,Console channel driver.,+portaudio,console.conf,chan_console,,))
 $(eval $(call BuildAsteriskModule,chan-dahdi,DAHDI channel,DAHDI telephony.,+dahdi-tools-libtonezone +kmod-dahdi +libpri @!aarch64,chan_dahdi.conf,chan_dahdi,,))
 $(eval $(call BuildAsteriskModule,chan-iax2,IAX2 channel,Inter Asterisk eXchange.,,iax.conf iaxprov.conf,chan_iax2,,))
-$(eval $(call BuildAsteriskModule,chan-mgcp,MGCP,Media Gateway Control Protocol.,,mgcp.conf,chan_mgcp,,))
 $(eval $(call BuildAsteriskModule,chan-mobile,Bluetooth channel,Bluetooth mobile device channel driver.,+bluez-libs,chan_mobile.conf,chan_mobile,,))
 $(eval $(call BuildAsteriskModule,chan-motif,Jingle channel,Motif Jingle channel driver.,+$(PKG_NAME)-res-xmpp,motif.conf,chan_motif,,))
 $(eval $(call BuildAsteriskModule,chan-ooh323,H.323 channel,Objective Systems H.323 channel.,,ooh323.conf,chan_ooh323,,))
 $(eval $(call BuildAsteriskModule,chan-rtp,RTP media channel,RTP media channel.,+asterisk-res-rtp-multicast,,chan_rtp,,))
-$(eval $(call BuildAsteriskModule,chan-sip,SIP channel,Session Initiation Protocol.,+$(PKG_NAME)-app-confbridge,sip.conf sip_notify.conf,chan_sip,,))
-$(eval $(call BuildAsteriskModule,chan-skinny,Skinny channel,Skinny Client Control Protocol.,,skinny.conf,chan_skinny,,))
 $(eval $(call BuildAsteriskModule,chan-unistim,Unistim channel,UNISTIM protocol.,,unistim.conf,chan_unistim,,))
 $(eval $(call BuildAsteriskModule,codec-a-mu,Alaw to ulaw translation,Alaw and ulaw direct coder/decoder.,,,codec_a_mu,,))
 $(eval $(call BuildAsteriskModule,codec-adpcm,ADPCM text,Adaptive Differential PCM coder/decoder.,,,codec_adpcm,,))
@@ -1021,7 +1012,6 @@ $(eval $(call BuildAsteriskModule,res-http-websocket,HTTP websocket,HTTP WebSock
 $(eval $(call BuildAsteriskModule,res-limit,Resource limits,Resource limits.,,,res_limit,,))
 $(eval $(call BuildAsteriskModule,res-manager-devicestate,Device state topic forwarder,Manager device state topic forwarder.,,,res_manager_devicestate,,))
 $(eval $(call BuildAsteriskModule,res-manager-presencestate,Presence state topic forwarder,Manager presence state topic forwarder.,,,res_manager_presencestate,,))
-$(eval $(call BuildAsteriskModule,res-monitor,PBX channel monitoring,Call monitoring resource.,,,res_monitor,,))
 $(eval $(call BuildAsteriskModule,res-musiconhold,MOH,Music On Hold resource.,,musiconhold.conf,res_musiconhold,,))
 $(eval $(call BuildAsteriskModule,res-mutestream,Mute audio stream resources,Mute audio stream resources.,,,res_mutestream,,))
 $(eval $(call BuildAsteriskModule,res-mwi-devstate,MWI device state subs,This module allows presence subscriptions to voicemail boxes. This\nallows common BLF keys to act as voicemail waiting indicators.,,,res_mwi_devstate,,))
@@ -1035,7 +1025,6 @@ $(eval $(call BuildAsteriskModule,res-pjsip-phoneprov,PJSIP Phone Provisioning,P
 $(eval $(call BuildAsteriskModule,res-pjsip-rfc3329,PJSIP RFC3329,PJSIP RFC3329 Support (partial).,+asterisk-pjsip +asterisk-res-pjproject,,res_pjsip_rfc3329,,))
 $(eval $(call BuildAsteriskModule,res-pjsip-stir-shaken,PJSIP STIR/SHAKEN resource module,PJSIP STIR/SHAKEN resource module.,+$(PKG_NAME)-pjsip +$(PKG_NAME)-res-stir-shaken,,res_pjsip_stir_shaken,,))
 $(eval $(call BuildAsteriskModule,res-pjproject,Bridge PJPROJECT to Asterisk logging,PJProject log and utility support.,+asterisk-res-sorcery +libpj +libpjlib-util +libpjmedia +libpjmedia +libpjnath +libpjsip-simple +libpjsip-ua +libpjsip +libpjsua +libpjsua2,pjproject.conf,res_pjproject,,))
-$(eval $(call BuildAsteriskModule,res-pktccops,PktcCOPS manager for MGCP,PktcCOPS manager for MGCP.,,res_pktccops.conf,res_pktccops,,))
 $(eval $(call BuildAsteriskModule,res-prometheus,Prometheus resource module,Prometheus resource module.,+libpjsip +libpjmedia +libpjnath +libpjsip-simple +libpjsip-ua +libpjsua +libpjsua2,prometheus.conf,res_prometheus,,))
 $(eval $(call BuildAsteriskModule,res-realtime,RealTime CLI,Realtime data lookup/rewrite.,,,res_realtime,,))
 $(eval $(call BuildAsteriskModule,res-remb-modifier,REMB modifier,REMB modifier module.,,,res_remb_modifier,,))
@@ -1062,7 +1051,9 @@ $(eval $(call BuildAsteriskModule,res-stir-shaken,STIR/SHAKEN resource module,ST
 $(eval $(call BuildAsteriskModule,res-stun-monitor,STUN monitoring,STUN network monitor.,,res_stun_monitor.conf,res_stun_monitor,,))
 $(eval $(call BuildAsteriskModule,res-timing-dahdi,DAHDI Timing Interface,DAHDI timing interface.,+$(PKG_NAME)-chan-dahdi,,res_timing_dahdi,,))
 $(eval $(call BuildAsteriskModule,res-timing-pthread,pthread Timing Interface,pthread timing interface.,,,res_timing_pthread,,))
+$(eval $(call BuildAsteriskModule,res-timing-timerfd,timerfd Timing Interface,timerfd timing interface.,,,res_timing_timerfd,,))
 $(eval $(call BuildAsteriskModule,res-tonedetect,Tone detection,Tone detection module.,,,res_tonedetect,,))
+$(eval $(call BuildAsteriskModule,res-websocket-client,WebSocket Client,WebSocket Client module.,,websocket_client.conf,res_websocket_client,,))
 $(eval $(call BuildAsteriskModule,res-xmpp,XMPP client and component module,Asterisk XMPP interface.,+libiksemel +libopenssl,xmpp.conf,res_xmpp,,))
 
 ################################

--- a/net/asterisk/Makefile
+++ b/net/asterisk/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=asterisk
-PKG_VERSION:=22.7.0
+PKG_VERSION:=23.1.0
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:digium:asterisk
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases
-PKG_HASH:=5b0e5d276aeb014bf8a08a94d1055a9e97b9dce3375846eea70da5221bf9efe7
+PKG_HASH:=04a05b555b27a7f5cc4f86d301190d7ee2cd4621490d262aed8613495b44316a
 
 PKG_BUILD_DEPENDS:=libxml2/host
 
@@ -323,8 +323,6 @@ MODULES_AVAILABLE:= \
 UTILS_AVAILABLE:= \
 	aelparse \
 	astcanary \
-	astdb2sqlite3 \
-	astdb2bdb \
 	check_expr \
 	check_expr2 \
 	smsq \
@@ -1068,8 +1066,6 @@ $(eval $(call BuildAsteriskModule,res-xmpp,XMPP client and component module,Aste
 
 $(eval $(call BuildAsteriskUtil,aelparse,Check extensions.ael file.,+$(PKG_NAME)-pbx-ael,))
 $(eval $(call BuildAsteriskUtil,astcanary,Assures Asterisk no threads have gone missing.,,))
-$(eval $(call BuildAsteriskUtil,astdb2sqlite3,Convert astdb to SQLite 3.,,))
-$(eval $(call BuildAsteriskUtil,astdb2bdb,Convert astdb back to Berkeley DB 1.86.,,))
 $(eval $(call BuildAsteriskUtil,check_expr,Expression checker [older version].,,))
 $(eval $(call BuildAsteriskUtil,check_expr2,Expression checker [newer version].,,))
 $(eval $(call BuildAsteriskUtil,smsq,Send messages from command line.,+libpopt,))

--- a/net/asterisk/Makefile
+++ b/net/asterisk/Makefile
@@ -1016,7 +1016,7 @@ $(eval $(call BuildAsteriskModule,res-mwi-devstate,MWI device state subs,This mo
 $(eval $(call BuildAsteriskModule,res-mwi-external,Core external MWI resource,Core external MWI resource.,,,res_mwi_external,,))
 $(eval $(call BuildAsteriskModule,res-mwi-external-ami,AMI for external MWI,AMI support for external MWI.,+$(PKG_NAME)-res-mwi-external,,res_mwi_external_ami,,))
 $(eval $(call BuildAsteriskModule,res-parking,Phone Parking,Call parking resource.,+$(PKG_NAME)-bridge-holding,res_parking.conf,res_parking,,))
-$(eval $(call BuildAsteriskModule,res-phoneprov,Phone Provisioning,HTTP phone provisioning.,,phoneprov.conf,res_phoneprov,,))
+$(eval $(call BuildAsteriskModule,res-phoneprov,Phone Provisioning,HTTP phone provisioning.,,phoneprov.conf phoneprov_users.conf,res_phoneprov,,))
 $(eval $(call BuildAsteriskModule,res-pjsip-aoc,PJSIP AOC,PJSIP AOC Support.,+asterisk-pjsip +asterisk-res-pjproject,,res_pjsip_aoc,,))
 $(eval $(call BuildAsteriskModule,res-pjsip-geolocation,PJSIP Geolocation,PJSIP Geolocation support.,+asterisk-pjsip +asterisk-res-geolocation,,res_pjsip_geolocation,,))
 $(eval $(call BuildAsteriskModule,res-pjsip-phoneprov,PJSIP Phone Provisioning,PJSIP phone provisioning.,+$(PKG_NAME)-pjsip +$(PKG_NAME)-res-phoneprov,,res_pjsip_phoneprov_provider,,))

--- a/net/asterisk/patches/001-phoneprov_users.patch
+++ b/net/asterisk/patches/001-phoneprov_users.patch
@@ -1,0 +1,86 @@
+--- a/configs/samples/phoneprov_users.conf
++++ /dev/null
+@@ -1,40 +0,0 @@
+-;
+-; Device provisioning configuration
+-;
+-; This file is used by res_phoneprov to define provisioning entries.
+-;
+-
+-[general]
+-;
+-; Full name of a user
+-;
+-fullname = New User
+-;
+-; MAC Address for res_phoneprov
+-;
+-;macaddress = 112233445566
+-;
+-; Auto provision the phone with res_phoneprov
+-;
+-;autoprov = yes
+-;
+-; Line Keys for hardphone
+-;
+-;LINEKEYS = 1
+-;
+-; Line number for hardphone
+-;
+-;linenumber = 1
+-;
+-; Local Caller ID number used with res_phoneprov and Asterisk GUI
+-;
+-;cid_number = 6000
+-
+-;[6000]
+-;fullname = Joe User
+-;secret = 1234
+-;macaddress = 112233445566
+-;autoprov = yes
+-;LINEKEYS = 1
+-;linenumber = 1
+-;cid_number = 6000
+--- /dev/null
++++ b/configs/samples/phoneprov_users.conf.sample
+@@ -0,0 +1,40 @@
++;
++; Device provisioning configuration
++;
++; This file is used by res_phoneprov to define provisioning entries.
++;
++
++[general]
++;
++; Full name of a user
++;
++fullname = New User
++;
++; MAC Address for res_phoneprov
++;
++;macaddress = 112233445566
++;
++; Auto provision the phone with res_phoneprov
++;
++;autoprov = yes
++;
++; Line Keys for hardphone
++;
++;LINEKEYS = 1
++;
++; Line number for hardphone
++;
++;linenumber = 1
++;
++; Local Caller ID number used with res_phoneprov and Asterisk GUI
++;
++;cid_number = 6000
++
++;[6000]
++;fullname = Joe User
++;secret = 1234
++;macaddress = 112233445566
++;autoprov = yes
++;LINEKEYS = 1
++;linenumber = 1
++;cid_number = 6000

--- a/net/asterisk/patches/053-musl-mutex-init.patch
+++ b/net/asterisk/patches/053-musl-mutex-init.patch
@@ -1,6 +1,6 @@
 --- a/include/asterisk/lock.h
 +++ b/include/asterisk/lock.h
-@@ -70,7 +70,7 @@ extern "C" {
+@@ -73,7 +73,7 @@ extern "C" {
  #define AST_PTHREADT_NULL (pthread_t) -1
  #define AST_PTHREADT_STOP (pthread_t) -2
  

--- a/net/asterisk/patches/130-eventfd.patch
+++ b/net/asterisk/patches/130-eventfd.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1293,7 +1293,7 @@ if test "${ac_cv_have_variable_fdset}x"
+@@ -1291,7 +1291,7 @@ if test "${ac_cv_have_variable_fdset}x"
  fi
  
  AC_MSG_CHECKING([if we have usable eventfd support])

--- a/net/asterisk/patches/140-use-default-lua.patch
+++ b/net/asterisk/patches/140-use-default-lua.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2645,7 +2645,7 @@ if test -z "$__opus_include" -o x"$__opu
+@@ -2641,7 +2641,7 @@ if test -z "$__opus_include" -o x"$__opu
  fi
  AST_EXT_LIB_CHECK([OPUSFILE], [opusfile], [op_open_callbacks], [opus/opusfile.h], [], [$__opus_include])
  

--- a/net/asterisk/patches/150-musl-12x.patch
+++ b/net/asterisk/patches/150-musl-12x.patch
@@ -18,18 +18,3 @@
  #include <alloca.h>
  #include <strings.h>
  #include <pthread.h>
---- a/utils/db1-ast/include/db.h
-+++ b/utils/db1-ast/include/db.h
-@@ -68,8 +68,11 @@ typedef	unsigned long long	u_int64_t;
- #endif /* __FreeBSD__ */
- #endif
- 
--#ifdef SOLARIS
-+#ifndef __P
- #define	__P(p) p
-+#endif
-+
-+#ifndef __BEGIN_DECLS
- #define __BEGIN_DECLS
- #define __END_DECLS
- #endif

--- a/net/asterisk/patches/180-app_queue_time_t.patch
+++ b/net/asterisk/patches/180-app_queue_time_t.patch
@@ -1,6 +1,6 @@
 --- a/apps/app_queue.c
 +++ b/apps/app_queue.c
-@@ -4803,8 +4803,12 @@ static int is_longest_waiting_caller(str
+@@ -4759,8 +4759,12 @@ static int is_longest_waiting_caller(str
  					 * will be unused until the first caller is picked up.
  					 */
  					if (ch->start < caller->start && !ch->pending) {

--- a/net/asterisk/patches/180-app_queue_time_t.patch
+++ b/net/asterisk/patches/180-app_queue_time_t.patch
@@ -1,6 +1,6 @@
 --- a/apps/app_queue.c
 +++ b/apps/app_queue.c
-@@ -4800,8 +4800,12 @@ static int is_longest_waiting_caller(str
+@@ -4803,8 +4803,12 @@ static int is_longest_waiting_caller(str
  					 * will be unused until the first caller is picked up.
  					 */
  					if (ch->start < caller->start && !ch->pending) {


### PR DESCRIPTION
This patch-set fixes asterisk compile and brings it up to current. See individual commit messages for details. 

@jslachta 

This will likely fix other asterisk components which depend on asterisk and fail to build.