### PR TITLE
dahdi-linux: fix hrtimer_init/hrtimer_setup handling on kernel 6.12

### DIFF
--- a/libs/dahdi-linux/patches/210-kernel-h-Add-wrappers-for.patch
+++ b/libs/dahdi-linux/patches/210-kernel-h-Add-wrappers-for.patch
@@ -1,44 +1,35 @@
---- a/include/dahdi/kernel.h
-+++ b/include/dahdi/kernel.h
-@@ -58,6 +58,15 @@
+From 0fc7bfe4adf9d0fdd9f1f84122306da196bc187a Mon Sep 17 00:00:00 2001
+From: InterLinked1 <24227567+InterLinked1@users.noreply.github.com>
+Date: Tue, 29 Jul 2025 15:19:43 -0400
+Subject: [PATCH] dahdi_dummy: Use hrtimer_setup on kernels >= 6.15.0.
+
+Kernel commit 908a1d775422ba2e27a5e33d0c130b522419e121 introduced
+hrtimer_setup to eventually replace hrtimer_init, which was done
+in kernel commit 9779489a31d77a7b9cb6f20d2d2caced4e29dbe6.
+Accordingly, we now use the new setup process on newer kernels.
+
+Resolves: #93
+---
+ drivers/dahdi/dahdi_dummy.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+--- a/drivers/dahdi/dahdi_dummy.c
++++ b/drivers/dahdi/dahdi_dummy.c
+@@ -229,12 +229,14 @@ int init_module(void)
  
- #include <linux/poll.h>
- 
-+/* Added for DAHDI use of hrtimers (hrtimer_init, etc.) */
-+#include <linux/hrtimer.h>
-+
-+/* del_timer[_sync] was renamed to timer_delete[_sync] in newer kernels */
+ #if defined(USE_HIGHRESTIMER)
+ 	printk(KERN_DEBUG "dahdi_dummy: Trying to load High Resolution Timer\n");
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
-+#define del_timer      timer_delete
-+#define del_timer_sync timer_delete_sync
-+#endif
-+
- #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
- #define netif_napi_add netif_napi_add_weight
- #endif
-@@ -66,6 +75,25 @@
- #include <linux/pci.h>
- #include <linux/dma-mapping.h>
- 
-+/* DAHDI expects hrtimer_init(), but kernels >= 6.8 removed it.
-+ * Recreate it using the modern hrtimer_setup() API.
-+ */
-+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
-+static inline void hrtimer_init(struct hrtimer *timer,
-+                                clockid_t clock_id,
-+                                enum hrtimer_mode mode)
-+{
-+    /* No callback yet — DAHDI sets it later with hrtimer_update_function() */
-+    hrtimer_setup(timer, NULL, clock_id, mode);
-+}
-+#endif
-+
-+/* from_timer() helper was removed in newer kernels; restore it for DAHDI. */
-+#ifndef from_timer
-+#define from_timer(var, callback_timer, timer_fieldname)           \
-+        container_of(callback_timer, typeof(*var), timer_fieldname)
-+#endif
-+
- static inline void *pci_alloc_consistent(struct pci_dev *hwdev, size_t size, dma_addr_t *dma_handle)
- {
-     return dma_alloc_coherent(hwdev == NULL ? NULL : &hwdev->dev, size, dma_handle, GFP_ATOMIC);
++	hrtimer_setup(&zaptimer, dahdi_dummy_hr_int, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
++#else
+ 	hrtimer_init(&zaptimer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+-	printk(KERN_DEBUG "dahdi_dummy: Initialized High Resolution Timer\n");
+-
+ 	/* Set timer callback function */
+ 	zaptimer.function = dahdi_dummy_hr_int;
+-
++#endif /* LINUX_VERSION_CODE */
++	printk(KERN_DEBUG "dahdi_dummy: Initialized High Resolution Timer\n");
+ 	printk(KERN_DEBUG "dahdi_dummy: Starting High Resolution Timer\n");
+ 	hrtimer_start(&zaptimer, ktime_set(0, DAHDI_TIME_NS), HRTIMER_MODE_REL);
+ 	printk(KERN_INFO "dahdi_dummy: High Resolution Timer started, good to go\n");


### PR DESCRIPTION
### Description

The local 210-kernel-h-Add-wrappers-for.patch added a hrtimer_init() compat wrapper in include/dahdi/kernel.h guarded by LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0). This guard is wrong: hrtimer_setup() was only introduced in kernel 6.13 (upstream commit ac8bca2e8f6b3406af10700c427eb9b405c34265), and hrtimer_init() was not actually removed until kernel 6.15 (upstream commit 9779489a31d77a7b9cb6f20d2d2caced4e29dbe6, "hrtimers: Delete hrtimer_init()"). As a result, on kernels 6.8-6.14 (including the 6.12 branch used by qualcommax/ipq807x) the wrapper collides with the kernel's own extern declaration of hrtimer_init(), and also references hrtimer_setup() before it exists on kernels 6.8-6.12, breaking the build:

```
    error: static declaration of 'hrtimer_init' follows non-static declaration
    error: implicit declaration of function 'hrtimer_setup'
```
Rather than just fixing the version guard on the local wrapper, adopt upstream's actual fix (https://github.com/asterisk/dahdi-linux/commit/0fc7bfe4adf9d0fdd9f1f84122306da196bc187a, "dahdi_dummy: Use hrtimer_setup on kernels >= 6.15.0."), which resolves the same issue (https://github.com/asterisk/dahdi-linux/issues/93) by switching between hrtimer_setup() and hrtimer_init() at the call site in drivers/dahdi/dahdi_dummy.c, guarded correctly by LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0), instead of reimplementing hrtimer_init() as a compat shim in kernel.h.

### To Reproduce

Build `kmod-dahdi` for the `qualcommax_ipq807x` target with kernel 6.12.94.

### Build log

```
2026-07-13T02:50:01.1550619Z make[5]: Entering directory '/home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/linux-6.12.94'
2026-07-13T02:50:01.6634840Z /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/Kbuild:126: CPU Architecture 'arm64' does not support VPMADT032 or HPEC. Skipping.
2026-07-13T02:50:01.6787126Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_adpcm_chan.o
2026-07-13T02:50:01.7297346Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_channel.o
2026-07-13T02:50:03.9360642Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_chip_open.o
2026-07-13T02:50:05.8190932Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_chip_stats.o
2026-07-13T02:50:05.8591575Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_conf_bridge.o
2026-07-13T02:50:06.4814426Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_debug.o
2026-07-13T02:50:06.5120432Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_events.o
2026-07-13T02:50:06.7571274Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_interrupts.o
2026-07-13T02:50:07.2011159Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_memory.o
2026-07-13T02:50:07.2853813Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_miscellaneous.o
2026-07-13T02:50:07.3992529Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_mixer.o
2026-07-13T02:50:07.5350774Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_phasing_tsst.o
2026-07-13T02:50:07.5864702Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_playout_buf.o
2026-07-13T02:50:07.7756182Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_remote_debug.o
2026-07-13T02:50:07.8298091Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_tlv.o
2026-07-13T02:50:08.1520071Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_tone_detection.o
2026-07-13T02:50:08.3372945Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_tsi_cnct.o
2026-07-13T02:50:08.3893801Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/octdeviceapi/oct6100api/oct6100_api/oct6100_tsst.o
2026-07-13T02:50:08.4967049Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/apilib/bt/octapi_bt0.o
2026-07-13T02:50:08.5459716Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/apilib/largmath/octapi_largmath.o
2026-07-13T02:50:08.6070667Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/apilib/llman/octapi_llman.o
2026-07-13T02:50:08.6601382Z   CC [M]  /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/oct612x-user.o
2026-07-13T02:50:09.1743536Z In file included from /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/oct612x-user.c:28:
2026-07-13T02:50:09.1745884Z /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/include/dahdi/kernel.h:82:20: error: static declaration of 'hrtimer_init' follows non-static declaration
2026-07-13T02:50:09.1747459Z    82 | static inline void hrtimer_init(struct hrtimer *timer,
2026-07-13T02:50:09.1747911Z       |                    ^~~~~~~~~~~~
2026-07-13T02:50:09.1748328Z In file included from ./include/linux/alarmtimer.h:6,
2026-07-13T02:50:09.1748896Z                  from ./include/linux/posix-timers.h:5,
2026-07-13T02:50:09.1749354Z                  from ./include/linux/sched/signal.h:13,
2026-07-13T02:50:09.1750155Z                  from ./include/linux/rcuwait.h:6,
2026-07-13T02:50:09.1750588Z                  from ./include/linux/percpu-rwsem.h:7,
2026-07-13T02:50:09.1751011Z                  from ./include/linux/fs.h:33,
2026-07-13T02:50:09.1751429Z                  from ./arch/arm64/include/asm/elf.h:141,
2026-07-13T02:50:09.1751854Z                  from ./include/linux/elf.h:6,
2026-07-13T02:50:09.1752252Z                  from ./include/linux/module.h:19,
2026-07-13T02:50:09.1753434Z                  from /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/oct612x-user.c:24:
2026-07-13T02:50:09.1755396Z ./include/linux/hrtimer.h:229:13: note: previous declaration of 'hrtimer_init' with type 'void(struct hrtimer *, clockid_t,  enum hrtimer_mode)' {aka 'void(struct hrtimer *, int,  enum hrtimer_mode)'}
2026-07-13T02:50:09.1756745Z   229 | extern void hrtimer_init(struct hrtimer *timer, clockid_t which_clock,
2026-07-13T02:50:09.1757405Z       |             ^~~~~~~~~~~~
2026-07-13T02:50:09.1882703Z /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/include/dahdi/kernel.h: In function 'hrtimer_init':
2026-07-13T02:50:09.1885221Z /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/include/dahdi/kernel.h:87:5: error: implicit declaration of function 'hrtimer_setup'; did you mean 'timer_setup'? [-Wimplicit-function-declaration]
2026-07-13T02:50:09.1887565Z    87 |     hrtimer_setup(timer, NULL, clock_id, mode);
2026-07-13T02:50:09.1888040Z       |     ^~~~~~~~~~~~~
2026-07-13T02:50:09.1888428Z       |     timer_setup
2026-07-13T02:50:09.2226680Z make[8]: *** [scripts/Makefile.build:229: /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x/oct612x-user.o] Error 1
2026-07-13T02:50:09.2229258Z make[7]: *** [scripts/Makefile.build:466: /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi/oct612x] Error 2
2026-07-13T02:50:09.2233432Z make[6]: *** [/home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/linux-6.12.94/Makefile:1959: /home/runner/actions-runner/_work/openwrt/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/dahdi-linux-3.4.0/drivers/dahdi] Error 2
```

Regards, Agustin

FYI @dangowrt @robimarko 