### PR TITLE
yate: convert init script to procd

### DIFF
--- a/net/yate/Makefile
+++ b/net/yate/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=yate
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/yatevoip/yate.git

--- a/net/yate/files/yate.init
+++ b/net/yate/files/yate.init
@@ -1,25 +1,31 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2013 OpenWrt.org
+
 START=50
+USE_PROCD=1
 
-SERVICE_USE_PID=1
+# Log verbosity level. An integer from 0 to 5 (5 is maximum logging).
+LOG_LEVEL=0
 
-YATE_BINARY="/usr/bin/yate"
-YATE_LOG_FILE=""
-YATE_OPTIONS="-d -s -p /var/run/yate.pid"
+# Log file name. If not specified, then logs go to the system log.
+LOG_FILE=""
 
-start() {
-	if [ -n "$YATE_LOG_FILE" ]; then
-		YATE_OPTIONS="$YATE_OPTIONS -r -l $YATE_LOG_FILE"
+start_service() {
+	procd_open_instance
+	procd_set_param command /usr/bin/yate -s
+
+	for x in $(seq $LOG_LEVEL); do
+		procd_append_param command -v
+	done
+
+	if [ -n "$LOG_FILE" ]; then
+		procd_append_param command -DZ -r -l "$LOG_FILE"
+	else
+		procd_append_param command -Dn
+		procd_set_param stdout 1
+		procd_set_param stderr 1
 	fi
 
-	service_start $YATE_BINARY $YATE_OPTIONS
-}
-
-stop() {
-	service_stop $YATE_BINARY
-}
-
-reload() {
-	service_reload $YATE_BINARY
+	procd_set_param pidfile /var/run/yate.pid
+	procd_set_param term_timeout 30
+	procd_close_instance
 }


### PR DESCRIPTION
Maintainer: @jslachta
Compile tested: this init script isn't compiled
Run tested: mips, Netgear R6850, 25.12. Logging to file and system log works. Changing logging verbosity level works. Starting, stopping and restarting yate works.

Description:
Current init script doesn't quite manage to terminate yate on stop request. There's a process left lingering. Changing to procd seems to fix this.

This change also adds the ability to get the yate logs sent to the system log.