### PR TITLE
asterisk, pjproject: update CPE IDs (OpenWrt 24.10)

### DIFF
--- a/libs/pjproject/Makefile
+++ b/libs/pjproject/Makefile
@@ -12,7 +12,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=pjproject
 PKG_VERSION:=2.14.1
 PKG_RELEASE:=1
-PKG_CPE_ID:=cpe:/a:pjsip:pjsip
+PKG_CPE_ID:=cpe:/a:teluu:pjsip
 
 # download "vX.Y.tar.gz" as "pjproject-vX.Y.tar.gz"
 PKG_SOURCE_URL_FILE:=$(PKG_VERSION).tar.gz

--- a/net/asterisk/Makefile
+++ b/net/asterisk/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=asterisk
 PKG_VERSION:=20.8.1
 PKG_RELEASE:=1
-PKG_CPE_ID:=cpe:/a:digium:asterisk
+PKG_CPE_ID:=cpe:/a:sangoma:asterisk
 
 PKG_SOURCE:=asterisk-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.asterisk.org/pub/telephony/asterisk/releases


### PR DESCRIPTION
This PR only changes the Makefile metadata in `asterisk` and `pjproject`, namely `PKG_CPE_ID`. These changes shouldn't affect the compilation or runtime.

Below are the commit messages for respective changes, they should be pretty self-descriptive.

This is a backport of #939 to OpenWrt 24.10.

---

* asterisk: update CPE ID

    In the official CPE dictionary [1], the latest Asterisk versions to have the
    old `cpe:/a:digium:asterisk` ID are 18.20.1 (2023-12-14), 20.5.1 (2023-12-14),
    21.0.0 (2023-10-18).

    All of them appeared in the CPE database in December 2023. Other Asterisk
    branches reached EoL before 2024 [2].

    For all new Asterisk security advisories since 2024 [3], the CPE ID used is
    `cpe:/a:sangoma:asterisk`, with first entries appearing in the database in
    August 2024.

    Update the CPE ID to the new value of `cpe:/a:sangoma:asterisk`.

    [1]: https://nvd.nist.gov/products/cpe
    [2]: https://docs.asterisk.org/About-the-Project/Asterisk-Versions/
    [3]: https://github.com/asterisk/asterisk/security

* pjproject: update CPE ID

    In the official CPE dictionary [4], `cpe:/a:pjsip:pjsip` is marked "deprecated"
    for most of the recorded versions. The value of `deprecatedBy` points at
    respective versions under `cpe:/a:teluu:pjsip`.

    The deprecation marking is pretty recent (2026-05-06). There are CVEs from 2026
    that reference both the deprecated [5] and the new [6] CPE IDs. It then depends
    on each particular analysis tool whether it consults the CPE database for
    deprecations.

    Update the CPE ID to the non-deprecated value of `cpe:/a:teluu:pjsip`.

    [4]: https://nvd.nist.gov/products/cpe
    [5]: https://www.cvedetails.com/vulnerability-list/vendor_id-21360/product_id-65638/Pjsip-Pjsip.html
    [6]: https://www.cvedetails.com/vulnerability-list/vendor_id-17771/product_id-44396/Teluu-Pjsip.html